### PR TITLE
feat(view): Update ContentView to use filteredLayers for navigation

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -106,14 +106,25 @@ struct ContentView: View {
           adjustPhaseSelection()
         }
         .onChange(of: layerSelection) { _, newValue in
-          viewModel.selectedLayerIndex = newValue
-          storedLayerIndex = newValue
+          // Convert filtered index to layer ID
+          if let layerId = viewModel.filteredIndexToLayerId(newValue) {
+            viewModel.selectedLayerId = layerId
+            // Convert layer ID to full array index
+            if let fullIndex = viewModel.layerIdToIndex(layerId) {
+              viewModel.selectedLayerIndex = fullIndex
+              storedLayerIndex = fullIndex
+            }
+          }
           showLayerIndicator = true
           scheduleLayerIndicatorHide()
         }
-        .onChange(of: viewModel.selectedLayerIndex) { _, newValue in
-          if layerSelection != newValue {
-            layerSelection = newValue
+        .onChange(of: viewModel.selectedLayerId) { _, newLayerId in
+          // When selectedLayerId changes, update layerSelection to match in filtered array
+          guard let layerId = newLayerId else { return }
+          if let filteredIndex = viewModel.layerIdToFilteredIndex(layerId) {
+            if layerSelection != filteredIndex {
+              layerSelection = filteredIndex
+            }
           }
         }
         .onChange(of: phaseSelection) { _, newValue in

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewFilteringTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewFilteringTests.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+import Testing
+
+@testable import WavelengthWatch_Watch_App
+
+/// Tests for ContentView navigation with filtered layers.
+///
+/// These tests verify that layer selection remains correct when switching
+/// between filter modes, and that indices are properly synchronized between
+/// the filtered and unfiltered layer arrays.
+@MainActor
+struct ContentViewFilteringTests {
+  private func createTestCatalog() -> CatalogResponseModel {
+    let phase = CatalogPhaseModel(
+      id: 1,
+      name: "Rising",
+      medicinal: [],
+      toxic: [],
+      strategies: []
+    )
+
+    // Create all 11 layers (0-10) matching production
+    let layers = [
+      CatalogLayerModel(id: 0, color: "Strategies", title: "SELF-CARE", subtitle: "(Strategies)", phases: [phase]),
+      CatalogLayerModel(id: 1, color: "Beige", title: "BEIGE", subtitle: "(Survival)", phases: [phase]),
+      CatalogLayerModel(id: 2, color: "Purple", title: "PURPLE", subtitle: "(Tribal)", phases: [phase]),
+      CatalogLayerModel(id: 3, color: "Red", title: "RED", subtitle: "(Power)", phases: [phase]),
+      CatalogLayerModel(id: 4, color: "Blue", title: "BLUE", subtitle: "(Order)", phases: [phase]),
+      CatalogLayerModel(id: 5, color: "Orange", title: "ORANGE", subtitle: "(Achievement)", phases: [phase]),
+      CatalogLayerModel(id: 6, color: "Green", title: "GREEN", subtitle: "(Community)", phases: [phase]),
+      CatalogLayerModel(id: 7, color: "Yellow", title: "YELLOW", subtitle: "(Integral)", phases: [phase]),
+      CatalogLayerModel(id: 8, color: "Turquoise", title: "TURQUOISE", subtitle: "(Holistic)", phases: [phase]),
+      CatalogLayerModel(id: 9, color: "Coral", title: "CORAL", subtitle: "(Transpersonal)", phases: [phase]),
+      CatalogLayerModel(id: 10, color: "Teal", title: "TEAL", subtitle: "(Unitive)", phases: [phase]),
+    ]
+
+    return CatalogResponseModel(phaseOrder: ["Rising"], layers: layers)
+  }
+
+  @Test func switchingFromAllToEmotionsOnlyPreservesLayerIdentity() async {
+    let catalog = createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(repository: repository, journalClient: journal)
+
+    await viewModel.loadCatalog()
+
+    // Layers are reversed in ContentViewModel, so layers = [10,9,8,7,6,5,4,3,2,1,0]
+    // User is viewing layer 5 (Orange) in browse mode at index 5
+    viewModel.selectedLayerIndex = 5
+    #expect(viewModel.layers[5].id == 5)
+    #expect(viewModel.layers[5].title == "ORANGE")
+
+    // Switch to emotions-only mode
+    viewModel.layerFilterMode = .emotionsOnly
+
+    // Expected: selectedLayerId should still be 5 (Orange)
+    #expect(viewModel.selectedLayerId == 5)
+
+    // Filtered layers (emotions-only, reversed): [10,9,8,7,6,5,4,3,2,1]
+    // Orange (id=5) should be at filtered index 5
+    let expectedFilteredIndex = viewModel.layerIdToFilteredIndex(5)
+    #expect(expectedFilteredIndex == 5)
+    #expect(viewModel.filteredLayers[5].id == 5)
+    #expect(viewModel.filteredLayers[5].title == "ORANGE")
+  }
+
+  @Test func switchingFromEmotionsOnlyToAllPreservesLayerIdentity() async {
+    let catalog = createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(repository: repository, journalClient: journal)
+
+    await viewModel.loadCatalog()
+
+    // Start in emotions-only mode
+    viewModel.layerFilterMode = .emotionsOnly
+
+    // Filtered layers (emotions-only, reversed): [10,9,8,7,6,5,4,3,2,1]
+    // User is viewing filtered index 5 (which is Orange, layer id=5)
+    #expect(viewModel.filteredLayers[5].id == 5)
+    #expect(viewModel.filteredLayers[5].title == "ORANGE")
+
+    // Set selectedLayerId to track by ID
+    viewModel.selectedLayerIndex = 5 // Orange in full array (reversed: [10,9,8,7,6,5,...])
+
+    // Switch back to .all mode
+    viewModel.layerFilterMode = .all
+
+    // Expected: selectedLayerId should still be 5 (Orange)
+    #expect(viewModel.selectedLayerId == 5)
+    #expect(viewModel.layers[5].id == 5)
+    #expect(viewModel.layers[5].title == "ORANGE")
+  }
+
+  @Test func switchingFromEmotionsOnlyToStrategiesOnlyClampsSelection() async {
+    let catalog = createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(repository: repository, journalClient: journal)
+
+    await viewModel.loadCatalog()
+
+    // Start in emotions-only mode, viewing Red (filtered index 2, id=3)
+    viewModel.layerFilterMode = .emotionsOnly
+    viewModel.selectedLayerId = 3 // Red
+    viewModel.selectedLayerIndex = 3 // Red in full array
+
+    // Switch to strategies-only mode (only layer 0)
+    viewModel.layerFilterMode = .strategiesOnly
+
+    // Red (id=3) is not in strategies-only, so selection should clamp to layer 0
+    #expect(viewModel.filteredLayers.count == 1)
+    #expect(viewModel.selectedLayerId == 0) // Clamped to strategies
+    #expect(viewModel.filteredLayers[0].id == 0)
+  }
+
+  @Test func filterModeChangeDoesNotCrashWithOutOfBoundsIndex() async {
+    let catalog = createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(repository: repository, journalClient: journal)
+
+    await viewModel.loadCatalog()
+
+    // Set to last layer in .all mode (Teal, id=10)
+    viewModel.selectedLayerIndex = 10
+    viewModel.selectedLayerId = 10
+    #expect(viewModel.layers.count == 11)
+
+    // Switch to strategies-only (only 1 layer)
+    viewModel.layerFilterMode = .strategiesOnly
+    #expect(viewModel.filteredLayers.count == 1)
+
+    // Teal (id=10) is not in strategies, so it should clamp to layer 0
+    #expect(viewModel.selectedLayerId == 0)
+    #expect(viewModel.filteredLayers[0].id == 0)
+  }
+}


### PR DESCRIPTION
## Summary
Complete Phase 0 by updating ContentView to use `filteredLayers` instead of `layers` for all navigation logic. This enables the layer filtering architecture that will be used by the emotion logging flow.

## Changes
- **Navigation ForEach**: Use `viewModel.filteredLayers` to render visible layers
- **Digital crown**: Clamp rotation to `filteredLayers.count` range
- **Layer indicator**: Show pills only for filtered layers
- **Swipe gestures**: Bound navigation to `filteredLayers.count`
- **Cleanup**: Remove unused `layerIndicator()` and `offset()` functions
- **StrategyListView**: Correctly keeps `viewModel.layers` for fallback curriculum search (searches all layers, not just visible ones)

## How It Works
ContentView now respects `ContentViewModel.layerFilterMode`:

| Mode | Visible Layers | Use Case |
|------|---------------|----------|
| `.all` | 0-10 (all) | Browse mode (default) |
| `.emotionsOnly` | 1-10 (emotions) | Emotion selection in flow |
| `.strategiesOnly` | 0 (strategies) | Strategy selection in flow |

Navigation automatically adapts:
- Digital crown range adjusts to filtered count
- Layer indicator shows only visible layers
- Swipe bounds respect filtered array size

## Testing
All 12 test suites passing (25/25 tests):
- Existing tests verify backward compatibility (default `.all` mode)
- ContentViewModel filtering tests verify mode switching
- No visual regressions in browse mode

## Dependencies
- ✅ Builds on #72 (LayerFilterMode enum)
- ✅ Builds on #95 (ContentViewModel filtering)

## Unblocks
- ✅ Phase 1 (Flow Foundation) - Can now begin implementing JournalFlowViewModel

**Closes #74** | **Completes Phase 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)