### PR TITLE
feat: show strategies by phase

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
@@ -8,8 +8,14 @@
 import Testing
 @testable import WavelengthWatch_Watch_App
 
-struct WavelengthWatch_Watch_AppTests {
-  @Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+struct StrategyParsingTests {
+  @Test func parsesRisingFirstStrategy() throws {
+    let data = StrategyData.load()
+    #expect(data[.Rising]?.first?.strategy == "Cold Shower")
+  }
+
+  @Test func handlesMissingWithdrawal() {
+    let data = StrategyData.load()
+    #expect(data[.Withdrawal]?.isEmpty == true)
   }
 }


### PR DESCRIPTION
## Summary
- load strategies from embedded JSON and map stage colors
- horizontally swipe through phases and tap for strategy list
- add watch app tests for strategy parsing

## Testing
- `pre-commit run --files frontend/WavelengthWatch/'WavelengthWatch Watch App'/ContentView.swift frontend/WavelengthWatch/'WavelengthWatch Watch AppTests'/WavelengthWatch_Watch_AppTests.swift`
- `pytest`
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project frontend/WavelengthWatch/WavelengthWatch.xcodeproj -scheme "WavelengthWatch Watch App" -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c22d8d34588322a20ef57b5974654e