### PR TITLE
Add journal API endpoints with filtering and tests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from collections import defaultdict, deque
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
 from .db import get_session_dep
@@ -21,6 +23,23 @@ SessionDep = Annotated[Session, Depends(get_session_dep)]
 
 BASE_DIR = Path(__file__).resolve().parent
 DATA_DIR = BASE_DIR / "data"
+
+# Simple in-memory rate limiting: allow `RATE_LIMIT` requests per `RATE_PERIOD`
+RATE_LIMIT = 100
+RATE_PERIOD = timedelta(minutes=1)
+_request_times: dict[str, deque[datetime]] = defaultdict(deque)
+
+
+def rate_limit(request: Request) -> None:
+    """Naive IP-based rate limiter."""
+    now = datetime.now(UTC)
+    ip = request.client.host if request.client else "unknown"
+    times = _request_times[ip]
+    while times and now - times[0] > RATE_PERIOD:
+        times.popleft()
+    if len(times) >= RATE_LIMIT:
+        raise HTTPException(status_code=429, detail="Too many requests")
+    times.append(now)
 
 
 def _load_json(filename: str) -> Any:
@@ -64,10 +83,17 @@ def strategies() -> Any:
 def create_journal(
     payload: JournalEntryCreateWithDetails,
     session: SessionDep,
+    _rate_limit: None = Depends(rate_limit),
 ) -> JournalEntry:
     """Create a journal entry with nested combo details."""
+    timestamp = payload.timestamp
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    else:
+        timestamp = timestamp.astimezone(UTC)
+    timestamp = timestamp.replace(tzinfo=None)
     entry = JournalEntry(
-        timestamp=payload.timestamp,
+        timestamp=timestamp,
         initiated_by=payload.initiated_by,
     )
     for detail in payload.details:
@@ -82,7 +108,7 @@ def create_journal(
     session.add(entry)
     session.commit()
     session.refresh(entry)
-    _ = entry.details  # load details before session closes
+    _: list[EntryDetail] = entry.details  # load details before session closes
     return entry
 
 
@@ -91,16 +117,28 @@ def list_journal(
     session: SessionDep,
     start: datetime | None = None,
     end: datetime | None = None,
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
 ) -> list[JournalEntry]:
     """Return journal entries optionally filtered by a date range."""
-    statement = select(JournalEntry)
+    statement = (
+        select(JournalEntry)
+        .options(selectinload(JournalEntry.details))  # type: ignore[arg-type]
+        .order_by(JournalEntry.timestamp.desc())  # type: ignore[attr-defined]
+    )
     if start is not None:
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=UTC)
+        else:
+            start = start.astimezone(UTC)
+        start = start.replace(tzinfo=None)
         statement = statement.where(JournalEntry.timestamp >= start)
     if end is not None:
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=UTC)
+        else:
+            end = end.astimezone(UTC)
+        end = end.replace(tzinfo=None)
         statement = statement.where(JournalEntry.timestamp <= end)
-    result = session.exec(statement)
-    entries = list(result)
-    # Ensure details are loaded before the session closes
-    for entry in entries:
-        _ = entry.details  # trigger lazy load
-    return entries
+    result = session.exec(statement.offset(offset).limit(limit))
+    return list(result)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlmodel import Session, select
+
+from .db import get_session_dep
+from .models import (
+    EntryDetail,
+    JournalEntry,
+    JournalEntryCreateWithDetails,
+    JournalEntryRead,
+)
+
+SessionDep = Annotated[Session, Depends(get_session_dep)]
 
 BASE_DIR = Path(__file__).resolve().parent
 DATA_DIR = BASE_DIR / "data"
@@ -46,3 +58,49 @@ def curriculum() -> Any:
 def strategies() -> Any:
     # Returns the JSON list of self-care strategies.
     return _load_json("strategies.json")
+
+
+@app.post("/journal", response_model=JournalEntryRead, status_code=201)
+def create_journal(
+    payload: JournalEntryCreateWithDetails,
+    session: SessionDep,
+) -> JournalEntry:
+    """Create a journal entry with nested combo details."""
+    entry = JournalEntry(
+        timestamp=payload.timestamp,
+        initiated_by=payload.initiated_by,
+    )
+    for detail in payload.details:
+        entry.details.append(
+            EntryDetail(
+                stage=detail.stage,
+                phase=detail.phase,
+                dosage=detail.dosage,
+                position=detail.position,
+            )
+        )
+    session.add(entry)
+    session.commit()
+    session.refresh(entry)
+    _ = entry.details  # load details before session closes
+    return entry
+
+
+@app.get("/journal", response_model=list[JournalEntryRead])
+def list_journal(
+    session: SessionDep,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> list[JournalEntry]:
+    """Return journal entries optionally filtered by a date range."""
+    statement = select(JournalEntry)
+    if start is not None:
+        statement = statement.where(JournalEntry.timestamp >= start)
+    if end is not None:
+        statement = statement.where(JournalEntry.timestamp <= end)
+    result = session.exec(statement)
+    entries = list(result)
+    # Ensure details are loaded before the session closes
+    for entry in entries:
+        _ = entry.details  # trigger lazy load
+    return entries

--- a/backend/db.py
+++ b/backend/db.py
@@ -29,3 +29,9 @@ def get_session() -> Iterator[Session]:
     """Yield a database session scoped to a context manager."""
     with Session(engine) as session:
         yield session
+
+
+def get_session_dep() -> Iterator[Session]:
+    """FastAPI dependency that yields a database session."""
+    with get_session() as session:
+        yield session

--- a/backend/models.py
+++ b/backend/models.py
@@ -45,7 +45,7 @@ class SelfCareLog(SQLModel, table=True):
     journal_id: int | None = Field(
         default=None, foreign_key="journalentry.id"
     )
-    strategy: str
+    strategy: str = Field(max_length=100)
     timestamp: datetime
 
     journal: "JournalEntry" = Relationship(back_populates="self_care_logs")
@@ -55,7 +55,7 @@ class SelfCareLogCreate(SQLModel):
     """Pydantic schema for creating ``SelfCareLog`` records."""
 
     journal_id: int
-    strategy: str
+    strategy: str = Field(max_length=100)
     timestamp: datetime
 
 
@@ -64,7 +64,7 @@ class JournalEntry(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     timestamp: datetime
-    initiated_by: str
+    initiated_by: str = Field(max_length=100)
 
     details: list[EntryDetail] = Relationship(
         back_populates="journal",
@@ -80,7 +80,7 @@ class JournalEntryCreate(SQLModel):
     """Pydantic schema for creating ``JournalEntry`` records."""
 
     timestamp: datetime
-    initiated_by: str
+    initiated_by: str = Field(max_length=100)
 
 
 class JournalEntryCreateWithDetails(JournalEntryCreate):

--- a/backend/models.py
+++ b/backend/models.py
@@ -29,6 +29,15 @@ class EntryDetailCreate(SQLModel):
     position: int
 
 
+class EntryDetailInput(SQLModel):
+    """Input schema for nested detail creation via the API."""
+
+    stage: int
+    phase: int
+    dosage: float
+    position: int
+
+
 class SelfCareLog(SQLModel, table=True):
     """Record of a self-care strategy linked to a journal entry."""
 
@@ -74,6 +83,19 @@ class JournalEntryCreate(SQLModel):
     initiated_by: str
 
 
+class JournalEntryCreateWithDetails(JournalEntryCreate):
+    """Schema for creating entries with nested detail records."""
+
+    details: list[EntryDetailInput]
+
+
+class JournalEntryRead(JournalEntryCreate):
+    """Schema for reading ``JournalEntry`` records with details."""
+
+    id: int
+    details: list[EntryDetail] = []
+
+
 __all__ = [
     "JournalEntry",
     "EntryDetail",
@@ -81,6 +103,9 @@ __all__ = [
     "JournalEntryCreate",
     "EntryDetailCreate",
     "SelfCareLogCreate",
+    "EntryDetailInput",
+    "JournalEntryCreateWithDetails",
+    "JournalEntryRead",
 ]
 
 

--- a/tests/backend/test_journal_api.py
+++ b/tests/backend/test_journal_api.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import create_engine
+
+import backend.db as db_module
+from backend.db import init_db
+
+
+@pytest.fixture(name="client")
+def fixture_client(tmp_path, monkeypatch) -> TestClient:
+    """Provide a TestClient with an isolated database."""
+    test_db = tmp_path / "test.db"
+    monkeypatch.setattr(db_module, "DATABASE_FILE", test_db)
+    monkeypatch.setattr(db_module, "DATABASE_URL", f"sqlite:///{test_db}")
+    engine = create_engine(db_module.DATABASE_URL, echo=False)
+    monkeypatch.setattr(db_module, "engine", engine)
+    init_db()
+    from backend.app import app
+
+    return TestClient(app)
+
+
+def _sample_payload(ts: datetime) -> dict[str, object]:
+    return {
+        "timestamp": ts.isoformat(),
+        "initiated_by": "tester",
+        "details": [
+            {"stage": 1, "phase": 1, "dosage": 1.0, "position": 1},
+        ],
+    }
+
+
+def test_create_journal_entry_with_details(client: TestClient) -> None:
+    payload = _sample_payload(datetime(2024, 1, 1, 12, 0, 0))
+    response = client.post("/journal", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["initiated_by"] == "tester"
+    assert len(data["details"]) == 1
+    assert data["details"][0]["stage"] == 1
+
+
+def test_create_journal_validation_error(client: TestClient) -> None:
+    payload = {"timestamp": datetime(2024, 1, 1).isoformat(), "details": []}
+    response = client.post("/journal", json=payload)
+    assert response.status_code == 422
+
+
+def test_list_journal_filtered_by_date(client: TestClient) -> None:
+    early = datetime(2024, 1, 1, 12, 0, 0)
+    late = datetime(2024, 2, 1, 12, 0, 0)
+    client.post("/journal", json=_sample_payload(early))
+    client.post("/journal", json=_sample_payload(late))
+
+    params = {
+        "start": datetime(2024, 1, 15).isoformat(),
+        "end": datetime(2024, 3, 1).isoformat(),
+    }
+    response = client.get("/journal", params=params)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["timestamp"].startswith("2024-02-01")


### PR DESCRIPTION
## Summary
- implement POST and GET /journal with SQLModel persistence
- add models for nested entry details
- cover journal API with FastAPI TestClient tests

## Testing
- `pre-commit run --files backend/models.py backend/app.py backend/db.py tests/backend/test_journal_api.py`
- `pytest tests/backend/test_journal_api.py tests/backend/test_models.py tests/backend/test_db.py`

------
https://chatgpt.com/codex/tasks/task_e_68c73e264af8832294a4fcabaf2af406