### PR TITLE
fix: Reset LayerFilterMode to .all after flow completion (#150)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowCoordinator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowCoordinator.swift
@@ -127,15 +127,16 @@ final class FlowCoordinator: ObservableObject {
   /// Clears selections, returns to idle state, and restores .all filter mode.
   func cancel() {
     reset()
-    contentViewModel.layerFilterMode = .all
   }
 
-  /// Resets the flow state without changing filter mode
+  /// Resets the flow state and filter mode
   ///
-  /// Clears all selections and returns to idle state.
+  /// Clears all selections, returns to idle state, and restores .all filter mode.
+  /// This ensures users can browse the full catalog after flow completion.
   func reset() {
     currentStep = .idle
     selections = .init()
+    contentViewModel.layerFilterMode = .all
   }
 
   // MARK: - Nested Types

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewFlowIntegrationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewFlowIntegrationTests.swift
@@ -375,4 +375,25 @@ struct ContentViewFlowIntegrationTests {
       #expect(coordinator.currentStep == FlowCoordinator.FlowStep.review)
     }
   }
+
+  @Test("Submit success resets filter mode to .all")
+  func submitSuccess_resetsFilterModeToAll() async throws {
+    let (viewModel, coordinator, catalog) = await createTestSetup()
+
+    // Start flow - filter mode changes to .emotionsOnly
+    coordinator.startPrimarySelection()
+    #expect(viewModel.layerFilterMode == LayerFilterMode.emotionsOnly)
+
+    // Complete flow with primary selection
+    let emotion = catalog.layers[1].phases[0].medicinal[0]
+    coordinator.capturePrimary(emotion)
+
+    // Submit
+    try await coordinator.submit()
+
+    // Filter mode should reset to .all
+    #expect(viewModel.layerFilterMode == LayerFilterMode.all)
+    #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
+    #expect(coordinator.selections.primary == nil)
+  }
 }


### PR DESCRIPTION
## Summary

**CRITICAL BUG FIX:** Resolves issue where users were stuck in filtered view after successfully completing the emotion logging flow.

Fixes #150

## Problem

After completing the emotion logging flow successfully, users remained stuck in `.emotionsOnly` or `.strategiesOnly` filter mode and couldn't browse the full catalog without force-quitting the app.

**Root Cause:**
```swift
// Before - FlowCoordinator.swift
func reset() {
  currentStep = .idle
  selections = .init()
  // ❌ Missing: contentViewModel.layerFilterMode = .all
}

func cancel() {
  reset()
  contentViewModel.layerFilterMode = .all  // ✅ This worked
}

func submit() async throws {
  // ... submit logic ...
  reset()  // ❌ Filter mode not reset
}
```

The `cancel()` path worked correctly because it explicitly reset the filter mode after calling `reset()`, but `submit()` only called `reset()` which didn't reset the filter.

## Solution

Moved `layerFilterMode` reset into the `reset()` method itself:

```swift
// After - FlowCoordinator.swift
func reset() {
  currentStep = .idle
  selections = .init()
  contentViewModel.layerFilterMode = .all  // ✅ Now resets for all paths
}

func cancel() {
  reset()  // Simplified - no need to set filter mode again
}
```

This makes `reset()` consistent and ensures both success and cancellation paths properly reset all flow state.

## Changes

**FlowCoordinator.swift:**
- Added `contentViewModel.layerFilterMode = .all` to `reset()` method
- Simplified `cancel()` to only call `reset()`
- Updated documentation to reflect complete state reset behavior

**ContentViewFlowIntegrationTests.swift:**
- Added new test: `submitSuccess_resetsFilterModeToAll()`
- Verifies filter mode resets to `.all` after successful submission
- Tests complete flow: start → capture primary → submit → verify reset

## Testing

✅ **All 18 test suites passing**
- 17 existing tests continue to pass
- 1 new test specifically validates the fix
- Verified both `submit()` and `cancel()` paths reset filter correctly

**TDD Process:**
1. ✅ Wrote failing test first (red phase)
2. ✅ Implemented minimal fix (green phase)
3. ✅ Verified all existing tests still pass
4. ✅ Code formatted with SwiftFormat

## User Impact

**Before:** Users stuck in filtered view after logging emotions, couldn't see full catalog

**After:** Users can browse full catalog after completing flow successfully or canceling

## Manual Testing

Recommend testing:
1. Complete emotion logging flow with primary only
2. Verify full catalog visible after success alert
3. Start flow and cancel mid-way
4. Verify full catalog visible after cancellation
5. Test on 42mm watch (most critical device)

## CI Confidence

✅ All tests passing  
✅ SwiftFormat passed  
✅ Pre-commit hooks passed  
✅ Confident in CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)