### PR TITLE
perf: Reduce UI indicator delays from 3s/2s to 1s

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -389,7 +389,7 @@ struct ContentView: View {
   private func scheduleLayerIndicatorHide() {
     hideIndicatorTask?.cancel()
     hideIndicatorTask = Task {
-      try? await Task.sleep(nanoseconds: 3_000_000_000)
+      try? await Task.sleep(nanoseconds: 1_000_000_000)
       guard !Task.isCancelled else { return }
       await MainActor.run {
         withAnimation(.easeOut(duration: 0.3)) {
@@ -520,7 +520,7 @@ struct LayerView: View {
     }
     hideIndicatorTask?.cancel()
     hideIndicatorTask = Task {
-      try? await Task.sleep(nanoseconds: 2_000_000_000)
+      try? await Task.sleep(nanoseconds: 1_000_000_000)
       guard !Task.isCancelled else { return }
       await MainActor.run {
         withAnimation(.easeOut(duration: 0.3)) {


### PR DESCRIPTION
## Summary
- Reduced layer indicator auto-hide delay from 3 seconds to 1 second
- Reduced page indicator auto-hide delay from 2 seconds to 1 second
- Improves perceived UI responsiveness and reduces potential test overhead

## Changes
- `ContentView.swift:392` - Layer indicator delay: 3s → 1s
- `ContentView.swift:523` - Page indicator delay: 2s → 1s

## Impact
- Better user experience with faster indicator hiding
- Total delay reduction of 4 seconds per navigation cycle
- Minimal code change (2 lines)

## Test Plan
- [x] All 12/12 test suites passing
- [x] Pre-commit hooks passing
- [x] SwiftFormat validation passing
- [x] Manual testing recommended for UI feel

## Resolves
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)