### PR TITLE
feat: store self-care strategies in database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ To set up the full development environment, run:
 bash dev-setup.sh
 ```
 
+**Deployment status**: WavelengthWatch has not yet been deployed to production. The team plans to ship to the App Store in the future, so schema migrations are not currently required.
+
 Agents working on this project must abide by the following operating principles:
 
 1. **Test-Driven Development (TDD) Is Required**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**Deployment status**: The project has not yet been deployed to production. Shipping to the App Store is on the roadmap, so database migrations are not currently required.
+
 ## Development Commands
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 WavelengthWatch is a watchOS-only app that brings the Archetypal Wavelength to your wrist. You can horizontally scroll through the six phases of the Wavelength, each phase offering a pocket-sized guide to its “medicinal” and “toxic” expressions. Tap on a phase to reveal a quick box of wisdom and self-care strategies, then swipe to the next when you’re ready. The goal is maximum uptime on your personal Apple Watch: even offline, the guidance is bundled into the app, and when connectivity is available, background refresh pulls the latest updates.
 
+_Status_: The project has not yet been deployed to production. An eventual App Store launch is planned, so formal database migrations are not currently required.
+
 ## Features
 
 - **Watch-Only App (SwiftUI)**: Built in Xcode 16.4, runs natively on watchOS 11.6.1 (Apple Watch Series 9).
@@ -11,7 +13,7 @@ WavelengthWatch is a watchOS-only app that brings the Archetypal Wavelength to y
 - **Phase Details**: Tap a phase to see “medicinal” and “toxic” expressions.
 - **Baseline Offline Data**: Core dataset (stages, phases, expressions, strategies) is bundled as JSON in the app, so the watch works instantly without a network.
 - **Optional Refresh**: When background time is available, the app fetches the latest JSON from the backend or static hosting, ensuring freshness without breaking offline reliability.
-- **FastAPI Backend**: A lightweight Python service (in `backend/app.py`) serves JSON mappings and static assets. The backend reads simple JSON files (converted from CSV during development) and can be deployed directly or fronted by S3/CloudFront for static hosting.
+- **FastAPI Backend**: A lightweight Python service (in `backend/app.py`) serves JSON mappings and static assets. Curriculum data is read from JSON files, while self-care strategies now live in a SQLite table (`SelfCareStrategy`) seeded from the legacy CSV/JSON sources.
 - **CI and Pre-commit**:
   - GitHub Actions workflow builds the watch app on a simulator, runs SwiftLint/SwiftFormat checks, and validates backend tests.
   - Pre-commit hooks enforce linting and formatting for both Swift (via Mint, SwiftLint, SwiftFormat) and Python (via Mypy, Ruff, etc. in the backend).

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,0 +1,12 @@
+"""Shared constants for backend services."""
+
+PHASE_ORDER: list[str] = [
+    "Rising",
+    "Peaking",
+    "Withdrawal",
+    "Diminishing",
+    "Bottoming Out",
+    "Restoration",
+]
+
+__all__ = ["PHASE_ORDER"]

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 # Import models so that SQLModel is aware of them before table creation.
 # The imported module is not used directly but ensures that metadata
 # includes all model definitions when `init_db` is called.
 from . import models  # noqa: F401
+from .constants import PHASE_ORDER
 
 # Database location
 DATABASE_FILE = Path(__file__).with_name("database.db")
@@ -22,6 +24,49 @@ engine = create_engine(DATABASE_URL, echo=False)
 def init_db() -> None:
     """Create database tables for all SQLModel subclasses."""
     SQLModel.metadata.create_all(engine)
+    _seed_self_care_strategies()
+
+
+def _seed_self_care_strategies() -> None:
+    """Populate default self-care strategies if the table is empty."""
+
+    from .models import SelfCareStrategy
+
+    data_file = Path(__file__).with_name("data") / "prod" / "a-w-strategies.json"
+    if not data_file.exists():
+        return
+
+    with Session(engine) as session:
+        exists = session.exec(select(SelfCareStrategy.id).limit(1)).first()
+        if exists is not None:
+            return
+
+        payload: dict[str, list[dict[str, str]]] = json.loads(
+            data_file.read_text(encoding="utf-8")
+        )
+
+        for phase in PHASE_ORDER:
+            for item in payload.get(phase, []):
+                session.add(
+                    SelfCareStrategy(
+                        color=item["color"],
+                        strategy=item["strategy"],
+                        phase=phase,
+                    )
+                )
+
+        for phase, items in payload.items():
+            if phase in PHASE_ORDER:
+                continue
+            for item in items:
+                session.add(
+                    SelfCareStrategy(
+                        color=item["color"],
+                        strategy=item["strategy"],
+                        phase=phase,
+                    )
+                )
+        session.commit()
 
 
 @contextmanager

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,8 +2,40 @@
 
 from datetime import datetime
 
+from pydantic import ConfigDict, model_validator
 from sqlalchemy import Index
 from sqlmodel import Field, Relationship, SQLModel
+
+
+class SelfCareStrategy(SQLModel, table=True):
+    """Catalog entry describing a self-care strategy."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    color: str = Field(max_length=50)
+    strategy: str = Field(max_length=200, unique=True)
+    phase: str = Field(max_length=100)
+
+    self_care_logs: list["SelfCareLog"] = Relationship(back_populates="strategy_ref")
+
+    __table_args__ = (
+        Index("ix_selfcarestrategy_phase", "phase"),
+    )
+
+
+class SelfCareStrategyCreate(SQLModel):
+    """Payload for creating new :class:`SelfCareStrategy` rows."""
+
+    color: str = Field(max_length=50)
+    strategy: str = Field(max_length=200)
+    phase: str = Field(max_length=100)
+
+
+class SelfCareStrategyRead(SelfCareStrategyCreate):
+    """Schema for reading :class:`SelfCareStrategy` records."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
 
 
 class EntryDetail(SQLModel, table=True):
@@ -46,28 +78,49 @@ class SelfCareLog(SQLModel, table=True):
     journal_id: int | None = Field(
         default=None, foreign_key="journalentry.id"
     )
-    strategy: str = Field(max_length=100)
+    strategy_id: int = Field(foreign_key="selfcarestrategy.id")
     timestamp: datetime
 
     journal: "JournalEntry" = Relationship(back_populates="self_care_logs")
+    strategy_ref: SelfCareStrategy | None = Relationship(back_populates="self_care_logs")
 
     __table_args__ = (
         Index("ix_selfcarelog_journal_timestamp", "journal_id", "timestamp"),
+        Index("ix_selfcarelog_strategy", "strategy_id"),
     )
+
+    @property
+    def strategy(self) -> str | None:
+        """Expose the related strategy label for response models."""
+
+        return self.strategy_ref.strategy if self.strategy_ref else None
 
 
 class SelfCareLogCreate(SQLModel):
     """Pydantic schema for creating ``SelfCareLog`` records."""
 
     journal_id: int
-    strategy: str = Field(max_length=100)
     timestamp: datetime
+    strategy_id: int | None = None
+    strategy: str | None = Field(default=None, max_length=200)
+
+    @model_validator(mode="after")
+    def _ensure_strategy_identifier(self) -> "SelfCareLogCreate":
+        if self.strategy_id is None and not self.strategy:
+            raise ValueError("strategy_id or strategy must be provided")
+        return self
 
 
-class SelfCareLogRead(SelfCareLogCreate):
+class SelfCareLogRead(SQLModel):
     """Schema for reading ``SelfCareLog`` records."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
+    journal_id: int
+    timestamp: datetime
+    strategy_id: int
+    strategy: str | None = None
 
 
 class JournalEntry(SQLModel, table=True):
@@ -111,10 +164,13 @@ __all__ = [
     "JournalEntry",
     "EntryDetail",
     "SelfCareLog",
+    "SelfCareStrategy",
     "JournalEntryCreate",
     "EntryDetailCreate",
     "SelfCareLogCreate",
     "SelfCareLogRead",
+    "SelfCareStrategyCreate",
+    "SelfCareStrategyRead",
     "EntryDetailInput",
     "JournalEntryCreateWithDetails",
     "JournalEntryRead",
@@ -125,3 +181,5 @@ __all__ = [
 JournalEntry.model_rebuild()
 EntryDetail.model_rebuild()
 SelfCareLog.model_rebuild()
+SelfCareStrategy.model_rebuild()
+SelfCareStrategyRead.model_rebuild()

--- a/tests/backend/test_models.py
+++ b/tests/backend/test_models.py
@@ -7,7 +7,12 @@ from sqlmodel import create_engine, select
 
 import backend.db as db_module
 from backend.db import get_session, init_db
-from backend.models import EntryDetail, JournalEntry, SelfCareLog
+from backend.models import (
+    EntryDetail,
+    JournalEntry,
+    SelfCareLog,
+    SelfCareStrategy,
+)
 
 
 @pytest.fixture(name="setup_db")
@@ -29,6 +34,14 @@ def _create_sample_entry() -> int:
     """
 
     with get_session() as session:
+        strategy = SelfCareStrategy(
+            color="Beige",
+            strategy="Test Strategy A",
+            phase="Restoration",
+        )
+        session.add(strategy)
+        session.commit()
+        session.refresh(strategy)
         entry = JournalEntry(
             timestamp=datetime(2024, 1, 1, 12, 0, 0),
             initiated_by="tester",
@@ -41,7 +54,7 @@ def _create_sample_entry() -> int:
         )
         entry.self_care_logs.append(
             SelfCareLog(
-                strategy="deep breathing",
+                strategy_id=strategy.id,
                 timestamp=datetime(2024, 1, 1, 12, 30, 0),
             )
         )
@@ -59,7 +72,23 @@ def test_models_persist_and_relate(setup_db):
         assert len(loaded.details) == 2
         assert {d.position for d in loaded.details} == {1, 2}
         assert len(loaded.self_care_logs) == 1
-        assert loaded.self_care_logs[0].strategy == "deep breathing"
+        assert loaded.self_care_logs[0].strategy_id == loaded.self_care_logs[0].strategy_ref.id
+        assert loaded.self_care_logs[0].strategy == "Test Strategy A"
+
+
+def test_strategy_survives_entry_deletion(setup_db):
+    entry_id = _create_sample_entry()
+
+    with get_session() as session:
+        entry = session.get(JournalEntry, entry_id)
+        assert entry is not None
+        strategy_id = entry.self_care_logs[0].strategy_id
+        session.delete(entry)
+        session.commit()
+
+    with get_session() as session:
+        strategy = session.get(SelfCareStrategy, strategy_id)
+        assert strategy is not None
 
 
 def test_cascade_delete_removes_related_records(setup_db):

--- a/tests/backend/test_strategies_api.py
+++ b/tests/backend/test_strategies_api.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import create_engine
+
+import backend.db as db_module
+from backend.db import init_db
+
+
+@pytest.fixture(name="client")
+def fixture_client(tmp_path, monkeypatch) -> TestClient:
+    """Provide a TestClient with an isolated database."""
+
+    test_db = tmp_path / "test.db"
+    monkeypatch.setattr(db_module, "DATABASE_FILE", test_db)
+    monkeypatch.setattr(db_module, "DATABASE_URL", f"sqlite:///{test_db}")
+    engine = create_engine(db_module.DATABASE_URL, echo=False)
+    monkeypatch.setattr(db_module, "engine", engine)
+    init_db()
+    from backend.app import app
+
+    return TestClient(app)
+
+
+def _create_strategy(client: TestClient, *, name: str, color: str, phase: str) -> dict[str, Any]:
+    payload = {"color": color, "strategy": name, "phase": phase}
+    resp = client.post("/strategies", json=payload)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def test_strategies_endpoint_matches_json(client: TestClient) -> None:
+    resp = client.get("/strategies")
+    assert resp.status_code == 200
+    data = resp.json()
+    expected = json.loads(
+        Path("backend/data/prod/a-w-strategies.json").read_text(encoding="utf-8")
+    )
+    assert data == expected
+
+
+def test_create_strategy_updates_index(client: TestClient) -> None:
+    created = _create_strategy(
+        client, name="API Added Strategy", color="Silver", phase="Restoration"
+    )
+
+    listing = client.get("/strategies/index")
+    assert listing.status_code == 200
+    payload = listing.json()
+    assert any(item["id"] == created["id"] for item in payload)
+    assert any(item["strategy"] == "API Added Strategy" for item in payload)
+
+    grouped = client.get("/strategies")
+    assert grouped.status_code == 200
+    strategies = grouped.json()[created["phase"]]
+    assert any(item["strategy"] == "API Added Strategy" for item in strategies)
+
+
+def test_duplicate_strategy_conflict(client: TestClient) -> None:
+    payload = {"name": "Duplicate Strategy", "color": "Amber", "phase": "Rising"}
+    created = _create_strategy(
+        client,
+        name=payload["name"],
+        color=payload["color"],
+        phase=payload["phase"],
+    )
+    assert created["strategy"] == payload["name"]
+
+    conflict = client.post(
+        "/strategies",
+        json={"strategy": payload["name"], "color": payload["color"], "phase": payload["phase"]},
+    )
+    assert conflict.status_code == 409
+
+
+def test_strategies_index_filter(client: TestClient) -> None:
+    _create_strategy(client, name="Filter Strategy", color="Gold", phase="Restoration")
+    resp = client.get("/strategies/index", params={"phase": "Restoration"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data
+    assert all(item["phase"] == "Restoration" for item in data)


### PR DESCRIPTION
## Summary
- add a dedicated `SelfCareStrategy` model seeded from the legacy dataset and link self-care logs via foreign keys
- update FastAPI endpoints to serve legacy JSON output while exposing strategy management APIs backed by the database
- expand backend tests for strategies and self-care logging and refresh documentation with current deployment status

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c84e6127688322aa559eb4e77de7cc