### PR TITLE
Fix PhaseNavigator adjusted selection returns

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/PhaseNavigator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/PhaseNavigator.swift
@@ -18,11 +18,11 @@ enum PhaseNavigator {
   /// - Returns: A selection in the range `1...phaseCount`.
   static func adjustedSelection(_ selection: Int, phaseCount: Int) -> Int {
     if selection == 0 {
-      phaseCount
+      return phaseCount
     } else if selection == phaseCount + 1 {
-      1
+      return 1
     } else {
-      selection
+      return selection
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure PhaseNavigator.adjustedSelection always returns a value in every branch so the watch target builds on CI

## Testing
- not run (Xcode is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d01452345c8322bcdcf7aa668c9fa6