### PR TITLE
fix(ui): Fix success alert auto-dismissal in review sheet (#161)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -175,6 +175,8 @@ struct ContentView: View {
           Task {
             do {
               try await flowCoordinator.submit()
+              // Success - reset flow state (quick log doesn't use review sheet)
+              flowCoordinator.reset()
             } catch {
               viewModel.journalFeedback = .init(kind: .failure("Failed to log emotion: \(error.localizedDescription)"))
             }
@@ -196,6 +198,8 @@ struct ContentView: View {
           Task {
             do {
               try await flowCoordinator.submit()
+              // Success - reset flow state (quick log doesn't use review sheet)
+              flowCoordinator.reset()
             } catch {
               viewModel.journalFeedback = .init(kind: .failure("Failed to log emotions: \(error.localizedDescription)"))
             }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowCoordinator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowCoordinator.swift
@@ -99,7 +99,9 @@ final class FlowCoordinator: ObservableObject {
   /// Submits the journal entry to the backend
   ///
   /// Validates that primary emotion is selected, then submits via ContentViewModel's throwing variant.
-  /// On success, resets the flow state. On error, preserves state for retry.
+  /// On success, keeps the flow state intact to allow success alert to display.
+  /// Caller is responsible for calling reset() after user dismisses success confirmation.
+  /// On error, preserves state for retry.
   /// - Throws: FlowError.missingPrimaryEmotion if no primary emotion is selected
   /// - Throws: Network/API errors from journal client
   func submit() async throws {
@@ -116,8 +118,8 @@ final class FlowCoordinator: ObservableObject {
       initiatedBy: .self_initiated
     )
 
-    // Reset flow only on success (errors propagate to caller)
-    reset()
+    // Don't reset here - let caller handle reset after user dismisses success alert
+    // This fixes #161: sheet was dismissing before alert could be read
   }
 
   // MARK: - Cancellation

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewFlowIntegrationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewFlowIntegrationTests.swift
@@ -97,6 +97,8 @@ struct ContentViewFlowIntegrationTests {
     // Submit
     do {
       try await coordinator.submit()
+      // Mimic ContentView behavior: reset after successful submission
+      coordinator.reset()
     } catch {
       Issue.record("Submit should not fail: \(error)")
     }
@@ -296,6 +298,8 @@ struct ContentViewFlowIntegrationTests {
 
     // Submit
     try await coordinator.submit()
+    // Mimic ContentView behavior: reset after successful submission
+    coordinator.reset()
 
     // Verify backend was called with correct data
     #expect(journalClient.submissions.count == 1)
@@ -390,6 +394,8 @@ struct ContentViewFlowIntegrationTests {
 
     // Submit
     try await coordinator.submit()
+    // Mimic ContentView behavior: reset after successful submission
+    coordinator.reset()
 
     // Filter mode should reset to .all
     #expect(viewModel.layerFilterMode == LayerFilterMode.all)
@@ -435,6 +441,8 @@ struct ContentViewFlowIntegrationTests {
 
     // User taps "Done" button - immediate submit
     try await coordinator.submit()
+    // Mimic ContentView "Done" button behavior: reset after successful submission
+    coordinator.reset()
 
     // Verify backend received submission
     #expect(journalClient.submissions.count == 1)


### PR DESCRIPTION
## Summary

Fixes #161 - Success alert after journal entry submission no longer dismisses before the user can read it.

## Root Cause

The success alert was auto-dismissing because:
1. `FlowCoordinator.submit()` called `reset()` internally on success
2. `reset()` changed `currentStep` from `.review` to `.idle`
3. Review sheet binding `.constant(currentStep == .review)` became `false`
4. Sheet dismissed immediately, taking the success alert with it before it could be read

## Solution

Changed the reset timing architecture:
- `FlowCoordinator.submit()` no longer calls `reset()` automatically
- Caller (ContentView) now controls when reset happens:
  - **Review sheet flow**: User taps OK on success alert → then reset
  - **Quick log flow** (Done button): Immediate reset after submit success

## Code Changes

### FlowCoordinator.swift
- Removed `reset()` call from `submit()` method
- Updated documentation to clarify caller is responsible for reset timing

### ContentView.swift
- Primary confirmation "Done" button: Added explicit `reset()` on success
- Secondary confirmation "Done" button: Added explicit `reset()` on success
- Review sheet "OK" button: Already calls `cancel()` which calls `reset()`

### ContentViewFlowIntegrationTests.swift
- Updated 4 tests to explicitly call `reset()` after `submit()` succeeds
- Tests now mimic ContentView behavior

## Timeline Fix

**Before:**
1. User taps Submit → `submit()` succeeds → `reset()` called internally → sheet binding becomes false
2. Sheet starts dismissing → `showingSuccess = true` → alert tries to show on dismissing sheet
3. Alert appears and disappears in ~0.1 seconds (unreadable)

**After:**
1. User taps Submit → `submit()` succeeds → `showingSuccess = true` (no reset yet)
2. Sheet stays open → alert shows on stable sheet → user can read message
3. User taps OK → `cancel()` called → `reset()` → `currentStep = .idle` → sheet dismisses cleanly

## Testing

- ✅ All 23 `ContentViewFlowIntegrationTests` pass
- ✅ All 18 test suites pass
- ✅ Pre-commit hooks pass

## Manual Testing Plan

Test on 42mm watch:
1. Complete full emotion logging flow → reach review sheet
2. Tap "Submit Entry" → wait for success alert
3. **Expected**: Alert appears and stays visible until user taps OK
4. **Expected**: User can read "Your journal entry has been saved."
5. Tap OK → sheet dismisses → returns to ContentView

🤖 Generated with [Claude Code](https://claude.com/claude-code)