### PR TITLE
Add shared directory overview to contributor guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,114 +76,16 @@ Use this quick reference tree to understand where major assets live before colla
 
 ```text
 WavelengthWatch/
-├── .github/
-│   └── workflows/
-│       ├── ci.yml
-│       ├── claude-code-review.yml
-│       └── claude.yml
-├── AGENTS.md
-├── CLAUDE.md
-├── README.md
-├── XCODE_BUILD_SETUP.md
-├── backend/
-│   ├── README.md
-│   ├── __init__.py
-│   ├── app.py
-│   ├── database.py
-│   ├── models.py
-│   ├── schemas.py
-│   ├── schemas_catalog.py
-│   ├── requirements-dev.txt
-│   ├── requirements.txt
-│   ├── data/
-│   │   ├── a-w-curriculum.csv
-│   │   ├── a-w-headers.csv
-│   │   ├── a-w-strategies.csv
-│   │   ├── curriculum.json
-│   │   ├── headers.json
-│   │   ├── strategies.json
-│   │   └── prod/
-│   │       ├── a-w-curriculum.json
-│   │       ├── a-w-headers.json
-│   │       └── a-w-strategies.json
-│   ├── routers/
-│   │   ├── __init__.py
-│   │   ├── catalog.py
-│   │   ├── curriculum.py
-│   │   ├── journal.py
-│   │   ├── layer.py
-│   │   ├── phase.py
-│   │   └── strategy.py
-│   ├── services/
-│   │   ├── __init__.py
-│   │   └── catalog.py
-│   └── tools/
-│       ├── csv_to_json.py
-│       ├── data/
-│       │   ├── curriculum.csv
-│       │   ├── journal.csv
-│       │   ├── layer.csv
-│       │   ├── phase.csv
-│       │   └── strategy.csv
-│       └── seed_data.py
-├── dev-setup.sh
-├── frontend/
-│   └── WavelengthWatch/
-│       ├── API_CONFIGURATION.md
-│       ├── WavelengthWatch Watch App/
-│       │   ├── App/
-│       │   │   └── AppConfiguration.swift
-│       │   ├── Assets.xcassets/
-│       │   │   ├── AccentColor.colorset
-│       │   │   ├── AppIcon.appiconset
-│       │   │   └── Contents.json
-│       │   ├── ContentView.swift
-│       │   ├── Models/
-│       │   │   └── CatalogModels.swift
-│       │   ├── PhaseNavigator.swift
-│       │   ├── Resources/
-│       │   │   └── APIConfiguration.plist
-│       │   ├── Services/
-│       │   │   ├── APIClient.swift
-│       │   │   ├── CatalogRepository.swift
-│       │   │   └── JournalClient.swift
-│       │   ├── ViewModels/
-│       │   │   └── ContentViewModel.swift
-│       │   └── WavelengthWatchApp.swift
-│       ├── WavelengthWatch Watch AppTests/
-│       │   └── WavelengthWatch_Watch_AppTests.swift
-│       ├── WavelengthWatch Watch AppUITests/
-│       │   ├── WavelengthWatch_Watch_AppUITests.swift
-│       │   └── WavelengthWatch_Watch_AppUITestsLaunchTests.swift
-│       ├── WavelengthWatch.xcodeproj/
-│       │   ├── project.pbxproj
-│       │   ├── project.xcworkspace/
-│       │   │   └── contents.xcworkspacedata
-│       │   └── xcuserdata/
-│       │       └── geoffgallinger.xcuserdatad/
-│       │           └── xcschemes/
-│       │               └── xcschememanagement.plist
-│       └── XCODE_PROJECT_UPDATES.md
-├── mypy.ini
-├── prompts/
-│   ├── add-headers.md
-│   ├── add-layers.md
-│   ├── ci-and-pre-commit-bootstrap.md
-│   ├── front-end-tracer-code.md
-│   └── journal_feature.md
-├── pyproject.toml
-├── pytest.ini
-├── ruff.toml
-├── scripts/
-│   └── convert_csv_to_json.sh
-└── tests/
-    └── backend/
-        ├── conftest.py
-        ├── test_app_config.py
-        ├── test_catalog_api.py
-        ├── test_curriculum_api.py
-        ├── test_journal_api.py
-        ├── test_layer_api.py
-        ├── test_phase_api.py
-        └── test_strategy_api.py
+├── backend/ — FastAPI + SQLModel service with routers, schemas, and CSV/JSON fixtures powering the curriculum and journal APIs.​
+│   ├── data/ — Source CSV/JSON catalogs bundled for backend seeding and the watch experience.
+│   ├── routers/ — Endpoint modules covering catalog, curriculum, journal, layer, phase, and strategy routes.
+│   └── tools/ — Utilities like CSV-to-JSON conversion and database seeding scripts used during setup and builds.
+├── frontend/ — watchOS SwiftUI project containing the main watch target, tests, and configuration docs for collaborators.
+│   └── WavelengthWatch Watch App/ — SwiftUI code organized into App, Assets, Models, Services, Resources, and ViewModels for the watch experience.
+├── tests/ — Pytest suite validating backend configuration and each API surface area.​
+├── prompts/ — Product and process prompts that capture planning notes for AI-assisted development.
+├── scripts/ — Automation helpers, including the CSV→JSON build script for bundling data with the app.​
+├── .github/workflows/ — Continuous integration workflows handling backend checks and automated reviews.
+├── README.md, XCODE_BUILD_SETUP.md — Contributor onboarding guide and Xcode build automation instructions.
+├── dev-setup.sh, pyproject.toml, mypy.ini, ruff.toml, pytest.ini — Repo-wide tooling bootstrap plus lint/type/test configuration defaults.
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,3 +69,121 @@ Agents working on this project must abide by the following operating principles:
   - Restoration leads to Rising.
 
   - Agents are expected to work in cycles: test → think → implement → test → think → refine → repeat (until all green).
+
+## Repository Directory Overview
+
+Use this quick reference tree to understand where major assets live before collaborating or delegating work:
+
+```text
+WavelengthWatch/
+├── .github/
+│   └── workflows/
+│       ├── ci.yml
+│       ├── claude-code-review.yml
+│       └── claude.yml
+├── AGENTS.md
+├── CLAUDE.md
+├── README.md
+├── XCODE_BUILD_SETUP.md
+├── backend/
+│   ├── README.md
+│   ├── __init__.py
+│   ├── app.py
+│   ├── database.py
+│   ├── models.py
+│   ├── schemas.py
+│   ├── schemas_catalog.py
+│   ├── requirements-dev.txt
+│   ├── requirements.txt
+│   ├── data/
+│   │   ├── a-w-curriculum.csv
+│   │   ├── a-w-headers.csv
+│   │   ├── a-w-strategies.csv
+│   │   ├── curriculum.json
+│   │   ├── headers.json
+│   │   ├── strategies.json
+│   │   └── prod/
+│   │       ├── a-w-curriculum.json
+│   │       ├── a-w-headers.json
+│   │       └── a-w-strategies.json
+│   ├── routers/
+│   │   ├── __init__.py
+│   │   ├── catalog.py
+│   │   ├── curriculum.py
+│   │   ├── journal.py
+│   │   ├── layer.py
+│   │   ├── phase.py
+│   │   └── strategy.py
+│   ├── services/
+│   │   ├── __init__.py
+│   │   └── catalog.py
+│   └── tools/
+│       ├── csv_to_json.py
+│       ├── data/
+│       │   ├── curriculum.csv
+│       │   ├── journal.csv
+│       │   ├── layer.csv
+│       │   ├── phase.csv
+│       │   └── strategy.csv
+│       └── seed_data.py
+├── dev-setup.sh
+├── frontend/
+│   └── WavelengthWatch/
+│       ├── API_CONFIGURATION.md
+│       ├── WavelengthWatch Watch App/
+│       │   ├── App/
+│       │   │   └── AppConfiguration.swift
+│       │   ├── Assets.xcassets/
+│       │   │   ├── AccentColor.colorset
+│       │   │   ├── AppIcon.appiconset
+│       │   │   └── Contents.json
+│       │   ├── ContentView.swift
+│       │   ├── Models/
+│       │   │   └── CatalogModels.swift
+│       │   ├── PhaseNavigator.swift
+│       │   ├── Resources/
+│       │   │   └── APIConfiguration.plist
+│       │   ├── Services/
+│       │   │   ├── APIClient.swift
+│       │   │   ├── CatalogRepository.swift
+│       │   │   └── JournalClient.swift
+│       │   ├── ViewModels/
+│       │   │   └── ContentViewModel.swift
+│       │   └── WavelengthWatchApp.swift
+│       ├── WavelengthWatch Watch AppTests/
+│       │   └── WavelengthWatch_Watch_AppTests.swift
+│       ├── WavelengthWatch Watch AppUITests/
+│       │   ├── WavelengthWatch_Watch_AppUITests.swift
+│       │   └── WavelengthWatch_Watch_AppUITestsLaunchTests.swift
+│       ├── WavelengthWatch.xcodeproj/
+│       │   ├── project.pbxproj
+│       │   ├── project.xcworkspace/
+│       │   │   └── contents.xcworkspacedata
+│       │   └── xcuserdata/
+│       │       └── geoffgallinger.xcuserdatad/
+│       │           └── xcschemes/
+│       │               └── xcschememanagement.plist
+│       └── XCODE_PROJECT_UPDATES.md
+├── mypy.ini
+├── prompts/
+│   ├── add-headers.md
+│   ├── add-layers.md
+│   ├── ci-and-pre-commit-bootstrap.md
+│   ├── front-end-tracer-code.md
+│   └── journal_feature.md
+├── pyproject.toml
+├── pytest.ini
+├── ruff.toml
+├── scripts/
+│   └── convert_csv_to_json.sh
+└── tests/
+    └── backend/
+        ├── conftest.py
+        ├── test_app_config.py
+        ├── test_catalog_api.py
+        ├── test_curriculum_api.py
+        ├── test_journal_api.py
+        ├── test_layer_api.py
+        ├── test_phase_api.py
+        └── test_strategy_api.py
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,124 @@ pre-commit run --all-files   # Run all pre-commit hooks
 pre-commit install           # Install hooks (done by dev-setup.sh)
 ```
 
+## Repository Directory Overview
+
+Use this directory snapshot to quickly orient agents and contributors before they jump into implementation details:
+
+```text
+WavelengthWatch/
+├── .github/
+│   └── workflows/
+│       ├── ci.yml
+│       ├── claude-code-review.yml
+│       └── claude.yml
+├── AGENTS.md
+├── CLAUDE.md
+├── README.md
+├── XCODE_BUILD_SETUP.md
+├── backend/
+│   ├── README.md
+│   ├── __init__.py
+│   ├── app.py
+│   ├── database.py
+│   ├── models.py
+│   ├── schemas.py
+│   ├── schemas_catalog.py
+│   ├── requirements-dev.txt
+│   ├── requirements.txt
+│   ├── data/
+│   │   ├── a-w-curriculum.csv
+│   │   ├── a-w-headers.csv
+│   │   ├── a-w-strategies.csv
+│   │   ├── curriculum.json
+│   │   ├── headers.json
+│   │   ├── strategies.json
+│   │   └── prod/
+│   │       ├── a-w-curriculum.json
+│   │       ├── a-w-headers.json
+│   │       └── a-w-strategies.json
+│   ├── routers/
+│   │   ├── __init__.py
+│   │   ├── catalog.py
+│   │   ├── curriculum.py
+│   │   ├── journal.py
+│   │   ├── layer.py
+│   │   ├── phase.py
+│   │   └── strategy.py
+│   ├── services/
+│   │   ├── __init__.py
+│   │   └── catalog.py
+│   └── tools/
+│       ├── csv_to_json.py
+│       ├── data/
+│       │   ├── curriculum.csv
+│       │   ├── journal.csv
+│       │   ├── layer.csv
+│       │   ├── phase.csv
+│       │   └── strategy.csv
+│       └── seed_data.py
+├── dev-setup.sh
+├── frontend/
+│   └── WavelengthWatch/
+│       ├── API_CONFIGURATION.md
+│       ├── WavelengthWatch Watch App/
+│       │   ├── App/
+│       │   │   └── AppConfiguration.swift
+│       │   ├── Assets.xcassets/
+│       │   │   ├── AccentColor.colorset
+│       │   │   ├── AppIcon.appiconset
+│       │   │   └── Contents.json
+│       │   ├── ContentView.swift
+│       │   ├── Models/
+│       │   │   └── CatalogModels.swift
+│       │   ├── PhaseNavigator.swift
+│       │   ├── Resources/
+│       │   │   └── APIConfiguration.plist
+│       │   ├── Services/
+│       │   │   ├── APIClient.swift
+│       │   │   ├── CatalogRepository.swift
+│       │   │   └── JournalClient.swift
+│       │   ├── ViewModels/
+│       │   │   └── ContentViewModel.swift
+│       │   └── WavelengthWatchApp.swift
+│       ├── WavelengthWatch Watch AppTests/
+│       │   └── WavelengthWatch_Watch_AppTests.swift
+│       ├── WavelengthWatch Watch AppUITests/
+│       │   ├── WavelengthWatch_Watch_AppUITests.swift
+│       │   └── WavelengthWatch_Watch_AppUITestsLaunchTests.swift
+│       ├── WavelengthWatch.xcodeproj/
+│       │   ├── project.pbxproj
+│       │   ├── project.xcworkspace/
+│       │   │   └── contents.xcworkspacedata
+│       │   └── xcuserdata/
+│       │       └── geoffgallinger.xcuserdatad/
+│       │           └── xcschemes/
+│       │               └── xcschememanagement.plist
+│       └── XCODE_PROJECT_UPDATES.md
+├── mypy.ini
+├── prompts/
+│   ├── add-headers.md
+│   ├── add-layers.md
+│   ├── ci-and-pre-commit-bootstrap.md
+│   ├── front-end-tracer-code.md
+│   └── journal_feature.md
+├── pyproject.toml
+├── pytest.ini
+├── ruff.toml
+├── scripts/
+│   └── convert_csv_to_json.sh
+└── tests/
+    └── backend/
+        ├── conftest.py
+        ├── test_app_config.py
+        ├── test_catalog_api.py
+        ├── test_curriculum_api.py
+        ├── test_journal_api.py
+        ├── test_layer_api.py
+        ├── test_phase_api.py
+        └── test_strategy_api.py
+```
+
 ## Architecture Overview
 
 ### High-Level Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,116 +49,18 @@ Use this directory snapshot to quickly orient agents and contributors before the
 
 ```text
 WavelengthWatch/
-├── .github/
-│   └── workflows/
-│       ├── ci.yml
-│       ├── claude-code-review.yml
-│       └── claude.yml
-├── AGENTS.md
-├── CLAUDE.md
-├── README.md
-├── XCODE_BUILD_SETUP.md
-├── backend/
-│   ├── README.md
-│   ├── __init__.py
-│   ├── app.py
-│   ├── database.py
-│   ├── models.py
-│   ├── schemas.py
-│   ├── schemas_catalog.py
-│   ├── requirements-dev.txt
-│   ├── requirements.txt
-│   ├── data/
-│   │   ├── a-w-curriculum.csv
-│   │   ├── a-w-headers.csv
-│   │   ├── a-w-strategies.csv
-│   │   ├── curriculum.json
-│   │   ├── headers.json
-│   │   ├── strategies.json
-│   │   └── prod/
-│   │       ├── a-w-curriculum.json
-│   │       ├── a-w-headers.json
-│   │       └── a-w-strategies.json
-│   ├── routers/
-│   │   ├── __init__.py
-│   │   ├── catalog.py
-│   │   ├── curriculum.py
-│   │   ├── journal.py
-│   │   ├── layer.py
-│   │   ├── phase.py
-│   │   └── strategy.py
-│   ├── services/
-│   │   ├── __init__.py
-│   │   └── catalog.py
-│   └── tools/
-│       ├── csv_to_json.py
-│       ├── data/
-│       │   ├── curriculum.csv
-│       │   ├── journal.csv
-│       │   ├── layer.csv
-│       │   ├── phase.csv
-│       │   └── strategy.csv
-│       └── seed_data.py
-├── dev-setup.sh
-├── frontend/
-│   └── WavelengthWatch/
-│       ├── API_CONFIGURATION.md
-│       ├── WavelengthWatch Watch App/
-│       │   ├── App/
-│       │   │   └── AppConfiguration.swift
-│       │   ├── Assets.xcassets/
-│       │   │   ├── AccentColor.colorset
-│       │   │   ├── AppIcon.appiconset
-│       │   │   └── Contents.json
-│       │   ├── ContentView.swift
-│       │   ├── Models/
-│       │   │   └── CatalogModels.swift
-│       │   ├── PhaseNavigator.swift
-│       │   ├── Resources/
-│       │   │   └── APIConfiguration.plist
-│       │   ├── Services/
-│       │   │   ├── APIClient.swift
-│       │   │   ├── CatalogRepository.swift
-│       │   │   └── JournalClient.swift
-│       │   ├── ViewModels/
-│       │   │   └── ContentViewModel.swift
-│       │   └── WavelengthWatchApp.swift
-│       ├── WavelengthWatch Watch AppTests/
-│       │   └── WavelengthWatch_Watch_AppTests.swift
-│       ├── WavelengthWatch Watch AppUITests/
-│       │   ├── WavelengthWatch_Watch_AppUITests.swift
-│       │   └── WavelengthWatch_Watch_AppUITestsLaunchTests.swift
-│       ├── WavelengthWatch.xcodeproj/
-│       │   ├── project.pbxproj
-│       │   ├── project.xcworkspace/
-│       │   │   └── contents.xcworkspacedata
-│       │   └── xcuserdata/
-│       │       └── geoffgallinger.xcuserdatad/
-│       │           └── xcschemes/
-│       │               └── xcschememanagement.plist
-│       └── XCODE_PROJECT_UPDATES.md
-├── mypy.ini
-├── prompts/
-│   ├── add-headers.md
-│   ├── add-layers.md
-│   ├── ci-and-pre-commit-bootstrap.md
-│   ├── front-end-tracer-code.md
-│   └── journal_feature.md
-├── pyproject.toml
-├── pytest.ini
-├── ruff.toml
-├── scripts/
-│   └── convert_csv_to_json.sh
-└── tests/
-    └── backend/
-        ├── conftest.py
-        ├── test_app_config.py
-        ├── test_catalog_api.py
-        ├── test_curriculum_api.py
-        ├── test_journal_api.py
-        ├── test_layer_api.py
-        ├── test_phase_api.py
-        └── test_strategy_api.py
+├── backend/ — FastAPI + SQLModel service with routers, schemas, and CSV/JSON fixtures powering the curriculum and journal APIs.​
+│   ├── data/ — Source CSV/JSON catalogs bundled for backend seeding and the watch experience.
+│   ├── routers/ — Endpoint modules covering catalog, curriculum, journal, layer, phase, and strategy routes.
+│   └── tools/ — Utilities like CSV-to-JSON conversion and database seeding scripts used during setup and builds.
+├── frontend/ — watchOS SwiftUI project containing the main watch target, tests, and configuration docs for collaborators.
+│   └── WavelengthWatch Watch App/ — SwiftUI code organized into App, Assets, Models, Services, Resources, and ViewModels for the watch experience.
+├── tests/ — Pytest suite validating backend configuration and each API surface area.​
+├── prompts/ — Product and process prompts that capture planning notes for AI-assisted development.
+├── scripts/ — Automation helpers, including the CSV→JSON build script for bundling data with the app.​
+├── .github/workflows/ — Continuous integration workflows handling backend checks and automated reviews.
+├── README.md, XCODE_BUILD_SETUP.md — Contributor onboarding guide and Xcode build automation instructions.
+├── dev-setup.sh, pyproject.toml, mypy.ini, ruff.toml, pytest.ini — Repo-wide tooling bootstrap plus lint/type/test configuration defaults.
 ```
 
 ## Architecture Overview

--- a/README.md
+++ b/README.md
@@ -21,117 +21,20 @@ Use the detailed tree below to locate major components quickly when joining the 
 
 ```text
 WavelengthWatch/
-├── .github/
-│   └── workflows/
-│       ├── ci.yml
-│       ├── claude-code-review.yml
-│       └── claude.yml
-├── AGENTS.md
-├── CLAUDE.md
-├── README.md
-├── XCODE_BUILD_SETUP.md
-├── backend/
-│   ├── README.md
-│   ├── __init__.py
-│   ├── app.py
-│   ├── database.py
-│   ├── models.py
-│   ├── schemas.py
-│   ├── schemas_catalog.py
-│   ├── requirements-dev.txt
-│   ├── requirements.txt
-│   ├── data/
-│   │   ├── a-w-curriculum.csv
-│   │   ├── a-w-headers.csv
-│   │   ├── a-w-strategies.csv
-│   │   ├── curriculum.json
-│   │   ├── headers.json
-│   │   ├── strategies.json
-│   │   └── prod/
-│   │       ├── a-w-curriculum.json
-│   │       ├── a-w-headers.json
-│   │       └── a-w-strategies.json
-│   ├── routers/
-│   │   ├── __init__.py
-│   │   ├── catalog.py
-│   │   ├── curriculum.py
-│   │   ├── journal.py
-│   │   ├── layer.py
-│   │   ├── phase.py
-│   │   └── strategy.py
-│   ├── services/
-│   │   ├── __init__.py
-│   │   └── catalog.py
-│   └── tools/
-│       ├── csv_to_json.py
-│       ├── data/
-│       │   ├── curriculum.csv
-│       │   ├── journal.csv
-│       │   ├── layer.csv
-│       │   ├── phase.csv
-│       │   └── strategy.csv
-│       └── seed_data.py
-├── dev-setup.sh
-├── frontend/
-│   └── WavelengthWatch/
-│       ├── API_CONFIGURATION.md
-│       ├── WavelengthWatch Watch App/
-│       │   ├── App/
-│       │   │   └── AppConfiguration.swift
-│       │   ├── Assets.xcassets/
-│       │   │   ├── AccentColor.colorset
-│       │   │   ├── AppIcon.appiconset
-│       │   │   └── Contents.json
-│       │   ├── ContentView.swift
-│       │   ├── Models/
-│       │   │   └── CatalogModels.swift
-│       │   ├── PhaseNavigator.swift
-│       │   ├── Resources/
-│       │   │   └── APIConfiguration.plist
-│       │   ├── Services/
-│       │   │   ├── APIClient.swift
-│       │   │   ├── CatalogRepository.swift
-│       │   │   └── JournalClient.swift
-│       │   ├── ViewModels/
-│       │   │   └── ContentViewModel.swift
-│       │   └── WavelengthWatchApp.swift
-│       ├── WavelengthWatch Watch AppTests/
-│       │   └── WavelengthWatch_Watch_AppTests.swift
-│       ├── WavelengthWatch Watch AppUITests/
-│       │   ├── WavelengthWatch_Watch_AppUITests.swift
-│       │   └── WavelengthWatch_Watch_AppUITestsLaunchTests.swift
-│       ├── WavelengthWatch.xcodeproj/
-│       │   ├── project.pbxproj
-│       │   ├── project.xcworkspace/
-│       │   │   └── contents.xcworkspacedata
-│       │   └── xcuserdata/
-│       │       └── geoffgallinger.xcuserdatad/
-│       │           └── xcschemes/
-│       │               └── xcschememanagement.plist
-│       └── XCODE_PROJECT_UPDATES.md
-├── mypy.ini
-├── prompts/
-│   ├── add-headers.md
-│   ├── add-layers.md
-│   ├── ci-and-pre-commit-bootstrap.md
-│   ├── front-end-tracer-code.md
-│   └── journal_feature.md
-├── pyproject.toml
-├── pytest.ini
-├── ruff.toml
-├── scripts/
-│   └── convert_csv_to_json.sh
-└── tests/
-    └── backend/
-        ├── conftest.py
-        ├── test_app_config.py
-        ├── test_catalog_api.py
-        ├── test_curriculum_api.py
-        ├── test_journal_api.py
-        ├── test_layer_api.py
-        ├── test_phase_api.py
-        └── test_strategy_api.py
+├── backend/ — FastAPI + SQLModel service with routers, schemas, and CSV/JSON fixtures powering the curriculum and journal APIs.​
+│   ├── data/ — Source CSV/JSON catalogs bundled for backend seeding and the watch experience.
+│   ├── routers/ — Endpoint modules covering catalog, curriculum, journal, layer, phase, and strategy routes.
+│   └── tools/ — Utilities like CSV-to-JSON conversion and database seeding scripts used during setup and builds.
+├── frontend/ — watchOS SwiftUI project containing the main watch target, tests, and configuration docs for collaborators.
+│   └── WavelengthWatch Watch App/ — SwiftUI code organized into App, Assets, Models, Services, Resources, and ViewModels for the watch experience.
+├── tests/ — Pytest suite validating backend configuration and each API surface area.​
+├── prompts/ — Product and process prompts that capture planning notes for AI-assisted development.
+├── scripts/ — Automation helpers, including the CSV→JSON build script for bundling data with the app.​
+├── .github/workflows/ — Continuous integration workflows handling backend checks and automated reviews.
+├── README.md, XCODE_BUILD_SETUP.md — Contributor onboarding guide and Xcode build automation instructions.
+├── dev-setup.sh, pyproject.toml, mypy.ini, ruff.toml, pytest.ini — Repo-wide tooling bootstrap plus lint/type/test configuration defaults.
 ```
+
 ## Configuring the Watch API Base URL
 
 The watch app resolves its networking configuration from `Resources/APIConfiguration.plist` inside the watch target. The plist contains an `API_BASE_URL` key that defaults to `https://api.not-configured.local`, a sentinel host that intentionally fails if you try to talk to it.

--- a/README.md
+++ b/README.md
@@ -16,26 +16,121 @@ _Status_: The project has not yet been deployed to production. An eventual App S
   - Pre-commit hooks enforce linting and formatting for both Swift (via Mint, SwiftLint, SwiftFormat) and Python (via Mypy, Ruff, etc. in the backend).
 
 ## Repository Structure
-```aiignore
+
+Use the detailed tree below to locate major components quickly when joining the project or pairing with an agent:
+
+```text
 WavelengthWatch/
-├── frontend/ # watchOS SwiftUI app
-│ └── WavelengthWatch/ # Xcode project + assets
-│
-├── backend/ # FastAPI service
-│ ├── app.py # FastAPI entrypoint
-│ ├── data/
-│ │ ├── curriculum.json # stage/phase + medicinal/toxic
-│ │ ├── strategies.json # self-care strategies
-│ │ └── images/ # optional static images
-│ └── requirements.txt
-│
-├── tests/ # shared test root
-│ ├── backend/ # pytest for FastAPI
-│ └── frontend/ # Swift XCTest / Swift Testing (lives in Xcode)
-│
-├── .github/workflows/ci.yml # CI pipeline
-├── .pre-commit-config.yaml # pre-commit hooks
-└── AGENTS.md # Guardrails for AI Agents in pair programming
+├── .github/
+│   └── workflows/
+│       ├── ci.yml
+│       ├── claude-code-review.yml
+│       └── claude.yml
+├── AGENTS.md
+├── CLAUDE.md
+├── README.md
+├── XCODE_BUILD_SETUP.md
+├── backend/
+│   ├── README.md
+│   ├── __init__.py
+│   ├── app.py
+│   ├── database.py
+│   ├── models.py
+│   ├── schemas.py
+│   ├── schemas_catalog.py
+│   ├── requirements-dev.txt
+│   ├── requirements.txt
+│   ├── data/
+│   │   ├── a-w-curriculum.csv
+│   │   ├── a-w-headers.csv
+│   │   ├── a-w-strategies.csv
+│   │   ├── curriculum.json
+│   │   ├── headers.json
+│   │   ├── strategies.json
+│   │   └── prod/
+│   │       ├── a-w-curriculum.json
+│   │       ├── a-w-headers.json
+│   │       └── a-w-strategies.json
+│   ├── routers/
+│   │   ├── __init__.py
+│   │   ├── catalog.py
+│   │   ├── curriculum.py
+│   │   ├── journal.py
+│   │   ├── layer.py
+│   │   ├── phase.py
+│   │   └── strategy.py
+│   ├── services/
+│   │   ├── __init__.py
+│   │   └── catalog.py
+│   └── tools/
+│       ├── csv_to_json.py
+│       ├── data/
+│       │   ├── curriculum.csv
+│       │   ├── journal.csv
+│       │   ├── layer.csv
+│       │   ├── phase.csv
+│       │   └── strategy.csv
+│       └── seed_data.py
+├── dev-setup.sh
+├── frontend/
+│   └── WavelengthWatch/
+│       ├── API_CONFIGURATION.md
+│       ├── WavelengthWatch Watch App/
+│       │   ├── App/
+│       │   │   └── AppConfiguration.swift
+│       │   ├── Assets.xcassets/
+│       │   │   ├── AccentColor.colorset
+│       │   │   ├── AppIcon.appiconset
+│       │   │   └── Contents.json
+│       │   ├── ContentView.swift
+│       │   ├── Models/
+│       │   │   └── CatalogModels.swift
+│       │   ├── PhaseNavigator.swift
+│       │   ├── Resources/
+│       │   │   └── APIConfiguration.plist
+│       │   ├── Services/
+│       │   │   ├── APIClient.swift
+│       │   │   ├── CatalogRepository.swift
+│       │   │   └── JournalClient.swift
+│       │   ├── ViewModels/
+│       │   │   └── ContentViewModel.swift
+│       │   └── WavelengthWatchApp.swift
+│       ├── WavelengthWatch Watch AppTests/
+│       │   └── WavelengthWatch_Watch_AppTests.swift
+│       ├── WavelengthWatch Watch AppUITests/
+│       │   ├── WavelengthWatch_Watch_AppUITests.swift
+│       │   └── WavelengthWatch_Watch_AppUITestsLaunchTests.swift
+│       ├── WavelengthWatch.xcodeproj/
+│       │   ├── project.pbxproj
+│       │   ├── project.xcworkspace/
+│       │   │   └── contents.xcworkspacedata
+│       │   └── xcuserdata/
+│       │       └── geoffgallinger.xcuserdatad/
+│       │           └── xcschemes/
+│       │               └── xcschememanagement.plist
+│       └── XCODE_PROJECT_UPDATES.md
+├── mypy.ini
+├── prompts/
+│   ├── add-headers.md
+│   ├── add-layers.md
+│   ├── ci-and-pre-commit-bootstrap.md
+│   ├── front-end-tracer-code.md
+│   └── journal_feature.md
+├── pyproject.toml
+├── pytest.ini
+├── ruff.toml
+├── scripts/
+│   └── convert_csv_to_json.sh
+└── tests/
+    └── backend/
+        ├── conftest.py
+        ├── test_app_config.py
+        ├── test_catalog_api.py
+        ├── test_curriculum_api.py
+        ├── test_journal_api.py
+        ├── test_layer_api.py
+        ├── test_phase_api.py
+        └── test_strategy_api.py
 ```
 ## Configuring the Watch API Base URL
 


### PR DESCRIPTION
## Summary
- add a detailed repository directory tree to AGENTS.md, CLAUDE.md, and README.md
- provide brief context before the tree so collaborators understand its intent

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdbd1d01648322acce716a201315f8