### PR TITLE
fix(ui): Standardize phase card widths across all phases (#166)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -20,6 +20,10 @@ private enum UIConstants {
   static let phaseAccentInnerWidth: CGFloat = 50
   static let phaseAccentInnerHeight: CGFloat = 2
 
+  // Phase card minimum width - sized to fit longest phase name "Bottoming Out"
+  // Ensures consistent card width across all phases for visual uniformity
+  static let phaseCardMinWidth: CGFloat = 145
+
   // Analytics view dimensions
   static let analyticsIconSize: CGFloat = 48
 }
@@ -734,6 +738,7 @@ struct PhasePageView: View {
             }
             .padding(.horizontal, 20 * scale)
             .padding(.vertical, 16)
+            .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
             .background(
               // Floating card background
               RoundedRectangle(cornerRadius: 16)


### PR DESCRIPTION
## Summary

Fixes #166 - Standardizes phase card widths so all cards are the same width regardless of phase name length.

## Problem

Phase cards had variable widths based on their label length:
- Short phase names ("Rising", "Falling") → narrow cards
- Long phase names ("Bottoming Out") → wider cards
- Creates visual inconsistency when scrolling horizontally

## Solution

Added a minimum width constant sized for the longest phase name ("Bottoming Out"):

```swift
// UIConstants
static let phaseCardMinWidth: CGFloat = 145

// Applied in PhasePageView
.frame(minWidth: UIConstants.phaseCardMinWidth * scale)
```

## Changes

**ContentView.swift:**
- Added `UIConstants.phaseCardMinWidth` constant (145pt at reference)
- Applied `.frame(minWidth:)` to phase card VStack
- Width scales responsively with watch size

## Responsive Scaling

| Watch Size | Screen Width | Card Min Width |
|------------|--------------|----------------|
| 42mm | 162pt | ~119pt |
| 41mm | 176pt | ~129pt |
| 45mm | 198pt | 145pt (reference) |
| 49mm | 205pt | ~150pt |

## Testing

- ✅ All 18 test suites pass
- ✅ Pre-commit hooks pass
- ✅ SwiftFormat clean

## Manual Testing Plan

1. Navigate to ContentView
2. Scroll horizontally through phases
3. **Verify**: All phase cards have consistent width
4. **Verify**: "Bottoming Out" text fits without truncation
5. **Verify**: Shorter phase names ("Rising") have same card width
6. Test on 42mm, 45mm watches

🤖 Generated with [Claude Code](https://claude.com/claude-code)