### PR TITLE
Add header conversion and display for watch app

### DIFF
--- a/backend/data/headers.json
+++ b/backend/data/headers.json
@@ -1,0 +1,46 @@
+{
+  "Beige": {
+    "title": "INHABIT",
+    "subtitle": "(Do)"
+  },
+  "Purple": {
+    "title": "INHABIT",
+    "subtitle": "(Feel)"
+  },
+  "Red": {
+    "title": "EXPRESS",
+    "subtitle": "(Do)"
+  },
+  "Blue": {
+    "title": "EXPRESS",
+    "subtitle": "(Feel)"
+  },
+  "Orange": {
+    "title": "COLLABORATE",
+    "subtitle": "(Do)"
+  },
+  "Green": {
+    "title": "COLLABORATE",
+    "subtitle": "(Feel)"
+  },
+  "Yellow": {
+    "title": "INTEGRATE",
+    "subtitle": "(Do)"
+  },
+  "Teal": {
+    "title": "INTEGRATE",
+    "subtitle": "(Feel)"
+  },
+  "Ultraviolet": {
+    "title": "ABSORB",
+    "subtitle": "(Do/Feel)"
+  },
+  "Clear Light": {
+    "title": "BE",
+    "subtitle": "(Neither/Both)"
+  },
+  "Strategies": {
+    "title": "Self-Care Strategies",
+    "subtitle": "(For Surfing)"
+  }
+}

--- a/backend/tools/csv_to_json.py
+++ b/backend/tools/csv_to_json.py
@@ -2,8 +2,8 @@
 """Utility to convert A-W CSV files into JSON.
 
 The script accepts a single CSV file. It inspects the header to determine
-whether the input represents curriculum data or self-care strategies and
-writes the corresponding JSON structure.
+whether the input represents curriculum data, self-care strategies, or
+layer headers and writes the corresponding JSON structure.
 
 Usage
 -----
@@ -34,6 +34,8 @@ def _detect(headers: Iterable[str]) -> str:
         return "curriculum"
     if {"strategy", "phase"}.issubset(lowered):
         return "strategies"
+    if {"level", "title"}.issubset(lowered):
+        return "headers"
     raise ValueError(f"Unrecognised CSV format with headers: {headers}")
 
 
@@ -87,6 +89,18 @@ def _convert_strategies(
     return {ph: result[ph] for ph in PHASE_ORDER if result.get(ph)}
 
 
+def _convert_headers(rows: list[dict[str, str]]) -> dict[str, dict[str, str]]:
+    result: dict[str, dict[str, str]] = {}
+    for row in rows:
+        level = row.get("level", "").strip().title()
+        title = row.get("title", "").strip()
+        subtitle = row.get("subtitle", "").strip()
+        if not level or not title:
+            continue
+        result[level] = {"title": title, "subtitle": subtitle}
+    return result
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Convert A-W CSV to JSON")
     parser.add_argument("csv_file", type=Path, help="Input CSV file")
@@ -105,6 +119,14 @@ def main() -> None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("w", encoding="utf-8") as fh:
             json.dump(data, fh, ensure_ascii=False, indent=2)
+            fh.write("\n")
+    elif kind == "headers":
+        header_data = _convert_headers(rows)
+        default_out = args.csv_file.with_name("headers.json")
+        out_path = args.out or default_out
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as fh:
+            json.dump(header_data, fh, ensure_ascii=False, indent=2)
             fh.write("\n")
     else:
         strat_data = _convert_strategies(rows)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
@@ -19,3 +19,11 @@ struct StrategyParsingTests {
     #expect(data[.Withdrawal]?.isEmpty == true)
   }
 }
+
+struct HeaderParsingTests {
+  @Test func parsesStrategiesHeader() {
+    let headers = HeaderData.load()
+    #expect(headers["Strategies"]?.title == "Self-Care Strategies")
+    #expect(headers["Blue"]?.subtitle == "(Feel)")
+  }
+}

--- a/tests/backend/test_csv_to_json.py
+++ b/tests/backend/test_csv_to_json.py
@@ -41,3 +41,11 @@ def test_strategies_conversion(tmp_path: Path) -> None:
         s["strategy"] == "Kirtan" and s["color"] == "Purple"
         for s in data["Restoration"]
     )
+
+
+def test_headers_conversion(tmp_path: Path) -> None:
+    output = tmp_path / "headers.json"
+    run_script("a-w-headers.csv", output)
+    data = json.loads(output.read_text())
+    assert data["Strategies"]["title"] == "Self-Care Strategies"
+    assert data["Blue"]["subtitle"] == "(Feel)"


### PR DESCRIPTION
## Summary
- convert A-W header CSV into JSON
- show layer titles and subtitles on watch strategy screens

## Testing
- `pytest -q`
- `swift test` *(fails: Could not find Package.swift)*
- `pre-commit run --files backend/tools/csv_to_json.py backend/data/headers.json tests/backend/test_csv_to_json.py frontend/WavelengthWatch/WavelengthWatch\ Watch\ App/ContentView.swift frontend/WavelengthWatch/WavelengthWatch\ Watch\ AppTests/WavelengthWatch_Watch_AppTests.swift` *(fails: Executable `swiftformat` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3706ffa5c8322b5737de671c1f7a1