### PR TITLE
Configure watch app API base URL

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Resources/APIConfiguration.plist
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Resources/APIConfiguration.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>API_BASE_URL</key>
-    <string>https://api.not-configured.local</string>
+    <string>http://127.0.0.1:8000</string>
 </dict>
 </plist>

--- a/frontend/WavelengthWatch/WavelengthWatch.xcodeproj/project.pbxproj
+++ b/frontend/WavelengthWatch/WavelengthWatch.xcodeproj/project.pbxproj
@@ -473,14 +473,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4YP4K7RFL9;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = WavelengthWatch;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKWatchOnly = YES;
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = 4YP4K7RFL9;
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_KEY_API_BASE_URL = "http://127.0.0.1:8000";
+                                INFOPLIST_KEY_CFBundleDisplayName = WavelengthWatch;
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+                                INFOPLIST_KEY_WKWatchOnly = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -502,14 +503,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4YP4K7RFL9;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = WavelengthWatch;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKWatchOnly = YES;
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = 4YP4K7RFL9;
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_KEY_API_BASE_URL = "http://127.0.0.1:8000";
+                                INFOPLIST_KEY_CFBundleDisplayName = WavelengthWatch;
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+                                INFOPLIST_KEY_WKWatchOnly = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
- add an `INFOPLIST_KEY_API_BASE_URL` entry for each build configuration of the WavelengthWatch Watch App target so the bundle exposes the backend host
- align the committed APIConfiguration plist with the same localhost FastAPI endpoint used for development

## Testing
- not run (requires Xcode)


------
https://chatgpt.com/codex/tasks/task_e_68cdbcc85c1c8322bb7771df5f3bbfea