### PR TITLE
feat: Add EmotionalLandscape models and service method (#187)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/AnalyticsModels.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/AnalyticsModels.swift
@@ -30,3 +30,63 @@ struct AnalyticsOverview: Codable, Equatable {
     case secondaryEmotionsPct = "secondary_emotions_pct"
   }
 }
+
+// MARK: - Emotional Landscape Models
+
+/// Layer distribution item for emotional landscape analytics
+struct LayerDistributionItem: Codable, Equatable {
+  let layerId: Int
+  let count: Int
+  let percentage: Double
+
+  enum CodingKeys: String, CodingKey {
+    case layerId = "layer_id"
+    case count
+    case percentage
+  }
+}
+
+/// Phase distribution item for emotional landscape analytics
+struct PhaseDistributionItem: Codable, Equatable {
+  let phaseId: Int
+  let count: Int
+  let percentage: Double
+
+  enum CodingKeys: String, CodingKey {
+    case phaseId = "phase_id"
+    case count
+    case percentage
+  }
+}
+
+/// Top emotion item for emotional landscape analytics
+struct TopEmotionItem: Codable, Equatable {
+  let curriculumId: Int
+  let expression: String
+  let layerId: Int
+  let phaseId: Int
+  let dosage: String
+  let count: Int
+
+  enum CodingKeys: String, CodingKey {
+    case curriculumId = "curriculum_id"
+    case expression
+    case layerId = "layer_id"
+    case phaseId = "phase_id"
+    case dosage
+    case count
+  }
+}
+
+/// Response model for /api/v1/analytics/emotional-landscape endpoint
+struct EmotionalLandscape: Codable, Equatable {
+  let layerDistribution: [LayerDistributionItem]
+  let phaseDistribution: [PhaseDistributionItem]
+  let topEmotions: [TopEmotionItem]
+
+  enum CodingKeys: String, CodingKey {
+    case layerDistribution = "layer_distribution"
+    case phaseDistribution = "phase_distribution"
+    case topEmotions = "top_emotions"
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/APIClient.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/APIClient.swift
@@ -4,6 +4,7 @@ enum APIPath {
   static let catalog = "/api/v1/catalog"
   static let journal = "/api/v1/journal"
   static let analyticsOverview = "/api/v1/analytics/overview"
+  static let analyticsEmotionalLandscape = "/api/v1/analytics/emotional-landscape"
 }
 
 protocol APIClientProtocol {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/AnalyticsService.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/AnalyticsService.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol AnalyticsServiceProtocol {
   func getOverview(userId: Int) async throws -> AnalyticsOverview
+  func getEmotionalLandscape(userId: Int) async throws -> EmotionalLandscape
 }
 
 final class AnalyticsService: AnalyticsServiceProtocol {
@@ -13,6 +14,11 @@ final class AnalyticsService: AnalyticsServiceProtocol {
 
   func getOverview(userId: Int) async throws -> AnalyticsOverview {
     let path = "\(APIPath.analyticsOverview)?user_id=\(userId)"
+    return try await apiClient.get(path)
+  }
+
+  func getEmotionalLandscape(userId: Int) async throws -> EmotionalLandscape {
+    let path = "\(APIPath.analyticsEmotionalLandscape)?user_id=\(userId)"
     return try await apiClient.get(path)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -8,8 +8,10 @@ struct AnalyticsViewModelTests {
 
   final class MockAnalyticsService: AnalyticsServiceProtocol {
     var overviewToReturn: AnalyticsOverview?
+    var emotionalLandscapeToReturn: EmotionalLandscape?
     var errorToThrow: Error?
     var getOverviewCallCount = 0
+    var getEmotionalLandscapeCallCount = 0
     var lastUserId: Int?
 
     func getOverview(userId: Int) async throws -> AnalyticsOverview {
@@ -25,6 +27,21 @@ struct AnalyticsViewModelTests {
       }
 
       return overview
+    }
+
+    func getEmotionalLandscape(userId: Int) async throws -> EmotionalLandscape {
+      getEmotionalLandscapeCallCount += 1
+      lastUserId = userId
+
+      if let error = errorToThrow {
+        throw error
+      }
+
+      guard let landscape = emotionalLandscapeToReturn else {
+        throw NSError(domain: "test", code: -1)
+      }
+
+      return landscape
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/EmotionalLandscapeModelsTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/EmotionalLandscapeModelsTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+@Suite("EmotionalLandscape Models Tests")
+struct EmotionalLandscapeModelsTests {
+  // MARK: - LayerDistributionItem Tests
+
+  @Test("LayerDistributionItem decodes from JSON with snake_case keys")
+  func layerDistributionItem_decodesFromJSON() throws {
+    let json = """
+    {
+      "layer_id": 1,
+      "count": 10,
+      "percentage": 25.5
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let item = try decoder.decode(LayerDistributionItem.self, from: data)
+
+    #expect(item.layerId == 1)
+    #expect(item.count == 10)
+    #expect(item.percentage == 25.5)
+  }
+
+  @Test("LayerDistributionItem conforms to Equatable")
+  func layerDistributionItem_conformsToEquatable() {
+    let item1 = LayerDistributionItem(layerId: 1, count: 10, percentage: 25.0)
+    let item2 = LayerDistributionItem(layerId: 1, count: 10, percentage: 25.0)
+    let item3 = LayerDistributionItem(layerId: 2, count: 5, percentage: 12.5)
+
+    #expect(item1 == item2)
+    #expect(item1 != item3)
+  }
+
+  // MARK: - PhaseDistributionItem Tests
+
+  @Test("PhaseDistributionItem decodes from JSON with snake_case keys")
+  func phaseDistributionItem_decodesFromJSON() throws {
+    let json = """
+    {
+      "phase_id": 2,
+      "count": 15,
+      "percentage": 37.5
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let item = try decoder.decode(PhaseDistributionItem.self, from: data)
+
+    #expect(item.phaseId == 2)
+    #expect(item.count == 15)
+    #expect(item.percentage == 37.5)
+  }
+
+  @Test("PhaseDistributionItem conforms to Equatable")
+  func phaseDistributionItem_conformsToEquatable() {
+    let item1 = PhaseDistributionItem(phaseId: 1, count: 5, percentage: 12.5)
+    let item2 = PhaseDistributionItem(phaseId: 1, count: 5, percentage: 12.5)
+    let item3 = PhaseDistributionItem(phaseId: 2, count: 10, percentage: 25.0)
+
+    #expect(item1 == item2)
+    #expect(item1 != item3)
+  }
+
+  // MARK: - TopEmotionItem Tests
+
+  @Test("TopEmotionItem decodes from JSON with snake_case keys")
+  func topEmotionItem_decodesFromJSON() throws {
+    let json = """
+    {
+      "curriculum_id": 5,
+      "expression": "Hopeful",
+      "layer_id": 2,
+      "phase_id": 1,
+      "dosage": "Medicinal",
+      "count": 8
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let item = try decoder.decode(TopEmotionItem.self, from: data)
+
+    #expect(item.curriculumId == 5)
+    #expect(item.expression == "Hopeful")
+    #expect(item.layerId == 2)
+    #expect(item.phaseId == 1)
+    #expect(item.dosage == "Medicinal")
+    #expect(item.count == 8)
+  }
+
+  @Test("TopEmotionItem conforms to Equatable")
+  func topEmotionItem_conformsToEquatable() {
+    let item1 = TopEmotionItem(
+      curriculumId: 1,
+      expression: "Joy",
+      layerId: 1,
+      phaseId: 1,
+      dosage: "Medicinal",
+      count: 5
+    )
+    let item2 = TopEmotionItem(
+      curriculumId: 1,
+      expression: "Joy",
+      layerId: 1,
+      phaseId: 1,
+      dosage: "Medicinal",
+      count: 5
+    )
+    let item3 = TopEmotionItem(
+      curriculumId: 2,
+      expression: "Anger",
+      layerId: 3,
+      phaseId: 2,
+      dosage: "Toxic",
+      count: 3
+    )
+
+    #expect(item1 == item2)
+    #expect(item1 != item3)
+  }
+
+  // MARK: - EmotionalLandscape Tests
+
+  @Test("EmotionalLandscape decodes from JSON with all components")
+  func emotionalLandscape_decodesFromJSON() throws {
+    let json = """
+    {
+      "layer_distribution": [
+        {"layer_id": 1, "count": 10, "percentage": 50.0},
+        {"layer_id": 2, "count": 10, "percentage": 50.0}
+      ],
+      "phase_distribution": [
+        {"phase_id": 1, "count": 15, "percentage": 75.0},
+        {"phase_id": 2, "count": 5, "percentage": 25.0}
+      ],
+      "top_emotions": [
+        {
+          "curriculum_id": 1,
+          "expression": "Joy",
+          "layer_id": 1,
+          "phase_id": 1,
+          "dosage": "Medicinal",
+          "count": 8
+        }
+      ]
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let landscape = try decoder.decode(EmotionalLandscape.self, from: data)
+
+    #expect(landscape.layerDistribution.count == 2)
+    #expect(landscape.phaseDistribution.count == 2)
+    #expect(landscape.topEmotions.count == 1)
+
+    #expect(landscape.layerDistribution[0].layerId == 1)
+    #expect(landscape.phaseDistribution[0].phaseId == 1)
+    #expect(landscape.topEmotions[0].expression == "Joy")
+  }
+
+  @Test("EmotionalLandscape conforms to Equatable")
+  func emotionalLandscape_conformsToEquatable() {
+    let layer1 = LayerDistributionItem(layerId: 1, count: 10, percentage: 50.0)
+    let phase1 = PhaseDistributionItem(phaseId: 1, count: 10, percentage: 50.0)
+    let emotion1 = TopEmotionItem(
+      curriculumId: 1,
+      expression: "Joy",
+      layerId: 1,
+      phaseId: 1,
+      dosage: "Medicinal",
+      count: 5
+    )
+
+    let landscape1 = EmotionalLandscape(
+      layerDistribution: [layer1],
+      phaseDistribution: [phase1],
+      topEmotions: [emotion1]
+    )
+
+    let landscape2 = EmotionalLandscape(
+      layerDistribution: [layer1],
+      phaseDistribution: [phase1],
+      topEmotions: [emotion1]
+    )
+
+    let landscape3 = EmotionalLandscape(
+      layerDistribution: [],
+      phaseDistribution: [],
+      topEmotions: []
+    )
+
+    #expect(landscape1 == landscape2)
+    #expect(landscape1 != landscape3)
+  }
+
+  @Test("EmotionalLandscape handles empty arrays")
+  func emotionalLandscape_handlesEmptyArrays() throws {
+    let json = """
+    {
+      "layer_distribution": [],
+      "phase_distribution": [],
+      "top_emotions": []
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let landscape = try decoder.decode(EmotionalLandscape.self, from: data)
+
+    #expect(landscape.layerDistribution.isEmpty)
+    #expect(landscape.phaseDistribution.isEmpty)
+    #expect(landscape.topEmotions.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

Adds shared infrastructure for Phase 2 Emotional Landscape feature implementation. This PR provides the foundation for parallel development of issues #197, #198, and #199.

## Changes

### Swift Models (AnalyticsModels.swift)
- `LayerDistributionItem` - Layer distribution with count and percentage
- `PhaseDistributionItem` - Phase distribution with count and percentage
- `TopEmotionItem` - Top emotions with curriculum details and dosage
- `EmotionalLandscape` - Complete response model containing all three components

All models include:
- Proper `CodingKeys` for snake_case ↔ camelCase mapping
- `Codable` conformance for JSON serialization
- `Equatable` conformance for testing

### Service Layer (AnalyticsService.swift)
- Added `getEmotionalLandscape(userId:)` to `AnalyticsServiceProtocol`
- Implemented in `AnalyticsService` using `/api/v1/analytics/emotional-landscape` endpoint
- Updated `MockAnalyticsService` in tests to support new method

### API Constants (APIClient.swift)
- Added `APIPath.analyticsEmotionalLandscape` constant

### Tests (EmotionalLandscapeModelsTests.swift)
- 8 comprehensive tests covering:
  - JSON decoding with snake_case keys ✅
  - Equatable conformance ✅
  - Empty array handling ✅
  - Complete EmotionalLandscape decoding ✅

## Test Results
```
✅ All 8 tests passing
✅ SwiftFormat validation passed
✅ Pre-commit hooks passed
```

## Backend Support
The backend endpoint `/api/v1/analytics/emotional-landscape` was implemented and merged in PR #226.

## Enables Parallel Development
This shared infrastructure allows these issues to be developed simultaneously:
- #197: Mode Distribution View (uses `layerDistribution`)
- #198: Phase Journey View (uses `phaseDistribution`)
- #199: Dosage Deep Dive (uses `topEmotions`)

All three can start work immediately after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>