### PR TITLE
Add FastAPI CRUD API with seeded reference data

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,40 @@
+"""Database configuration and session management utilities."""
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from typing import Any
+
+from sqlmodel import Session, SQLModel, create_engine
+from sqlalchemy.pool import StaticPool
+
+DATABASE_URL_ENV = "DATABASE_URL"
+DEFAULT_SQLITE_URL = "sqlite:///./app.db"
+
+
+def _create_engine() -> Any:
+    """Create a SQLModel compatible engine with sensible defaults."""
+    database_url = os.getenv(DATABASE_URL_ENV, DEFAULT_SQLITE_URL)
+    engine_kwargs: dict[str, Any] = {"echo": False}
+
+    if database_url.startswith("sqlite"):
+        connect_args = {"check_same_thread": False}
+        engine_kwargs["connect_args"] = connect_args
+        if database_url in {"sqlite://", "sqlite:///:memory:"}:
+            engine_kwargs["poolclass"] = StaticPool
+
+    return create_engine(database_url, **engine_kwargs)
+
+
+engine = _create_engine()
+
+
+def create_db_and_tables() -> None:
+    """Create database tables based on SQLModel metadata."""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Generator[Session, None, None]:
+    """Yield a SQLModel session to interact with the database."""
+    with Session(engine) as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,33 @@
+"""FastAPI application entry point."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from sqlmodel import Session
+
+from app import routers
+from app.database import create_db_and_tables, engine
+from app.seed_data import seed_data
+
+app = FastAPI(title="WavelengthWatch API", version="0.1.0")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialize database schema and seed data on startup."""
+    create_db_and_tables()
+    with Session(engine) as session:
+        seed_data(session)
+
+
+# Include routers
+app.include_router(routers.layer.router)
+app.include_router(routers.phase.router)
+app.include_router(routers.curriculum.router)
+app.include_router(routers.strategy.router)
+app.include_router(routers.journal.router)
+
+
+@app.get("/health", tags=["health"])
+def healthcheck() -> dict[str, str]:
+    """Simple healthcheck endpoint."""
+    return {"status": "ok"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,106 @@
+"""Database models defined using SQLModel with relationships."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Layer(SQLModel, table=True):
+    """Represents an archetypal layer of the curriculum."""
+
+    __tablename__ = "layer"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    color: str
+    title: str
+    subtitle: str
+
+    curriculum_items: list["Curriculum"] = Relationship(back_populates="layer")
+    strategies: list["Strategy"] = Relationship(back_populates="layer")
+
+
+class Phase(SQLModel, table=True):
+    """Represents a progression phase."""
+
+    __tablename__ = "phase"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+
+    curriculum_items: list["Curriculum"] = Relationship(back_populates="phase")
+    strategies: list["Strategy"] = Relationship(back_populates="phase")
+
+
+class Curriculum(SQLModel, table=True):
+    """Represents a curriculum item tying together layer, phase, and dosage."""
+
+    __tablename__ = "curriculum"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    stage_id: int = Field(foreign_key="layer.id")
+    phase_id: int = Field(foreign_key="phase.id")
+    dosage: str
+    expression: str
+
+    layer: Layer = Relationship(back_populates="curriculum_items")
+    phase: Phase = Relationship(back_populates="curriculum_items")
+    journal_entries: list["Journal"] = Relationship(
+        back_populates="curriculum",
+        sa_relationship_kwargs={
+            "primaryjoin": "Curriculum.id == Journal.curriculum_id",
+            "foreign_keys": "Journal.curriculum_id",
+        },
+    )
+    secondary_journal_entries: list["Journal"] = Relationship(
+        back_populates="secondary_curriculum",
+        sa_relationship_kwargs={
+            "primaryjoin": "Curriculum.id == Journal.secondary_curriculum_id",
+            "foreign_keys": "Journal.secondary_curriculum_id",
+        },
+    )
+
+
+class Strategy(SQLModel, table=True):
+    """Represents a strategy associated with a specific layer and phase."""
+
+    __tablename__ = "strategy"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    strategy: str
+    layer_id: int = Field(foreign_key="layer.id")
+    phase_id: int = Field(foreign_key="phase.id")
+
+    layer: Layer = Relationship(back_populates="strategies")
+    phase: Phase = Relationship(back_populates="strategies")
+    journal_entries: list["Journal"] = Relationship(back_populates="strategy")
+
+
+class Journal(SQLModel, table=True):
+    """Represents a journal entry submitted by a user."""
+
+    __tablename__ = "journal"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False)
+    )
+    user_id: int
+    curriculum_id: int = Field(foreign_key="curriculum.id")
+    secondary_curriculum_id: Optional[int] = Field(
+        default=None, foreign_key="curriculum.id"
+    )
+    strategy_id: Optional[int] = Field(default=None, foreign_key="strategy.id")
+
+    curriculum: Curriculum = Relationship(
+        back_populates="journal_entries",
+        sa_relationship_kwargs={"foreign_keys": "Journal.curriculum_id"},
+    )
+    secondary_curriculum: Optional[Curriculum] = Relationship(
+        back_populates="secondary_journal_entries",
+        sa_relationship_kwargs={
+            "foreign_keys": "Journal.secondary_curriculum_id",
+        },
+    )
+    strategy: Optional[Strategy] = Relationship(back_populates="journal_entries")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,10 @@
+"""Router package exports for FastAPI application."""
+from . import curriculum, journal, layer, phase, strategy
+
+__all__ = [
+    "curriculum",
+    "journal",
+    "layer",
+    "phase",
+    "strategy",
+]

--- a/app/routers/curriculum.py
+++ b/app/routers/curriculum.py
@@ -1,0 +1,120 @@
+"""Curriculum CRUD endpoints."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.models import Curriculum
+from app.schemas import CurriculumCreate, CurriculumRead, CurriculumUpdate
+
+router = APIRouter(prefix="/curriculum", tags=["curriculum"])
+
+
+@router.get("/", response_model=List[CurriculumRead])
+def list_curriculum(
+    *,
+    session: Session = Depends(get_session),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    stage_id: Optional[int] = Query(default=None),
+    phase_id: Optional[int] = Query(default=None),
+    dosage: Optional[str] = Query(default=None),
+) -> List[Curriculum]:
+    """List curriculum items with optional filtering."""
+
+    statement = (
+        select(Curriculum)
+        .options(
+            selectinload(Curriculum.layer),
+            selectinload(Curriculum.phase),
+        )
+        .order_by(Curriculum.id)
+    )
+
+    if stage_id is not None:
+        statement = statement.where(Curriculum.stage_id == stage_id)
+    if phase_id is not None:
+        statement = statement.where(Curriculum.phase_id == phase_id)
+    if dosage is not None:
+        statement = statement.where(Curriculum.dosage == dosage)
+
+    curriculum_items = session.exec(statement.offset(offset).limit(limit)).all()
+    return curriculum_items
+
+
+@router.get("/{curriculum_id}", response_model=CurriculumRead)
+def get_curriculum(
+    *, curriculum_id: int, session: Session = Depends(get_session)
+) -> Curriculum:
+    """Retrieve a curriculum entry by identifier."""
+
+    statement = (
+        select(Curriculum)
+        .where(Curriculum.id == curriculum_id)
+        .options(
+            selectinload(Curriculum.layer),
+            selectinload(Curriculum.phase),
+        )
+    )
+    curriculum = session.exec(statement).one_or_none()
+    if curriculum is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Curriculum not found")
+    return curriculum
+
+
+@router.post("/", response_model=CurriculumRead, status_code=status.HTTP_201_CREATED)
+def create_curriculum(
+    *, payload: CurriculumCreate, session: Session = Depends(get_session)
+) -> Curriculum:
+    """Create a new curriculum entry.
+
+    Curriculum rows are typically reference data but can be adjusted via this endpoint.
+    """
+
+    curriculum = Curriculum.model_validate(payload)
+    session.add(curriculum)
+    session.commit()
+    session.refresh(curriculum)
+    return curriculum
+
+
+@router.put("/{curriculum_id}", response_model=CurriculumRead)
+def update_curriculum(
+    *, curriculum_id: int, payload: CurriculumUpdate, session: Session = Depends(get_session)
+) -> Curriculum:
+    """Update an existing curriculum entry."""
+
+    curriculum = session.get(Curriculum, curriculum_id)
+    if curriculum is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Curriculum not found")
+
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(curriculum, key, value)
+
+    session.add(curriculum)
+    session.commit()
+    session.refresh(curriculum)
+    return curriculum
+
+
+@router.delete(
+    "/{curriculum_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_curriculum(
+    *, curriculum_id: int, session: Session = Depends(get_session)
+) -> Response:
+    """Delete a curriculum entry."""
+
+    curriculum = session.get(Curriculum, curriculum_id)
+    if curriculum is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Curriculum not found")
+
+    session.delete(curriculum)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/journal.py
+++ b/app/routers/journal.py
@@ -1,0 +1,131 @@
+"""Journal CRUD endpoints."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.models import Curriculum, Journal, Strategy
+from app.schemas import JournalCreate, JournalRead, JournalUpdate
+from app.utils import ensure_aware
+
+
+def _normalize_entry(entry: Journal) -> Journal:
+    entry.created_at = ensure_aware(entry.created_at)
+    return entry
+
+router = APIRouter(prefix="/journal", tags=["journal"])
+
+
+def _journal_base_statement():
+    return select(Journal).options(
+        selectinload(Journal.curriculum).selectinload(Curriculum.layer),
+        selectinload(Journal.curriculum).selectinload(Curriculum.phase),
+        selectinload(Journal.secondary_curriculum).selectinload(Curriculum.layer),
+        selectinload(Journal.secondary_curriculum).selectinload(Curriculum.phase),
+        selectinload(Journal.strategy).selectinload(Strategy.layer),
+        selectinload(Journal.strategy).selectinload(Strategy.phase),
+    )
+
+
+@router.get("/", response_model=List[JournalRead])
+def list_journal(
+    *,
+    session: Session = Depends(get_session),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    user_id: Optional[int] = Query(default=None),
+    strategy_id: Optional[int] = Query(default=None),
+    from_: Optional[datetime] = Query(default=None, alias="from"),
+    to: Optional[datetime] = Query(default=None),
+) -> List[Journal]:
+    """List journal entries with optional filters."""
+
+    statement = _journal_base_statement().order_by(Journal.created_at.desc())
+
+    if user_id is not None:
+        statement = statement.where(Journal.user_id == user_id)
+    if strategy_id is not None:
+        statement = statement.where(Journal.strategy_id == strategy_id)
+    if from_ is not None:
+        statement = statement.where(Journal.created_at >= ensure_aware(from_))
+    if to is not None:
+        statement = statement.where(Journal.created_at <= ensure_aware(to))
+
+    journals = session.exec(statement.offset(offset).limit(limit)).all()
+    return [_normalize_entry(journal) for journal in journals]
+
+
+@router.get("/{journal_id}", response_model=JournalRead)
+def get_journal(
+    *, journal_id: int, session: Session = Depends(get_session)
+) -> Journal:
+    """Retrieve a specific journal entry."""
+
+    statement = _journal_base_statement().where(Journal.id == journal_id)
+    journal = session.exec(statement).one_or_none()
+    if journal is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Journal not found")
+    return _normalize_entry(journal)
+
+
+@router.post("/", response_model=JournalRead, status_code=status.HTTP_201_CREATED)
+def create_journal(
+    *, payload: JournalCreate, session: Session = Depends(get_session)
+) -> Journal:
+    """Create a new journal entry."""
+
+    journal = Journal.model_validate(payload)
+    journal.created_at = ensure_aware(journal.created_at)
+
+    session.add(journal)
+    session.commit()
+    session.refresh(journal)
+
+    # Reload with relationships for consistent response
+    return get_journal(journal_id=journal.id, session=session)
+
+
+@router.put("/{journal_id}", response_model=JournalRead)
+def update_journal(
+    *, journal_id: int, payload: JournalUpdate, session: Session = Depends(get_session)
+) -> Journal:
+    """Update an existing journal entry."""
+
+    journal = session.get(Journal, journal_id)
+    if journal is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Journal not found")
+
+    update_data = payload.model_dump(exclude_unset=True)
+    if "created_at" in update_data and update_data["created_at"] is not None:
+        update_data["created_at"] = ensure_aware(update_data["created_at"])
+
+    for key, value in update_data.items():
+        setattr(journal, key, value)
+
+    session.add(journal)
+    session.commit()
+    session.refresh(journal)
+
+    return get_journal(journal_id=journal.id, session=session)
+
+
+@router.delete(
+    "/{journal_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_journal(*, journal_id: int, session: Session = Depends(get_session)) -> Response:
+    """Delete a journal entry."""
+
+    journal = session.get(Journal, journal_id)
+    if journal is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Journal not found")
+
+    session.delete(journal)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/layer.py
+++ b/app/routers/layer.py
@@ -1,0 +1,86 @@
+"""Layer CRUD endpoints."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.models import Layer
+from app.schemas import LayerCreate, LayerRead, LayerUpdate
+
+router = APIRouter(prefix="/layers", tags=["layers"])
+
+
+@router.get("/", response_model=List[LayerRead])
+def list_layers(
+    *,
+    session: Session = Depends(get_session),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> List[Layer]:
+    """List layers with pagination."""
+
+    statement = select(Layer).options(selectinload(Layer.curriculum_items))
+    layers = session.exec(statement.offset(offset).limit(limit)).all()
+    return layers
+
+
+@router.get("/{layer_id}", response_model=LayerRead)
+def get_layer(*, layer_id: int, session: Session = Depends(get_session)) -> Layer:
+    """Retrieve a single layer by identifier."""
+
+    statement = select(Layer).where(Layer.id == layer_id)
+    layer = session.exec(statement).one_or_none()
+    if layer is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Layer not found")
+    return layer
+
+
+@router.post("/", response_model=LayerRead, status_code=status.HTTP_201_CREATED)
+def create_layer(*, payload: LayerCreate, session: Session = Depends(get_session)) -> Layer:
+    """Create a new layer.
+
+    Even though layers are typically reference data, the endpoint allows creation for
+    administrative tooling.
+    """
+
+    layer = Layer.model_validate(payload)
+    session.add(layer)
+    session.commit()
+    session.refresh(layer)
+    return layer
+
+
+@router.put("/{layer_id}", response_model=LayerRead)
+def update_layer(
+    *, layer_id: int, payload: LayerUpdate, session: Session = Depends(get_session)
+) -> Layer:
+    """Update an existing layer."""
+
+    layer = session.get(Layer, layer_id)
+    if layer is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Layer not found")
+
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(layer, key, value)
+
+    session.add(layer)
+    session.commit()
+    session.refresh(layer)
+    return layer
+
+
+@router.delete("/{layer_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+def delete_layer(*, layer_id: int, session: Session = Depends(get_session)) -> Response:
+    """Delete a layer entry."""
+
+    layer = session.get(Layer, layer_id)
+    if layer is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Layer not found")
+
+    session.delete(layer)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/phase.py
+++ b/app/routers/phase.py
@@ -1,0 +1,81 @@
+"""Phase CRUD endpoints."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.models import Phase
+from app.schemas import PhaseCreate, PhaseRead, PhaseUpdate
+
+router = APIRouter(prefix="/phases", tags=["phases"])
+
+
+@router.get("/", response_model=List[PhaseRead])
+def list_phases(
+    *,
+    session: Session = Depends(get_session),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> List[Phase]:
+    """List phases with pagination."""
+
+    statement = select(Phase).options(selectinload(Phase.curriculum_items))
+    phases = session.exec(statement.offset(offset).limit(limit)).all()
+    return phases
+
+
+@router.get("/{phase_id}", response_model=PhaseRead)
+def get_phase(*, phase_id: int, session: Session = Depends(get_session)) -> Phase:
+    """Retrieve a specific phase."""
+
+    phase = session.exec(select(Phase).where(Phase.id == phase_id)).one_or_none()
+    if phase is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Phase not found")
+    return phase
+
+
+@router.post("/", response_model=PhaseRead, status_code=status.HTTP_201_CREATED)
+def create_phase(*, payload: PhaseCreate, session: Session = Depends(get_session)) -> Phase:
+    """Create a new phase entry."""
+
+    phase = Phase.model_validate(payload)
+    session.add(phase)
+    session.commit()
+    session.refresh(phase)
+    return phase
+
+
+@router.put("/{phase_id}", response_model=PhaseRead)
+def update_phase(
+    *, phase_id: int, payload: PhaseUpdate, session: Session = Depends(get_session)
+) -> Phase:
+    """Update an existing phase."""
+
+    phase = session.get(Phase, phase_id)
+    if phase is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Phase not found")
+
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(phase, key, value)
+
+    session.add(phase)
+    session.commit()
+    session.refresh(phase)
+    return phase
+
+
+@router.delete("/{phase_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+def delete_phase(*, phase_id: int, session: Session = Depends(get_session)) -> Response:
+    """Delete a phase."""
+
+    phase = session.get(Phase, phase_id)
+    if phase is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Phase not found")
+
+    session.delete(phase)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/strategy.py
+++ b/app/routers/strategy.py
@@ -1,0 +1,114 @@
+"""Strategy CRUD endpoints."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.models import Strategy
+from app.schemas import StrategyCreate, StrategyRead, StrategyUpdate
+
+router = APIRouter(prefix="/strategies", tags=["strategies"])
+
+
+@router.get("/", response_model=List[StrategyRead])
+def list_strategies(
+    *,
+    session: Session = Depends(get_session),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    layer_id: Optional[int] = Query(default=None),
+    phase_id: Optional[int] = Query(default=None),
+) -> List[Strategy]:
+    """List strategies with optional filters."""
+
+    statement = (
+        select(Strategy)
+        .options(
+            selectinload(Strategy.layer),
+            selectinload(Strategy.phase),
+        )
+        .order_by(Strategy.id)
+    )
+
+    if layer_id is not None:
+        statement = statement.where(Strategy.layer_id == layer_id)
+    if phase_id is not None:
+        statement = statement.where(Strategy.phase_id == phase_id)
+
+    strategies = session.exec(statement.offset(offset).limit(limit)).all()
+    return strategies
+
+
+@router.get("/{strategy_id}", response_model=StrategyRead)
+def get_strategy(
+    *, strategy_id: int, session: Session = Depends(get_session)
+) -> Strategy:
+    """Retrieve a specific strategy."""
+
+    statement = (
+        select(Strategy)
+        .where(Strategy.id == strategy_id)
+        .options(
+            selectinload(Strategy.layer),
+            selectinload(Strategy.phase),
+        )
+    )
+    strategy = session.exec(statement).one_or_none()
+    if strategy is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found")
+    return strategy
+
+
+@router.post("/", response_model=StrategyRead, status_code=status.HTTP_201_CREATED)
+def create_strategy(
+    *, payload: StrategyCreate, session: Session = Depends(get_session)
+) -> Strategy:
+    """Create a new strategy entry."""
+
+    strategy = Strategy.model_validate(payload)
+    session.add(strategy)
+    session.commit()
+    session.refresh(strategy)
+    return strategy
+
+
+@router.put("/{strategy_id}", response_model=StrategyRead)
+def update_strategy(
+    *, strategy_id: int, payload: StrategyUpdate, session: Session = Depends(get_session)
+) -> Strategy:
+    """Update an existing strategy."""
+
+    strategy = session.get(Strategy, strategy_id)
+    if strategy is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found")
+
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(strategy, key, value)
+
+    session.add(strategy)
+    session.commit()
+    session.refresh(strategy)
+    return strategy
+
+
+@router.delete(
+    "/{strategy_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_strategy(
+    *, strategy_id: int, session: Session = Depends(get_session)
+) -> Response:
+    """Delete a strategy entry."""
+
+    strategy = session.get(Strategy, strategy_id)
+    if strategy is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Strategy not found")
+
+    session.delete(strategy)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,133 @@
+"""Pydantic/SQLModel schemas for request and response bodies."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import ConfigDict, Field as PydanticField
+from sqlmodel import SQLModel
+
+
+class LayerBase(SQLModel):
+    color: str = PydanticField(description="Display color of the layer")
+    title: str = PydanticField(description="Primary layer title")
+    subtitle: str = PydanticField(description="Supporting subtitle text")
+
+
+class LayerCreate(LayerBase):
+    """Payload for creating a new layer reference item."""
+
+
+class LayerUpdate(SQLModel):
+    color: Optional[str] = None
+    title: Optional[str] = None
+    subtitle: Optional[str] = None
+
+
+class LayerRead(LayerBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PhaseBase(SQLModel):
+    name: str = PydanticField(description="Name of the phase")
+
+
+class PhaseCreate(PhaseBase):
+    pass
+
+
+class PhaseUpdate(SQLModel):
+    name: Optional[str] = None
+
+
+class PhaseRead(PhaseBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CurriculumBase(SQLModel):
+    stage_id: int = PydanticField(description="Foreign key to Layer.id")
+    phase_id: int = PydanticField(description="Foreign key to Phase.id")
+    dosage: str = PydanticField(
+        description="Dosage descriptor. Known values include 'Medicinal' and 'Toxic'."
+    )
+    expression: str = PydanticField(description="Curriculum expression label")
+
+
+class CurriculumCreate(CurriculumBase):
+    pass
+
+
+class CurriculumUpdate(SQLModel):
+    stage_id: Optional[int] = None
+    phase_id: Optional[int] = None
+    dosage: Optional[str] = None
+    expression: Optional[str] = None
+
+
+class CurriculumRead(CurriculumBase):
+    id: int
+    layer: Optional[LayerRead] = None
+    phase: Optional[PhaseRead] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class StrategyBase(SQLModel):
+    strategy: str = PydanticField(description="Strategy description")
+    layer_id: int = PydanticField(description="Foreign key to Layer.id")
+    phase_id: int = PydanticField(description="Foreign key to Phase.id")
+
+
+class StrategyCreate(StrategyBase):
+    pass
+
+
+class StrategyUpdate(SQLModel):
+    strategy: Optional[str] = None
+    layer_id: Optional[int] = None
+    phase_id: Optional[int] = None
+
+
+class StrategyRead(StrategyBase):
+    id: int
+    layer: Optional[LayerRead] = None
+    phase: Optional[PhaseRead] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class JournalBase(SQLModel):
+    created_at: datetime = PydanticField(description="Timestamp when the entry was recorded")
+    user_id: int = PydanticField(description="Identifier for the user submitting the entry")
+    curriculum_id: int = PydanticField(description="Primary curriculum reference")
+    secondary_curriculum_id: Optional[int] = PydanticField(
+        default=None, description="Optional secondary curriculum reference"
+    )
+    strategy_id: Optional[int] = PydanticField(
+        default=None, description="Optional strategy reference"
+    )
+
+
+class JournalCreate(JournalBase):
+    pass
+
+
+class JournalUpdate(SQLModel):
+    created_at: Optional[datetime] = None
+    user_id: Optional[int] = None
+    curriculum_id: Optional[int] = None
+    secondary_curriculum_id: Optional[int] = None
+    strategy_id: Optional[int] = None
+
+
+class JournalRead(JournalBase):
+    id: int
+    curriculum: Optional[CurriculumRead] = None
+    secondary_curriculum: Optional[CurriculumRead] = None
+    strategy: Optional[StrategyRead] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/seed_data.py
+++ b/app/seed_data.py
@@ -1,0 +1,308 @@
+"""Seed data loader for initializing the database with CSV fixtures."""
+from __future__ import annotations
+
+import csv
+import io
+from typing import Iterable, Optional
+
+from sqlmodel import Session, select
+
+from app.models import Curriculum, Journal, Layer, Phase, Strategy
+from app.utils import parse_iso_datetime
+
+LAYER_CSV = '''id,color,title,subtitle
+0,Strategies,SELF-CARE,(For Surfing)
+1,Beige,INHABIT,(Do)
+2,Purple,INHABIT,(Feel)
+3,Red,EXPRESS,(Do)
+4,Blue,EXPRESS,(Feel)
+5,Orange,COLLABORATE,(Do)
+6,Green,COLLABORATE,(Feel)
+7,Yellow,INTEGRATE,(Do)
+8,Teal,INTEGRATE,(Feel)
+9,Ultraviolet,ABSORB,(Do/Feel)
+10,Clear Light,BE,(Neither/Both)
+'''
+
+PHASE_CSV = '''id,name
+1,Rising
+2,Peaking
+3,Withdrawal
+4,Diminishing
+5,Bottoming Out
+6,Restoration
+'''
+
+CURRICULUM_CSV = '''id,stage_id,phase_id,dosage,expression
+1,1,1,Medicinal,Commitment
+2,2,1,Medicinal,Inspiration
+3,3,1,Medicinal,Leading
+4,4,1,Medicinal,Ambition
+5,5,1,Medicinal,Hypothesize
+6,6,1,Medicinal,Connection
+7,7,1,Medicinal,Rebellion
+8,8,1,Medicinal,Epiphany
+9,9,1,Medicinal,Unification of Mind
+10,1,1,Toxic,Overcommitment
+11,2,1,Toxic,Grandiosity 
+12,3,1,Toxic,Dominating
+13,4,1,Toxic,Voraciousness
+14,5,1,Toxic,Assert
+15,6,1,Toxic,Oversharing
+16,7,1,Toxic,Mischief
+17,8,1,Toxic,Delusion
+18,9,1,Toxic,Worldly Desire
+19,1,2,Medicinal,Diligence
+20,2,2,Medicinal,Joy
+21,3,2,Medicinal,Power-With
+22,4,2,Medicinal,Attunement
+23,5,2,Medicinal,Experiment
+24,6,2,Medicinal,Belonging
+25,7,2,Medicinal,Anarchy
+26,8,2,Medicinal,Gnosis
+27,9,2,Medicinal,Jhana
+28,1,2,Toxic,Thriving
+29,2,2,Toxic,Ecstasy
+30,3,2,Toxic,Power-Over
+31,4,2,Toxic,Leprosy
+32,5,2,Toxic,Crusade
+33,6,2,Toxic,Megalomania
+34,7,2,Toxic,Chaos
+35,8,2,Toxic,Psychosis
+36,9,2,Toxic,Bliss Addiction
+37,1,3,Medicinal,Steadiness
+38,2,3,Medicinal,Introspectivity
+39,3,3,Medicinal,Stepping Back
+40,4,3,Medicinal,Humility
+41,5,3,Medicinal,Questioning
+42,6,3,Medicinal,Boundaries
+43,7,3,Medicinal,Reassessment
+44,8,3,Medicinal,Openness
+45,9,3,Medicinal,Directed Curiosity
+46,1,3,Toxic,Indolence
+47,2,3,Toxic,Flatness 
+48,3,3,Toxic,Cowardice
+49,4,3,Toxic,Self-Loathing
+50,5,3,Toxic,Suspicion
+51,6,3,Toxic,Isolationism
+52,7,3,Toxic,Alienation
+53,8,3,Toxic,Meaninglessness 
+54,9,3,Toxic,Religious Hypocrisy
+55,1,4,Medicinal,Recharging
+56,2,4,Medicinal,Coziness
+57,3,4,Medicinal,Walking Away
+58,4,4,Medicinal,Self-Love
+59,5,4,Medicinal,Clarity
+60,6,4,Medicinal,Connection
+61,7,4,Medicinal,Healing
+62,8,4,Medicinal,Faith
+63,9,4,Medicinal,Soul-Nourishment
+64,1,4,Toxic,Numbness
+65,2,4,Toxic,Boredom
+66,3,4,Toxic,Powerlessness
+67,4,4,Toxic,Self-Harm
+68,5,4,Toxic,Jealousy
+69,6,4,Toxic,Career-ism
+70,7,4,Toxic,Anger
+71,8,4,Toxic,Cynicism 
+72,9,4,Toxic,Dogma
+73,1,5,Medicinal,Recovery
+74,2,5,Medicinal,Safety
+75,3,5,Medicinal,Discernment
+76,4,5,Medicinal,Authenticity
+77,5,5,Medicinal,Research
+78,6,5,Medicinal,Trust
+79,7,5,Medicinal,Boundaries
+80,8,5,Medicinal,Compassion
+81,9,5,Medicinal,Self-Acceptance
+82,1,5,Toxic,Rock Bottom
+83,2,5,Toxic,Isolation
+84,3,5,Toxic,Shame
+85,4,5,Toxic,Denial
+86,5,5,Toxic,Paralysis
+87,6,5,Toxic,Tribalism
+88,7,5,Toxic,Hatred
+89,8,5,Toxic,Self-Loathing
+90,9,5,Toxic,Hopelessness
+91,1,6,Medicinal,Rebuilding
+92,2,6,Medicinal,Hopefulness
+93,3,6,Medicinal,Reassert
+94,4,6,Medicinal,Self-Acceptance
+95,5,6,Medicinal,Question
+96,6,6,Medicinal,Vulnerability
+97,7,6,Medicinal,Disintegrate
+98,8,6,Medicinal,Pattern-Seeking
+99,9,6,Medicinal,Directed Attention
+100,1,6,Toxic,New Plan
+101,2,6,Toxic,Selfishness
+102,3,6,Toxic,Revenge
+103,4,6,Toxic,Self-Repression
+104,5,6,Toxic,Presume
+105,6,6,Toxic,Bitterness
+106,7,6,Toxic,The Aftermath
+107,8,6,Toxic,Belief Salience
+108,9,6,Toxic,Laziness or Lethargy
+'''
+
+STRATEGY_CSV = '''id,strategy,layer_id,phase_id
+1,Readjusting posture,1,5
+2,Getting Comfy,1,5
+3,Drinking Water,1,5
+4,Listening to Music,2,5
+5,Pranayama (Lion's Breath),3,5
+6,Learning,5,5
+7,One Pushup / One Squat,1,6
+8,Wash face,1,6
+9,Kirtan,2,6
+10,Taking a Bath,2,6
+11,Getting Some Sunshine,2,6
+12,Somatic Meditation,3,6
+13,Biking,3,6
+14,Jogging,3,6
+15,Dancing,3,6
+16,Husband Time,4,6
+17,Cold Shower,1,1
+18,Clairaudient Practice,2,1
+19,Divination,2,1
+20,Insight Practice,2,1
+21,Activation Breathwork,3,1
+22,Competition/Boasting with Friend,5,1
+23,Prepare for a Good Conversation,6,1
+24,Beginner's Mind,4,1
+25,Make Plans,5,1
+26,Go on a Walk,3,2
+27,Sexy Loving Relationship Stuff,4,2
+28,Weightlifting,5,2
+29,Pranayama (Skull Shining Breath),5,2
+30,Prepare a Meal + Clean Kitchen,6,2
+31,Restorative Moment w/ Close Friend,6,2
+32,Compassion/Ethics,4,2
+33,Networking/Connecting w/ New Folks,6,2
+34,Taking solo trampoline time,2,3
+35,Scaling back your to-do list,5,3
+36,Staying in Crowds,4,3
+37,"""I belong here"" Mantra",4,3
+38,Tune into Loved Ones' Mood Phases,4,3
+39,Intense Exercise,5,3
+40,Pranayama (Xanax Breath - 4/7/8),5,3
+41,Pranayama (Box Breathing - 4/4/4/4),5,3
+42,5-4-3-2-1 Technique,1,3
+43,Grounding Exercises,1,3
+44,Anti-Anxiety Medication,7,3
+45,Long Drives,2,4
+46,Hot Beverages,2,4
+47,Walking,3,4
+48,Journaling,6,4
+49,Cleaning,6,4
+'''
+
+JOURNAL_CSV = '''id,created_at,user_id,curriculum_id,secondary_curriculum_id,strategy_id
+1,2025-09-13T12:34:00.000Z,1,10,11,17.0
+2,2025-09-14T10:34:00.000Z,2,24,19,
+3,2025-09-15T18:34:00.000Z,1,101,5,10.0
+'''
+
+
+def _parse_optional_int(value: Optional[str]) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return int(float(value))
+
+
+def _load_rows(csv_content: str) -> Iterable[dict[str, str]]:
+    reader = csv.DictReader(io.StringIO(csv_content.strip()))
+    return list(reader)
+
+
+def seed_data(session: Session) -> None:
+    """Seed all tables if they are currently empty."""
+
+    if session.exec(select(Layer).limit(1)).first() is None:
+        _seed_layers(session)
+    if session.exec(select(Phase).limit(1)).first() is None:
+        _seed_phases(session)
+    if session.exec(select(Curriculum).limit(1)).first() is None:
+        _seed_curriculum(session)
+    if session.exec(select(Strategy).limit(1)).first() is None:
+        _seed_strategies(session)
+    if session.exec(select(Journal).limit(1)).first() is None:
+        _seed_journal(session)
+
+
+def _seed_layers(session: Session) -> None:
+    rows = _load_rows(LAYER_CSV)
+    layers = [
+        Layer(
+            id=int(row["id"]),
+            color=row["color"],
+            title=row["title"],
+            subtitle=row["subtitle"],
+        )
+        for row in rows
+    ]
+    session.add_all(layers)
+    session.commit()
+
+
+def _seed_phases(session: Session) -> None:
+    rows = _load_rows(PHASE_CSV)
+    phases = [
+        Phase(
+            id=int(row["id"]),
+            name=row["name"],
+        )
+        for row in rows
+    ]
+    session.add_all(phases)
+    session.commit()
+
+
+def _seed_curriculum(session: Session) -> None:
+    rows = _load_rows(CURRICULUM_CSV)
+    items = [
+        Curriculum(
+            id=int(row["id"]),
+            stage_id=int(row["stage_id"]),
+            phase_id=int(row["phase_id"]),
+            dosage=row["dosage"],
+            expression=row["expression"],
+        )
+        for row in rows
+    ]
+    session.add_all(items)
+    session.commit()
+
+
+def _seed_strategies(session: Session) -> None:
+    rows = _load_rows(STRATEGY_CSV)
+    strategies = [
+        Strategy(
+            id=int(row["id"]),
+            strategy=row["strategy"],
+            layer_id=int(row["layer_id"]),
+            phase_id=int(row["phase_id"]),
+        )
+        for row in rows
+    ]
+    session.add_all(strategies)
+    session.commit()
+
+
+def _seed_journal(session: Session) -> None:
+    rows = _load_rows(JOURNAL_CSV)
+    journal_entries = [
+        Journal(
+            id=int(row["id"]),
+            created_at=parse_iso_datetime(row["created_at"]),
+            user_id=int(row["user_id"]),
+            curriculum_id=int(row["curriculum_id"]),
+            secondary_curriculum_id=_parse_optional_int(row["secondary_curriculum_id"]),
+            strategy_id=_parse_optional_int(row["strategy_id"]),
+        )
+        for row in rows
+    ]
+    session.add_all(journal_entries)
+    session.commit()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,31 @@
+"""Utility helpers for the FastAPI application."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timezone
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO-8601 string into an aware datetime.
+
+    Args:
+        value: The ISO-8601 formatted datetime string. Handles a trailing ``Z``
+            by converting it to ``+00:00`` before parsing.
+
+    Returns:
+        A timezone-aware datetime normalized to UTC.
+    """
+
+    normalized = value.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(normalized)
+    return ensure_aware(dt)
+
+
+def ensure_aware(dt: datetime) -> datetime:
+    """Ensure the provided datetime is timezone-aware.
+
+    Naive datetimes are assumed to be in UTC to keep storage consistent.
+    """
+
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(timezone.utc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "wavelengthwatch-fastapi"
+version = "0.1.0"
+description = "FastAPI service for WavelengthWatch curriculum data"
+requires-python = ">=3.11"
+authors = [{name = "WavelengthWatch Bots"}]
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "sqlmodel",
+    "pydantic",
+    "python-dotenv",
+    "httpx",
+    "pytest",
+    "pytest-asyncio",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "mypy",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+strict_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+show_error_codes = true
+pretty = true

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,77 @@
+"""Integration tests for the journal endpoints."""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlmodel import SQLModel, Session
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+
+from app.main import app  # noqa: E402  # pylint: disable=wrong-import-position
+from app.database import engine  # noqa: E402
+from app.seed_data import seed_data  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def prepare_database() -> None:
+    """Ensure a clean database with seeded data for each test."""
+
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        seed_data(session)
+    yield
+    SQLModel.metadata.drop_all(engine)
+
+
+@pytest.mark.asyncio
+async def test_journal_crud_flow() -> None:
+    """Exercise the happy-path CRUD flow for journal entries."""
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        list_response = await client.get("/journal/")
+        assert list_response.status_code == 200
+        starting_count = len(list_response.json())
+
+        payload = {
+            "created_at": "2025-10-01T12:00:00Z",
+            "user_id": 42,
+            "curriculum_id": 1,
+            "secondary_curriculum_id": 2,
+            "strategy_id": 1,
+        }
+        create_response = await client.post("/journal/", json=payload)
+        assert create_response.status_code == 201, create_response.text
+        created = create_response.json()
+        created_id = created["id"]
+
+        parsed_created_at = datetime.fromisoformat(created["created_at"].replace("Z", "+00:00"))
+        expected_created_at = datetime.fromisoformat(payload["created_at"].replace("Z", "+00:00"))
+        assert parsed_created_at == expected_created_at
+        assert created["curriculum"]["id"] == payload["curriculum_id"]
+        assert created["secondary_curriculum"]["id"] == payload["secondary_curriculum_id"]
+        assert created["strategy"]["id"] == payload["strategy_id"]
+
+        detail_response = await client.get(f"/journal/{created_id}")
+        assert detail_response.status_code == 200
+        assert detail_response.json()["id"] == created_id
+
+        update_payload = {"strategy_id": 2}
+        update_response = await client.put(f"/journal/{created_id}", json=update_payload)
+        assert update_response.status_code == 200
+        assert update_response.json()["strategy"]["id"] == update_payload["strategy_id"]
+
+        delete_response = await client.delete(f"/journal/{created_id}")
+        assert delete_response.status_code == 204
+
+        # Confirm the entry is gone and count restored
+        final_list = await client.get("/journal/")
+        assert final_list.status_code == 200
+        assert len(final_list.json()) == starting_count
+
+        missing_response = await client.get(f"/journal/{created_id}")
+        assert missing_response.status_code == 404


### PR DESCRIPTION
## Summary
- add a FastAPI + SQLModel service with routers for layers, phases, curriculum, strategies, and journal entries
- seed the SQLite database from bundled CSV fixtures and normalize timezone-aware timestamps
- document project usage and add an async journal CRUD integration test

## Testing
- pytest tests/test_journal.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d55c0cf0832283586a11152e71c2