### PR TITLE
fix: Uniform phase card sizing for all phase names (#119)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -20,9 +20,13 @@ private enum UIConstants {
   static let phaseAccentInnerWidth: CGFloat = 50
   static let phaseAccentInnerHeight: CGFloat = 2
 
-  // Phase card minimum width - sized to fit longest phase name "Bottoming Out"
-  // Ensures consistent card width across all phases for visual uniformity
-  static let phaseCardMinWidth: CGFloat = 145
+  // Phase card fixed width - sized to fit longest phase name "Bottoming Out"
+  // All phase cards use this exact width for visual uniformity
+  static let phaseCardWidth: CGFloat = 145
+
+  // Phase name text width - constrains text to fixed width so all phase names
+  // scale identically (shorter names like "Rising" match "Bottoming Out" sizing)
+  static let phaseNameWidth: CGFloat = 120
 
   // Analytics view dimensions
   static let analyticsIconSize: CGFloat = 48
@@ -702,6 +706,7 @@ struct PhasePageView: View {
             }
 
             // Hero phase name with sophisticated treatment
+            // Fixed width ensures all phase names scale identically
             Text(phase.name)
               .font(.largeTitle)
               .fontWeight(.light)
@@ -709,8 +714,8 @@ struct PhasePageView: View {
               .multilineTextAlignment(.center)
               .lineLimit(1)
               .minimumScaleFactor(0.4)
+              .frame(width: UIConstants.phaseNameWidth * scale)
               .shadow(color: .black.opacity(0.3), radius: 2 * scale, x: 0, y: 1)
-              .padding(.horizontal, 4 * scale)
 
             // Mystical accent - geometric crystal element
             ZStack {
@@ -745,7 +750,7 @@ struct PhasePageView: View {
           }
           .padding(.horizontal, 20 * scale)
           .padding(.vertical, 16)
-          .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
+          .frame(width: UIConstants.phaseCardWidth * scale)
           .background(
             // Floating card background
             RoundedRectangle(cornerRadius: 16)


### PR DESCRIPTION
## Summary

- Change phase card from `minWidth` to fixed `width` (145pt scaled)
- Add fixed-width frame (120pt scaled) to phase name text
- All phase names now scale identically regardless of text length

## Problem

Previously, shorter phase names like "Rising" displayed with:
- Larger text (no scaling needed)
- Narrower cards (minWidth allowed shrinking)

While longer names like "Bottoming Out" displayed with:
- Smaller text (minimumScaleFactor kicked in)
- Wider cards

## Solution

By constraining both the card and text to fixed widths:
1. **Card width**: Changed `frame(minWidth:)` to `frame(width:)` 
2. **Text width**: Added `frame(width: UIConstants.phaseNameWidth * scale)` to phase name

Now all phases render with identical card dimensions and text scaling.

## Test plan

- [x] Run tests: `frontend/WavelengthWatch/run-tests-individually.sh` ✅ All 18 test suites pass
- [x] Run pre-commit: `pre-commit run --all-files` ✅ All hooks pass
- [ ] Manual testing on 46mm simulator: Verify all phase cards are same width and text same size

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)