### PR TITLE
Store self-care strategies in database

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -81,9 +81,22 @@ def curriculum() -> Any:
     return _load_json("curriculum.json")
 
 
-@app.get("/strategies", response_model=list[SelfCareStrategyRead])
-def list_strategies(session: SessionDep) -> list[SelfCareStrategy]:
-    """Return all available self-care strategies."""
+@app.get(
+    "/strategies",
+    response_model=list[SelfCareStrategyRead]
+    | dict[str, list[dict[str, str]]],
+)
+def list_strategies(
+    session: SessionDep, raw: bool = False
+) -> list[SelfCareStrategy] | dict[str, list[dict[str, str]]]:
+    """Return all available self-care strategies.
+
+    Setting ``raw`` to ``True`` returns the legacy JSON structure used by the
+    original watchOS client. This maintains backward compatibility while the
+    frontend transitions to the structured database-backed format.
+    """
+    if raw:
+        return _load_json("strategies.json")
     result = session.exec(select(SelfCareStrategy))
     return list(result)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -39,6 +39,29 @@ class EntryDetailInput(SQLModel):
     position: int
 
 
+class SelfCareStrategy(SQLModel, table=True):
+    """Catalog of available self-care strategies."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    color: str = Field(max_length=100)
+    strategy: str = Field(max_length=100)
+
+    logs: list["SelfCareLog"] = Relationship(back_populates="strategy")
+
+
+class SelfCareStrategyCreate(SQLModel):
+    """Schema for creating ``SelfCareStrategy`` records."""
+
+    color: str = Field(max_length=100)
+    strategy: str = Field(max_length=100)
+
+
+class SelfCareStrategyRead(SelfCareStrategyCreate):
+    """Schema for reading ``SelfCareStrategy`` records."""
+
+    id: int
+
+
 class SelfCareLog(SQLModel, table=True):
     """Record of a self-care strategy linked to a journal entry."""
 
@@ -46,10 +69,13 @@ class SelfCareLog(SQLModel, table=True):
     journal_id: int | None = Field(
         default=None, foreign_key="journalentry.id"
     )
-    strategy: str = Field(max_length=100)
+    strategy_id: int | None = Field(
+        default=None, foreign_key="selfcarestrategy.id"
+    )
     timestamp: datetime
 
     journal: "JournalEntry" = Relationship(back_populates="self_care_logs")
+    strategy: SelfCareStrategy | None = Relationship(back_populates="logs")
 
     __table_args__ = (
         Index("ix_selfcarelog_journal_timestamp", "journal_id", "timestamp"),
@@ -60,7 +86,7 @@ class SelfCareLogCreate(SQLModel):
     """Pydantic schema for creating ``SelfCareLog`` records."""
 
     journal_id: int
-    strategy: str = Field(max_length=100)
+    strategy_id: int
     timestamp: datetime
 
 
@@ -111,10 +137,13 @@ __all__ = [
     "JournalEntry",
     "EntryDetail",
     "SelfCareLog",
+    "SelfCareStrategy",
     "JournalEntryCreate",
     "EntryDetailCreate",
     "SelfCareLogCreate",
     "SelfCareLogRead",
+    "SelfCareStrategyCreate",
+    "SelfCareStrategyRead",
     "EntryDetailInput",
     "JournalEntryCreateWithDetails",
     "JournalEntryRead",
@@ -125,3 +154,4 @@ __all__ = [
 JournalEntry.model_rebuild()
 EntryDetail.model_rebuild()
 SelfCareLog.model_rebuild()
+SelfCareStrategy.model_rebuild()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -8,9 +8,17 @@
 import SwiftUI
 
 struct Strategy: Identifiable, Decodable {
+  private let strategyId: Int?
   let color: String
   let strategy: String
-  var id: String { strategy }
+
+  var id: Int { strategyId ?? strategy.hashValue }
+
+  private enum CodingKeys: String, CodingKey {
+    case strategyId = "id"
+    case color
+    case strategy
+  }
 }
 
 struct LayerHeader: Decodable {

--- a/tests/backend/test_strategy_api.py
+++ b/tests/backend/test_strategy_api.py
@@ -37,6 +37,15 @@ def test_create_and_list_strategies(client: TestClient) -> None:
     assert items[0]["strategy"] == "Drink Water"
 
 
+def test_list_strategies_raw(client: TestClient) -> None:
+    resp = client.get("/strategies", params={"raw": True})
+    assert resp.status_code == 200
+    data = resp.json()
+    # legacy format should include phase keys like "Rising"
+    assert "Rising" in data
+    assert isinstance(data["Rising"], list)
+
+
 def test_strategy_validation(client: TestClient) -> None:
     payload = {"color": "B" * 101, "strategy": "A"}
     resp = client.post("/strategies", json=payload)

--- a/tests/backend/test_strategy_api.py
+++ b/tests/backend/test_strategy_api.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import create_engine
+
+import backend.db as db_module
+from backend.db import init_db
+
+
+@pytest.fixture(name="client")
+def fixture_client(tmp_path, monkeypatch) -> TestClient:
+    """Provide a TestClient with an isolated database."""
+    test_db = tmp_path / "test.db"
+    monkeypatch.setattr(db_module, "DATABASE_FILE", test_db)
+    monkeypatch.setattr(db_module, "DATABASE_URL", f"sqlite:///{test_db}")
+    engine = create_engine(db_module.DATABASE_URL, echo=False)
+    monkeypatch.setattr(db_module, "engine", engine)
+    init_db()
+    from backend.app import app
+
+    return TestClient(app)
+
+
+def test_create_and_list_strategies(client: TestClient) -> None:
+    payload = {"color": "Blue", "strategy": "Drink Water"}
+    resp = client.post("/strategies", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["color"] == "Blue"
+    assert data["strategy"] == "Drink Water"
+
+    resp = client.get("/strategies")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["strategy"] == "Drink Water"
+
+
+def test_strategy_validation(client: TestClient) -> None:
+    payload = {"color": "B" * 101, "strategy": "A"}
+    resp = client.post("/strategies", json=payload)
+    assert resp.status_code == 422
+
+    inj_payload = {"color": "Blue", "strategy": "1; DROP TABLE"}
+    resp = client.post("/strategies", json=inj_payload)
+    assert resp.status_code == 201


### PR DESCRIPTION
## Summary
- replace static strategies files with `SelfCareStrategy` table and schemas
- update self-care logging to reference `strategy_id`
- add API endpoints and tests for managing self-care strategies

## Testing
- `pre-commit run --files backend/app.py backend/models.py tests/backend/test_models.py tests/backend/test_self_care_api.py tests/backend/test_strategy_api.py`
- `pytest tests/backend -q`


------
https://chatgpt.com/codex/tasks/task_e_68c820ccf3dc8322a0c1d418b8975676