### PR TITLE
perf: Add timeout configuration to URLSession

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/APIClient.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/APIClient.swift
@@ -28,7 +28,9 @@ final class APIClient: APIClientProtocol {
       self.session = session
     } else {
       let configuration = URLSessionConfiguration.ephemeral
-      configuration.waitsForConnectivity = true
+      configuration.waitsForConnectivity = false
+      configuration.timeoutIntervalForRequest = 10.0
+      configuration.timeoutIntervalForResource = 30.0
       self.session = URLSession(configuration: configuration)
     }
     self.decoder = decoder


### PR DESCRIPTION
## Summary
- Set `waitsForConnectivity = false` to prevent indefinite hangs
- Add 10 second request timeout (`timeoutIntervalForRequest`)
- Add 30 second resource timeout (`timeoutIntervalForResource`)
- Improves test performance and production UX on flaky networks

## Problem
Previously, APIClient used `waitsForConnectivity = true` without any timeout configuration, causing:
- Tests to wait 60+ seconds for network timeouts
- App to hang indefinitely waiting for connectivity
- Poor user experience on flaky networks

## Changes
`APIClient.swift:31-33`
- Changed `waitsForConnectivity` from `true` to `false`
- Added `timeoutIntervalForRequest = 10.0` (10 seconds per request)
- Added `timeoutIntervalForResource = 30.0` (30 seconds total for entire resource)

## Impact
- **Tests**: Failures now timeout in 10s instead of 60+ seconds
- **Production**: App fails fast instead of hanging indefinitely
- **UX**: Better responsiveness on poor connectivity

## Test Plan
- [x] All 12/12 test suites passing
- [x] Pre-commit hooks passing
- [x] SwiftFormat validation passing
- [ ] Manual testing recommended for network timeout behavior

## Resolves
Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)