### PR TITLE
fix: Filter Clear Light emotions by current phase name

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -1008,7 +1008,7 @@ struct CurriculumDetailView: View {
   private func computeAllMedicinalEmotions() -> [LayeredEmotion] {
     var emotions: [LayeredEmotion] = []
     for sourceLayer in viewModel.layers where sourceLayer.id != 0 && sourceLayer.id != Self.clearLightLayerID {
-      for sourcePhase in sourceLayer.phases {
+      for sourcePhase in sourceLayer.phases where sourcePhase.name == phase.name {
         for entry in sourcePhase.medicinal {
           emotions.append(LayeredEmotion(
             layerId: sourceLayer.id,
@@ -1026,7 +1026,7 @@ struct CurriculumDetailView: View {
   private func computeAllToxicEmotions() -> [LayeredEmotion] {
     var emotions: [LayeredEmotion] = []
     for sourceLayer in viewModel.layers where sourceLayer.id != 0 && sourceLayer.id != Self.clearLightLayerID {
-      for sourcePhase in sourceLayer.phases {
+      for sourcePhase in sourceLayer.phases where sourcePhase.name == phase.name {
         for entry in sourcePhase.toxic {
           emotions.append(LayeredEmotion(
             layerId: sourceLayer.id,


### PR DESCRIPTION
## Bug

Clear Light detail view showed **ALL emotions from ALL phases** instead of only emotions matching the current phase.

**Example**: Viewing Clear Light → Rising phase showed emotions from Rising, Peaking, Falling, Bottoming Out, etc. instead of just Rising.

## Root Cause

The aggregation loops in `computeAllMedicinalEmotions()` and `computeAllToxicEmotions()` iterated all phases without filtering:

```swift
for sourcePhase in sourceLayer.phases {  // ← No filter!
```

## Fix

Added phase name filter to both methods:

```swift
for sourcePhase in sourceLayer.phases where sourcePhase.name == phase.name {
```

## Changes

- `ContentView.swift`: 2 lines changed (added `where sourcePhase.name == phase.name` filter)

## Testing

- ✅ All 18 test suites pass
- ✅ Pre-commit hooks pass

## Manual Testing

1. Navigate to Clear Light layer (layer 10)
2. Open detail view for "Rising" phase
3. **Verify**: Only Rising phase emotions appear (not all phases)
4. Navigate to "Peaking" phase
5. **Verify**: Only Peaking phase emotions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)