### PR TITLE
Add watch JournalAPI and request tests

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/JournalAPI.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/JournalAPI.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+struct JournalAPI {
+  struct Entry: Codable, Equatable {
+    let title: String
+    let mood: String
+    let note: String
+  }
+
+  enum JournalAPIError: LocalizedError {
+    case encodingFailed(underlying: Error)
+    case invalidResponse
+    case requestFailed(statusCode: Int)
+    case transportError(underlying: Error)
+
+    var errorDescription: String? {
+      switch self {
+      case .encodingFailed:
+        return "We couldn't prepare your journal entry."
+      case .invalidResponse:
+        return "The server returned something unexpected."
+      case .requestFailed(let statusCode):
+        return "The server responded with status code \(statusCode)."
+      case .transportError:
+        return "We couldn't reach the server."
+      }
+    }
+
+    var failureReason: String? {
+      switch self {
+      case .encodingFailed(let underlying):
+        return underlying.localizedDescription
+      case .transportError(let underlying):
+        return underlying.localizedDescription
+      case .invalidResponse:
+        return "The response was not an HTTP response."
+      case .requestFailed:
+        return "The request finished with a non-success status code."
+      }
+    }
+  }
+
+  static let dummyEntry = Entry(
+    title: "Daily Reflection",
+    mood: "Restorative",
+    note: "Felt grounded during breathwork and noted gentle mood shifts."
+  )
+
+  private static let defaultEndpoint: URL = {
+    guard let url = URL(string: "https://example.com/api/journal") else {
+      preconditionFailure("Invalid default journal API URL.")
+    }
+    return url
+  }()
+
+  private let session: URLSession
+  private let endpoint: URL
+
+  init(session: URLSession = .shared, endpoint: URL = JournalAPI.defaultEndpoint) {
+    self.session = session
+    self.endpoint = endpoint
+  }
+
+  @discardableResult
+  func postJournal() async throws -> Entry {
+    let entry = Self.dummyEntry
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+
+    do {
+      request.httpBody = try encoder.encode(entry)
+    } catch {
+      throw JournalAPIError.encodingFailed(underlying: error)
+    }
+
+    do {
+      let (_, response) = try await session.data(for: request)
+      guard let httpResponse = response as? HTTPURLResponse else {
+        throw JournalAPIError.invalidResponse
+      }
+
+      guard (200..<300).contains(httpResponse.statusCode) else {
+        throw JournalAPIError.requestFailed(statusCode: httpResponse.statusCode)
+      }
+
+      return entry
+    } catch let apiError as JournalAPIError {
+      throw apiError
+    } catch {
+      throw JournalAPIError.transportError(underlying: error)
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/JournalAPI.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/JournalAPI.swift
@@ -16,26 +16,26 @@ struct JournalAPI {
     var errorDescription: String? {
       switch self {
       case .encodingFailed:
-        return "We couldn't prepare your journal entry."
+        "We couldn't prepare your journal entry."
       case .invalidResponse:
-        return "The server returned something unexpected."
-      case .requestFailed(let statusCode):
-        return "The server responded with status code \(statusCode)."
+        "The server returned something unexpected."
+      case let .requestFailed(statusCode):
+        "The server responded with status code \(statusCode)."
       case .transportError:
-        return "We couldn't reach the server."
+        "We couldn't reach the server."
       }
     }
 
     var failureReason: String? {
       switch self {
-      case .encodingFailed(let underlying):
-        return underlying.localizedDescription
-      case .transportError(let underlying):
-        return underlying.localizedDescription
+      case let .encodingFailed(underlying):
+        underlying.localizedDescription
+      case let .transportError(underlying):
+        underlying.localizedDescription
       case .invalidResponse:
-        return "The response was not an HTTP response."
+        "The response was not an HTTP response."
       case .requestFailed:
-        return "The request finished with a non-success status code."
+        "The request finished with a non-success status code."
       }
     }
   }
@@ -83,7 +83,7 @@ struct JournalAPI {
         throw JournalAPIError.invalidResponse
       }
 
-      guard (200..<300).contains(httpResponse.statusCode) else {
+      guard (200 ..< 300).contains(httpResponse.statusCode) else {
         throw JournalAPIError.requestFailed(statusCode: httpResponse.statusCode)
       }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalAPITests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalAPITests.swift
@@ -114,7 +114,7 @@ struct JournalAPITests {
     }
 
     switch error {
-    case .requestFailed(let statusCode):
+    case let .requestFailed(statusCode):
       #expect(statusCode == 500)
     default:
       #expect(false)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalAPITests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalAPITests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+private final class URLProtocolSpy: URLProtocol {
+  enum SpyError: Error {
+    case missingHandler
+  }
+
+  static var requestHandler: ((URLRequest) throws -> (Data, URLResponse))?
+
+  static func reset() {
+    requestHandler = nil
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let handler = Self.requestHandler else {
+      client?.urlProtocol(self, didFailWithError: SpyError.missingHandler)
+      return
+    }
+
+    do {
+      let (data, response) = try handler(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+enum JournalAPITestsError: Error {
+  case missingRequest
+  case missingBody
+}
+
+struct JournalAPITests {
+  @Test func postJournalBuildsExpectedRequest() async throws {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [URLProtocolSpy.self]
+    let session = URLSession(configuration: configuration)
+    let endpoint = URL(string: "https://example.com/journal")!
+    let api = JournalAPI(session: session, endpoint: endpoint)
+
+    var capturedRequest: URLRequest?
+    URLProtocolSpy.requestHandler = { request in
+      capturedRequest = request
+      let response = HTTPURLResponse(
+        url: endpoint,
+        statusCode: 201,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+      return (Data(), response)
+    }
+    defer { URLProtocolSpy.reset() }
+
+    let entry = try await api.postJournal()
+    #expect(entry == JournalAPI.dummyEntry)
+
+    guard let request = capturedRequest else {
+      throw JournalAPITestsError.missingRequest
+    }
+    #expect(request.httpMethod == "POST")
+    #expect(request.url == endpoint)
+    #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+    guard let body = request.httpBody else {
+      throw JournalAPITestsError.missingBody
+    }
+    let decoded = try JSONDecoder().decode(JournalAPI.Entry.self, from: body)
+    #expect(decoded == JournalAPI.dummyEntry)
+  }
+
+  @Test func postJournalPropagatesRequestFailures() async throws {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [URLProtocolSpy.self]
+    let session = URLSession(configuration: configuration)
+    let endpoint = URL(string: "https://example.com/journal")!
+    let api = JournalAPI(session: session, endpoint: endpoint)
+
+    URLProtocolSpy.requestHandler = { _ in
+      let response = HTTPURLResponse(
+        url: endpoint,
+        statusCode: 500,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+      return (Data(), response)
+    }
+    defer { URLProtocolSpy.reset() }
+
+    var recordedError: JournalAPI.JournalAPIError?
+    do {
+      _ = try await api.postJournal()
+    } catch let error as JournalAPI.JournalAPIError {
+      recordedError = error
+    }
+
+    guard let error = recordedError else {
+      #expect(false)
+      return
+    }
+
+    switch error {
+    case .requestFailed(let statusCode):
+      #expect(statusCode == 500)
+    default:
+      #expect(false)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a watch JournalAPI with a URLSession-based postJournal helper and dummy entry payload
- surface localized error descriptions for common request failures
- cover request construction and failure handling with URLProtocol-based tests

## Testing
- not run (requires Xcode and the watchOS test environment)

------
https://chatgpt.com/codex/tasks/task_e_68c8bcba7f148322bc12e8bc74586ad3