### PR TITLE
feat(models): Add LayerFilterMode enum for flow navigation filtering

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/LayerFilterMode.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/LayerFilterMode.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Defines filtering modes for layer visibility in the emotion logging flow.
+///
+/// The app displays layers in three distinct contexts:
+/// - **Browse mode**: All layers (0-10) are visible for free exploration
+/// - **Emotion selection**: Only emotion layers (1-10) visible, strategies layer hidden
+/// - **Strategy selection**: Only strategies layer (0) visible, emotion layers hidden
+enum LayerFilterMode: Equatable {
+  /// Browse mode - shows all layers (0-10)
+  case all
+
+  /// Emotion selection mode - shows only emotion layers (1-10), hides strategies (layer 0)
+  case emotionsOnly
+
+  /// Strategy selection mode - shows only strategies layer (0), hides emotion layers (1-10)
+  case strategiesOnly
+
+  /// Filters a collection of layers based on the current mode.
+  ///
+  /// - Parameter layers: The full collection of catalog layers to filter
+  /// - Returns: A filtered array containing only layers matching this mode's criteria
+  func filter(_ layers: [CatalogLayerModel]) -> [CatalogLayerModel] {
+    switch self {
+    case .all:
+      layers
+    case .emotionsOnly:
+      layers.filter { $0.id >= 1 }
+    case .strategiesOnly:
+      layers.filter { $0.id == 0 }
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LayerFilterModeTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LayerFilterModeTests.swift
@@ -1,0 +1,118 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+@Suite("LayerFilterMode Tests")
+struct LayerFilterModeTests {
+  // MARK: - Test Data
+
+  private func makeMockLayers() -> [CatalogLayerModel] {
+    [
+      CatalogLayerModel(
+        id: 0,
+        color: "Strategies",
+        title: "Self-Care",
+        subtitle: "Strategies",
+        phases: []
+      ),
+      CatalogLayerModel(
+        id: 1,
+        color: "Beige",
+        title: "Beige",
+        subtitle: "Survival",
+        phases: []
+      ),
+      CatalogLayerModel(
+        id: 2,
+        color: "Purple",
+        title: "Purple",
+        subtitle: "Tribal",
+        phases: []
+      ),
+      CatalogLayerModel(
+        id: 3,
+        color: "Red",
+        title: "Red",
+        subtitle: "Power",
+        phases: []
+      ),
+    ]
+  }
+
+  // MARK: - Filter All Tests
+
+  @Test("filter all returns all layers")
+  func filterAll_returnsAllLayers() {
+    let layers = makeMockLayers()
+    let filtered = LayerFilterMode.all.filter(layers)
+
+    #expect(filtered.count == 4)
+    #expect(filtered[0].id == 0)
+    #expect(filtered[1].id == 1)
+    #expect(filtered[2].id == 2)
+    #expect(filtered[3].id == 3)
+  }
+
+  // MARK: - Emotions Only Tests
+
+  @Test("filter emotionsOnly excludes layer zero")
+  func filterEmotionsOnly_excludesLayerZero() {
+    let layers = makeMockLayers()
+    let filtered = LayerFilterMode.emotionsOnly.filter(layers)
+
+    #expect(!filtered.contains { $0.id == 0 })
+  }
+
+  @Test("filter emotionsOnly includes layers one to ten")
+  func filterEmotionsOnly_includesLayersOneToTen() {
+    let layers = makeMockLayers()
+    let filtered = LayerFilterMode.emotionsOnly.filter(layers)
+
+    #expect(filtered.count == 3)
+    #expect(filtered[0].id == 1)
+    #expect(filtered[1].id == 2)
+    #expect(filtered[2].id == 3)
+  }
+
+  @Test("filter emotionsOnly with empty array returns empty")
+  func filterEmotionsOnly_withEmptyArray_returnsEmpty() {
+    let layers: [CatalogLayerModel] = []
+    let filtered = LayerFilterMode.emotionsOnly.filter(layers)
+
+    #expect(filtered.isEmpty)
+  }
+
+  // MARK: - Strategies Only Tests
+
+  @Test("filter strategiesOnly includes only layer zero")
+  func filterStrategiesOnly_includesOnlyLayerZero() {
+    let layers = makeMockLayers()
+    let filtered = LayerFilterMode.strategiesOnly.filter(layers)
+
+    #expect(filtered.count == 1)
+    #expect(filtered[0].id == 0)
+  }
+
+  @Test("filter strategiesOnly excludes other layers")
+  func filterStrategiesOnly_excludesOtherLayers() {
+    let layers = makeMockLayers()
+    let filtered = LayerFilterMode.strategiesOnly.filter(layers)
+
+    #expect(!filtered.contains { $0.id > 0 })
+  }
+
+  // MARK: - Equatable Tests
+
+  @Test("equatable same modes are equal")
+  func equatable_sameModesAreEqual() {
+    #expect(LayerFilterMode.all == LayerFilterMode.all)
+    #expect(LayerFilterMode.emotionsOnly == LayerFilterMode.emotionsOnly)
+    #expect(LayerFilterMode.strategiesOnly == LayerFilterMode.strategiesOnly)
+  }
+
+  @Test("equatable different modes are not equal")
+  func equatable_differentModesAreNotEqual() {
+    #expect(LayerFilterMode.all != LayerFilterMode.emotionsOnly)
+    #expect(LayerFilterMode.emotionsOnly != LayerFilterMode.strategiesOnly)
+    #expect(LayerFilterMode.strategiesOnly != LayerFilterMode.all)
+  }
+}


### PR DESCRIPTION
## Summary
Implements **Phase 0.1** of the emotion logging flow by creating the foundational `LayerFilterMode` enum that enables dynamic layer filtering across three view modes.

## Changes
- ✅ Created `LayerFilterMode` enum with three modes:
  - `.all` - Browse mode (layers 0-10)
  - `.emotionsOnly` - Emotion selection (layers 1-10 only)
  - `.strategiesOnly` - Strategy selection (layer 0 only)
- ✅ Implemented `filter()` method for filtering `CatalogLayerModel` arrays
- ✅ Comprehensive test suite with 8 tests (all passing)
- ✅ Full documentation with examples

## Test Coverage
```
LayerFilterModeTests: 8/8 passed
- filter all returns all layers
- filter emotionsOnly excludes layer zero
- filter emotionsOnly includes layers one to ten
- filter emotionsOnly with empty array returns empty
- filter strategiesOnly includes only layer zero
- filter strategiesOnly excludes other layers
- equatable same modes are equal
- equatable different modes are not equal
```

## Acceptance Criteria
- [x] Enum exists with three cases
- [x] filter() method correctly filters layers for each mode
- [x] All tests pass
- [x] Code is formatted with SwiftFormat

## Next Steps
This enables **Phase 0.2** (#73) where we'll add `layerFilterMode` and `filteredLayers` to `ContentViewModel`.

## References
- **Issue**: Closes #72
- **Epic**: #92 - Multi-Step Emotion Logging Flow
- **Spec**: `prompts/claude-comm/2025-11-19-emotion-logging-flow-spec.md` (FR-0)
- **Plan**: `prompts/claude-comm/plans/2025-11-19-emotion-logging-flow-implementation-plan.md` (Task 0.1)

**Lines Changed**: 151 additions (2 files)
**Effort**: 2 hours