### PR TITLE
feat: add journal entry models with cascade tests

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -6,6 +6,11 @@ from pathlib import Path
 
 from sqlmodel import Session, SQLModel, create_engine
 
+# Import models so that SQLModel is aware of them before table creation.
+# The imported module is not used directly but ensures that metadata
+# includes all model definitions when `init_db` is called.
+from . import models  # noqa: F401
+
 # Database location
 DATABASE_FILE = Path(__file__).with_name("database.db")
 DATABASE_URL = f"sqlite:///{DATABASE_FILE}"

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,62 @@
+"""Database models and Pydantic schemas for journaling."""
+
+from datetime import datetime
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class EntryDetail(SQLModel, table=True):
+    """Detail row tied to a :class:`JournalEntry`."""
+
+    journal_id: int | None = Field(
+        default=None, foreign_key="journalentry.id", primary_key=True
+    )
+    stage: int
+    phase: int
+    dosage: float
+    position: int = Field(primary_key=True)
+
+    journal: "JournalEntry" = Relationship(back_populates="details")
+
+
+class EntryDetailCreate(SQLModel):
+    """Pydantic schema for creating ``EntryDetail`` records."""
+
+    journal_id: int
+    stage: int
+    phase: int
+    dosage: float
+    position: int
+
+
+class JournalEntry(SQLModel, table=True):
+    """Represents a journaling session."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    timestamp: datetime
+    initiated_by: str
+
+    details: list[EntryDetail] = Relationship(
+        back_populates="journal",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+
+
+class JournalEntryCreate(SQLModel):
+    """Pydantic schema for creating ``JournalEntry`` records."""
+
+    timestamp: datetime
+    initiated_by: str
+
+
+__all__ = [
+    "JournalEntry",
+    "EntryDetail",
+    "JournalEntryCreate",
+    "EntryDetailCreate",
+]
+
+
+# Resolve forward references for Pydantic/SQLModel.
+JournalEntry.model_rebuild()
+EntryDetail.model_rebuild()

--- a/tests/backend/test_models.py
+++ b/tests/backend/test_models.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlmodel import create_engine, select
+
+import backend.db as db_module
+from backend.db import get_session, init_db
+from backend.models import EntryDetail, JournalEntry
+
+
+@pytest.fixture(name="setup_db")
+def fixture_setup_db(tmp_path, monkeypatch):
+    """Configure an isolated SQLite database for each test."""
+
+    test_db = tmp_path / "test.db"
+    monkeypatch.setattr(db_module, "DATABASE_FILE", test_db)
+    monkeypatch.setattr(db_module, "DATABASE_URL", f"sqlite:///{test_db}")
+    engine = create_engine(db_module.DATABASE_URL, echo=False)
+    monkeypatch.setattr(db_module, "engine", engine)
+    init_db()
+
+
+def _create_sample_entry() -> int:
+    """Helper to persist a journal entry with two details.
+
+    Returns the primary key of the created ``JournalEntry``.
+    """
+
+    with get_session() as session:
+        entry = JournalEntry(
+            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+            initiated_by="tester",
+        )
+        entry.details.append(
+            EntryDetail(stage=1, phase=1, dosage=1.0, position=1)
+        )
+        entry.details.append(
+            EntryDetail(stage=2, phase=2, dosage=2.0, position=2)
+        )
+        session.add(entry)
+        session.commit()
+        return entry.id  # type: ignore[return-value]
+
+
+def test_models_persist_and_relate(setup_db):
+    entry_id = _create_sample_entry()
+
+    with get_session() as session:
+        loaded = session.get(JournalEntry, entry_id)
+        assert loaded is not None
+        assert len(loaded.details) == 2
+        assert {d.position for d in loaded.details} == {1, 2}
+
+
+def test_cascade_delete_removes_details(setup_db):
+    entry_id = _create_sample_entry()
+
+    with get_session() as session:
+        entry = session.get(JournalEntry, entry_id)
+        assert entry is not None
+        session.delete(entry)
+        session.commit()
+
+    with get_session() as session:
+        remaining = session.exec(select(EntryDetail)).all()
+        assert remaining == []


### PR DESCRIPTION
## Summary
- add JournalEntry and EntryDetail models with creation schemas
- register models during database init
- test relationships and cascade deletion behaviour

## Testing
- `pre-commit run --files backend/models.py backend/db.py tests/backend/test_models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7378cd3e48322b3079917808892b0