### PR TITLE
feat(viewmodel): Add layer filtering support to ContentViewModel

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
@@ -9,9 +9,20 @@ final class ContentViewModel: ObservableObject {
   @Published var selectedLayerIndex: Int
   @Published var selectedPhaseIndex: Int
   @Published var currentInitiatedBy: InitiatedBy = .self_initiated
+  @Published var layerFilterMode: LayerFilterMode = .all
 
   private let repository: CatalogRepositoryProtocol
   private let journalClient: JournalClientProtocol
+
+  /// Returns layers filtered according to the current filter mode.
+  ///
+  /// The filtered layers change based on `layerFilterMode`:
+  /// - `.all`: All layers (0-10) for normal browsing
+  /// - `.emotionsOnly`: Only emotion layers (1-10), excluding strategies
+  /// - `.strategiesOnly`: Only strategies layer (0)
+  var filteredLayers: [CatalogLayerModel] {
+    layerFilterMode.filter(layers)
+  }
 
   struct JournalFeedback: Identifiable, Equatable {
     enum Kind: Equatable {


### PR DESCRIPTION
## Summary
Add layer filtering infrastructure to ContentViewModel to support three distinct view modes (.all, .emotionsOnly, .strategiesOnly) required for the emotion logging flow.

## Changes
- Add `layerFilterMode` property (defaults to `.all`)
- Add `filteredLayers` computed property using `LayerFilterMode.filter()`
- Update SampleData to include all 11 layers (0-10) matching production spiral dynamics model
- Add 5 comprehensive tests for filtering functionality

## Tests
- ✅ `filteredLayersDefaultsToAll`: Verifies default `.all` mode
- ✅ `filteredLayersWithEmotionsOnlyExcludesLayerZero`: Verifies emotions filtering
- ✅ `filteredLayersWithStrategiesOnlyIncludesOnlyLayerZero`: Verifies strategies filtering
- ✅ `filteredLayersReactsToModeChange`: Verifies dynamic filtering (11→10→1 layers)
- ✅ `filteredLayersWhenLayersEmptyReturnsEmpty`: Edge case handling

All 12 test suites passing (20/20 tests).

## Dependencies
- ✅ Builds on #93 (LayerFilterMode enum)
- 🔜 Unblocks #74 (ContentView integration)

**Closes #73**

🤖 Generated with [Claude Code](https://claude.com/claude-code)