### PR TITLE
fix: Add responsive scaling for 42mm Apple Watch (#125)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -4,6 +4,24 @@ import SwiftUI
 
 private enum UIConstants {
   static let menuButtonSize: CGFloat = 20
+
+  // Reference screen width for scaling (Apple Watch Series 9 45mm = 198pt)
+  static let referenceScreenWidth: CGFloat = 198
+
+  // Calculate scale factor based on actual screen width
+  static func scaleFactor(for width: CGFloat) -> CGFloat {
+    width / referenceScreenWidth
+  }
+
+  // Phase card dimensions (at reference size)
+  static let phaseOrbSize: CGFloat = 160
+  static let phaseAccentOuterWidth: CGFloat = 60
+  static let phaseAccentOuterHeight: CGFloat = 3
+  static let phaseAccentInnerWidth: CGFloat = 50
+  static let phaseAccentInnerHeight: CGFloat = 2
+
+  // Analytics view dimensions
+  static let analyticsIconSize: CGFloat = 48
 }
 
 // Environment key for tracking detail view visibility
@@ -557,6 +575,8 @@ struct PhasePageView: View {
 
   var body: some View {
     GeometryReader { geometry in
+      let scale = UIConstants.scaleFactor(for: geometry.size.width)
+
       ZStack {
         // Background - non-tappable
         VStack(spacing: 0) {
@@ -575,17 +595,20 @@ struct PhasePageView: View {
                     Color.clear,
                   ]),
                   center: .center,
-                  startRadius: 20,
-                  endRadius: 80
+                  startRadius: 20 * scale,
+                  endRadius: 80 * scale
                 )
               )
-              .frame(width: 160, height: 160)
-              .blur(radius: 1)
+              .frame(
+                width: UIConstants.phaseOrbSize * scale,
+                height: UIConstants.phaseOrbSize * scale
+              )
+              .blur(radius: 1 * scale)
 
             // Main content container - floating card
-            VStack(spacing: 12) {
+            VStack(spacing: 12 * scale) {
               // Layer context - minimal and elegant
-              VStack(spacing: 4) {
+              VStack(spacing: 4 * scale) {
                 Text(layer.title)
                   .font(.caption)
                   .fontWeight(.medium)
@@ -610,16 +633,19 @@ struct PhasePageView: View {
                 .multilineTextAlignment(.center)
                 .lineLimit(1)
                 .minimumScaleFactor(0.4)
-                .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
-                .padding(.horizontal, 4)
+                .shadow(color: .black.opacity(0.3), radius: 2 * scale, x: 0, y: 1)
+                .padding(.horizontal, 4 * scale)
 
               // Mystical accent - geometric crystal element
               ZStack {
                 // Outer glow
                 Capsule()
                   .fill(color.opacity(0.3))
-                  .frame(width: 60, height: 3)
-                  .blur(radius: 3)
+                  .frame(
+                    width: UIConstants.phaseAccentOuterWidth * scale,
+                    height: UIConstants.phaseAccentOuterHeight * scale
+                  )
+                  .blur(radius: 3 * scale)
 
                 // Inner crystal line
                 Capsule()
@@ -634,11 +660,14 @@ struct PhasePageView: View {
                       endPoint: .trailing
                     )
                   )
-                  .frame(width: 50, height: 2)
-                  .shadow(color: color.opacity(0.8), radius: 4)
+                  .frame(
+                    width: UIConstants.phaseAccentInnerWidth * scale,
+                    height: UIConstants.phaseAccentInnerHeight * scale
+                  )
+                  .shadow(color: color.opacity(0.8), radius: 4 * scale)
               }
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 20 * scale)
             .padding(.vertical, 16)
             .background(
               // Floating card background
@@ -1166,26 +1195,31 @@ struct MenuView: View {
 
 struct AnalyticsView: View {
   var body: some View {
-    VStack(spacing: 16) {
-      Image(systemName: "chart.bar.fill")
-        .font(.system(size: 48))
-        .foregroundColor(.blue.opacity(0.6))
+    GeometryReader { geometry in
+      let scale = UIConstants.scaleFactor(for: geometry.size.width)
 
-      Text("Analytics")
-        .font(.title2)
-        .fontWeight(.thin)
+      VStack(spacing: 16 * scale) {
+        Image(systemName: "chart.bar.fill")
+          .font(.system(size: UIConstants.analyticsIconSize * scale))
+          .foregroundColor(.blue.opacity(0.6))
 
-      Text("Coming Soon")
-        .font(.caption)
-        .foregroundColor(.secondary)
+        Text("Analytics")
+          .font(.title2)
+          .fontWeight(.thin)
 
-      Text("View your journal history, patterns, and insights.")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
-        .padding(.horizontal)
+        Text("Coming Soon")
+          .font(.caption)
+          .foregroundColor(.secondary)
+
+        Text("View your journal history, patterns, and insights.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal)
+      }
+      .padding()
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-    .padding()
   }
 }
 


### PR DESCRIPTION
## Summary

Implements responsive UI scaling to fix squished/cramped appearance on 42mm and 41mm Apple Watch sizes.

Fixes #125

## Problem

Phase cards and UI elements used fixed dimensions designed for 45mm watches, causing layout issues on smaller screens:

**Watch Sizes:**
- 42mm: ~162pt width (Series 7, SE) - **Most affected**
- 41mm: ~176pt width (Series 10) - Moderately affected
- 45mm: ~198pt width (Series 9, 8, 7) - Reference size (designed for this)
- 49mm: ~205pt width (Ultra, Ultra 2) - Could benefit from slightly larger elements

**Issues on 42mm:**
- 160pt orb on 162pt screen = nearly full width, no breathing room
- Cramped spacing around phase name
- Accent elements (60pt/50pt capsules) too large relative to screen
- Overall UI feels squished and crowded

## Solution

Added responsive scaling using GeometryReader-based scale factor:

```swift
// Reference: 45mm Apple Watch (198pt width)
let scale = geometry.size.width / 198.0

// Apply to all dimensions
.frame(width: 160 * scale, height: 160 * scale)  // Orb
.frame(width: 60 * scale, height: 3 * scale)      // Accent
.padding(.horizontal, 20 * scale)                 // Spacing
```

**Resulting orb sizes:**
- 42mm: 131pt (was 160pt) - ✅ Much better proportions
- 41mm: 142pt (was 160pt) - ✅ Improved
- 45mm: 160pt (unchanged) - ✅ Reference size
- 49mm: 166pt (was 160pt) - ✅ Appropriate scaling up

## Changes

**UIConstants (new):**
```swift
static let referenceScreenWidth: CGFloat = 198
static func scaleFactor(for width: CGFloat) -> CGFloat {
  width / referenceScreenWidth
}

// Dimension constants at reference size
static let phaseOrbSize: CGFloat = 160
static let phaseAccentOuterWidth: CGFloat = 60
static let phaseAccentOuterHeight: CGFloat = 3
static let phaseAccentInnerWidth: CGFloat = 50
static let phaseAccentInnerHeight: CGFloat = 2
static let analyticsIconSize: CGFloat = 48
```

**PhasePageView:**
- All hardcoded dimensions now scale proportionally:
  - Orb frame: `160 * scale`
  - RadialGradient radii: `20 * scale`, `80 * scale`
  - VStack/HStack spacing: `12 * scale`, `4 * scale`
  - Padding values: `20 * scale`, `4 * scale`
  - Capsule frames: `60 * scale`, `50 * scale`, `3 * scale`, `2 * scale`
  - Shadow/blur radii: `2 * scale`, `3 * scale`, `4 * scale`

**AnalyticsView:**
- Icon size: `48 * scale`
- VStack spacing: `16 * scale`
- Added `.frame(maxWidth:maxHeight:)` for proper centering in GeometryReader

## Testing

✅ All 18 test suites passing  
✅ SwiftFormat passed  
✅ Pre-commit hooks passed  
✅ No functional changes (UI scaling only)

## Visual Impact

**Before (42mm):**
- Orb dominates screen (160pt on 162pt width)
- Cramped, crowded appearance
- Poor visual balance

**After (42mm):**
- Orb properly scaled (131pt on 162pt width)
- Comfortable spacing
- Balanced, mystical aesthetic maintained

## Device Compatibility Matrix

| Device | Width | Scale | Orb Size | Impact |
|--------|-------|-------|----------|---------|
| **42mm** (SE, S7) | 162pt | 0.82x | 131pt | ✅ Major improvement |
| **41mm** (S10) | 176pt | 0.89x | 142pt | ✅ Improvement |
| **45mm** (S9, S8, S7) | 198pt | 1.00x | 160pt | ✅ Unchanged (ref) |
| **49mm** (Ultra) | 205pt | 1.04x | 166pt | ✅ Appropriate upscale |

## Manual Testing Recommended

1. Test on 42mm simulator/device (Apple Watch Series 7, SE)
   - Verify orb doesn't dominate screen
   - Check comfortable spacing around phase name
   - Confirm accent elements properly sized

2. Test on other sizes for regression
   - 41mm, 45mm, 49mm simulators
   - Verify visual proportions maintained
   - Check mystical aesthetic preserved

3. Navigate through all phases/layers
   - Verify consistent scaling across all screens
   - Check no clipping or overflow

## CI Confidence

✅ All tests passing  
✅ Code formatted  
✅ Confident in CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)