### PR TITLE
feat: Add local fallback to AnalyticsViewModel

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
@@ -2,8 +2,13 @@ import Foundation
 
 /// View model for analytics overview screen.
 ///
-/// Fetches and manages analytics data from the backend, handling loading
-/// states, errors, and empty data scenarios.
+/// Fetches and manages analytics data from the backend with local fallback,
+/// handling loading states, errors, and empty data scenarios.
+///
+/// ## Data Strategy
+/// - Tries backend first for fresh data
+/// - Falls back to local calculation if backend fails
+/// - Requires local calculator, journal repository, and catalog for offline support
 @MainActor
 final class AnalyticsViewModel: ObservableObject {
   enum LoadingState: Equatable {
@@ -16,18 +21,32 @@ final class AnalyticsViewModel: ObservableObject {
   @Published private(set) var state: LoadingState = .idle
 
   private let analyticsService: AnalyticsServiceProtocol
+  private let localCalculator: LocalAnalyticsCalculatorProtocol?
+  private let journalRepository: JournalRepositoryProtocol?
+  private let catalogRepository: CatalogRepositoryProtocol?
   private let userDefaults: UserDefaults
   private let userDefaultsKey = "com.wavelengthwatch.userIdentifier"
 
   init(
     analyticsService: AnalyticsServiceProtocol,
+    localCalculator: LocalAnalyticsCalculatorProtocol? = nil,
+    journalRepository: JournalRepositoryProtocol? = nil,
+    catalogRepository: CatalogRepositoryProtocol? = nil,
     userDefaults: UserDefaults = .standard
   ) {
     self.analyticsService = analyticsService
+    self.localCalculator = localCalculator
+    self.journalRepository = journalRepository
+    self.catalogRepository = catalogRepository
     self.userDefaults = userDefaults
   }
 
-  /// Fetches analytics overview data from the backend.
+  /// Fetches analytics overview data from backend with local fallback.
+  ///
+  /// Strategy:
+  /// 1. Try backend first for fresh data
+  /// 2. If backend fails and local components available, calculate from local storage
+  /// 3. If both fail, report error
   func loadAnalytics() async {
     state = .loading
 
@@ -36,7 +55,40 @@ final class AnalyticsViewModel: ObservableObject {
       let overview = try await analyticsService.getOverview(userId: userId)
       state = .loaded(overview)
     } catch {
-      state = .error("Failed to load analytics: \(error.localizedDescription)")
+      // Try local fallback if available
+      if let localOverview = await tryLocalCalculation() {
+        state = .loaded(localOverview)
+      } else {
+        state = .error("Failed to load analytics: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Attempts to calculate analytics from local storage.
+  ///
+  /// - Returns: Locally calculated overview if all components available, nil otherwise
+  private func tryLocalCalculation() async -> AnalyticsOverview? {
+    guard
+      let calculator = localCalculator,
+      let repository = journalRepository,
+      let catalogRepo = catalogRepository,
+      let catalog = catalogRepo.cachedCatalog()
+    else {
+      return nil
+    }
+
+    do {
+      let entries = try repository.fetchAll()
+      let endDate = Date()
+      let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
+
+      return calculator.calculateOverview(
+        entries: entries,
+        startDate: startDate,
+        endDate: endDate
+      )
+    } catch {
+      return nil
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -221,4 +221,249 @@ struct AnalyticsViewModelTests {
     #expect(mockService.lastUserId != nil)
     #expect(mockService.lastUserId! > 0)
   }
+
+  // MARK: - Local Fallback Tests
+
+  final class MockLocalAnalyticsCalculator: LocalAnalyticsCalculatorProtocol {
+    var overviewToReturn: AnalyticsOverview?
+    var landscapeToReturn: EmotionalLandscape?
+    var calculateOverviewCallCount = 0
+    var calculateLandscapeCallCount = 0
+
+    func calculateOverview(
+      entries: [LocalJournalEntry],
+      startDate: Date,
+      endDate: Date
+    ) -> AnalyticsOverview {
+      calculateOverviewCallCount += 1
+      return overviewToReturn ?? AnalyticsOverview(
+        totalEntries: 0,
+        currentStreak: 0,
+        longestStreak: 0,
+        avgFrequency: 0,
+        lastCheckIn: nil,
+        medicinalRatio: 0,
+        medicinalTrend: 0,
+        dominantLayerId: nil,
+        dominantPhaseId: nil,
+        uniqueEmotions: 0,
+        strategiesUsed: 0,
+        secondaryEmotionsPct: 0
+      )
+    }
+
+    func calculateEmotionalLandscape(
+      entries: [LocalJournalEntry],
+      limit: Int
+    ) -> EmotionalLandscape {
+      calculateLandscapeCallCount += 1
+      return landscapeToReturn ?? EmotionalLandscape(
+        layerDistribution: [],
+        phaseDistribution: [],
+        topEmotions: []
+      )
+    }
+  }
+
+  final class MockJournalRepository: JournalRepositoryProtocol {
+    var entriesToReturn: [LocalJournalEntry] = []
+    var errorToThrow: Error?
+    var fetchAllCallCount = 0
+
+    func save(_ entry: LocalJournalEntry) throws {
+      if let error = errorToThrow { throw error }
+    }
+
+    func update(_ entry: LocalJournalEntry) throws {
+      if let error = errorToThrow { throw error }
+    }
+
+    func delete(id: UUID) throws {
+      if let error = errorToThrow { throw error }
+    }
+
+    func fetch(id: UUID) throws -> LocalJournalEntry? {
+      if let error = errorToThrow { throw error }
+      return entriesToReturn.first { $0.id == id }
+    }
+
+    func fetchAll() throws -> [LocalJournalEntry] {
+      fetchAllCallCount += 1
+      if let error = errorToThrow { throw error }
+      return entriesToReturn
+    }
+
+    func fetchPendingSync() throws -> [LocalJournalEntry] {
+      if let error = errorToThrow { throw error }
+      return entriesToReturn.filter { $0.syncStatus == .pending }
+    }
+
+    func count() throws -> Int {
+      if let error = errorToThrow { throw error }
+      return entriesToReturn.count
+    }
+  }
+
+  final class MockCatalogRepository: CatalogRepositoryProtocol {
+    var catalogToReturn: CatalogResponseModel?
+
+    func cachedCatalog() -> CatalogResponseModel? {
+      catalogToReturn
+    }
+
+    func loadCatalog(forceRefresh: Bool) async throws -> CatalogResponseModel {
+      throw NSError(domain: "test", code: -1)
+    }
+
+    func refreshCatalog() async throws -> CatalogResponseModel {
+      throw NSError(domain: "test", code: -1)
+    }
+  }
+
+  @Test("viewModel falls back to local when backend fails")
+  @MainActor
+  func viewModel_fallsBackToLocalWhenBackendFails() async {
+    let mockService = MockAnalyticsService()
+    mockService.errorToThrow = NSError(domain: "test", code: -1)
+
+    let mockCalculator = MockLocalAnalyticsCalculator()
+    let localOverview = AnalyticsOverview(
+      totalEntries: 5,
+      currentStreak: 2,
+      longestStreak: 3,
+      avgFrequency: 1.5,
+      lastCheckIn: Date(),
+      medicinalRatio: 0.6,
+      medicinalTrend: 0.1,
+      dominantLayerId: 2,
+      dominantPhaseId: 1,
+      uniqueEmotions: 4,
+      strategiesUsed: 2,
+      secondaryEmotionsPct: 0.5
+    )
+    mockCalculator.overviewToReturn = localOverview
+
+    let mockRepository = MockJournalRepository()
+    mockRepository.entriesToReturn = [
+      LocalJournalEntry(createdAt: Date(), userID: 1, curriculumID: 1),
+    ]
+
+    let mockCatalog = MockCatalogRepository()
+    mockCatalog.catalogToReturn = testCatalog()
+
+    let viewModel = AnalyticsViewModel(
+      analyticsService: mockService,
+      localCalculator: mockCalculator,
+      journalRepository: mockRepository,
+      catalogRepository: mockCatalog
+    )
+
+    await viewModel.loadAnalytics()
+
+    if case let .loaded(overview) = viewModel.state {
+      #expect(overview == localOverview)
+      #expect(mockService.getOverviewCallCount == 1)
+      #expect(mockCalculator.calculateOverviewCallCount == 1)
+      #expect(mockRepository.fetchAllCallCount == 1)
+    } else {
+      Issue.record("Expected loaded state with local data, got \(viewModel.state)")
+    }
+  }
+
+  @Test("viewModel reports error when both backend and local fail")
+  @MainActor
+  func viewModel_reportsErrorWhenBothFail() async {
+    let mockService = MockAnalyticsService()
+    mockService.errorToThrow = NSError(domain: "test", code: -1)
+
+    let mockRepository = MockJournalRepository()
+    mockRepository.errorToThrow = NSError(domain: "test", code: -2)
+
+    let mockCatalog = MockCatalogRepository()
+
+    let viewModel = AnalyticsViewModel(
+      analyticsService: mockService,
+      localCalculator: nil,
+      journalRepository: mockRepository,
+      catalogRepository: mockCatalog
+    )
+
+    await viewModel.loadAnalytics()
+
+    if case let .error(message) = viewModel.state {
+      #expect(message.contains("Failed to load analytics"))
+      #expect(mockService.getOverviewCallCount == 1)
+    } else {
+      Issue.record("Expected error state, got \(viewModel.state)")
+    }
+  }
+
+  @Test("viewModel uses backend successfully without trying local")
+  @MainActor
+  func viewModel_usesBackendWithoutTryingLocal() async {
+    let mockService = MockAnalyticsService()
+    let backendOverview = AnalyticsOverview(
+      totalEntries: 10,
+      currentStreak: 5,
+      longestStreak: 12,
+      avgFrequency: 2.0,
+      lastCheckIn: Date(),
+      medicinalRatio: 0.75,
+      medicinalTrend: 0.05,
+      dominantLayerId: 1,
+      dominantPhaseId: 2,
+      uniqueEmotions: 8,
+      strategiesUsed: 3,
+      secondaryEmotionsPct: 0.6
+    )
+    mockService.overviewToReturn = backendOverview
+
+    let mockCalculator = MockLocalAnalyticsCalculator()
+    let mockRepository = MockJournalRepository()
+    let mockCatalog = MockCatalogRepository()
+
+    let viewModel = AnalyticsViewModel(
+      analyticsService: mockService,
+      localCalculator: mockCalculator,
+      journalRepository: mockRepository,
+      catalogRepository: mockCatalog
+    )
+
+    await viewModel.loadAnalytics()
+
+    if case let .loaded(overview) = viewModel.state {
+      #expect(overview == backendOverview)
+      #expect(mockService.getOverviewCallCount == 1)
+      #expect(mockCalculator.calculateOverviewCallCount == 0)
+      #expect(mockRepository.fetchAllCallCount == 0)
+    } else {
+      Issue.record("Expected loaded state, got \(viewModel.state)")
+    }
+  }
+
+  // Helper to create test catalog
+  private func testCatalog() -> CatalogResponseModel {
+    CatalogResponseModel(
+      phaseOrder: ["Rising", "Peaking", "Falling", "Resting"],
+      layers: [
+        CatalogLayerModel(
+          id: 1,
+          color: "#F5DEB3",
+          title: "Beige",
+          subtitle: "The Observer",
+          phases: [
+            CatalogPhaseModel(
+              id: 1,
+              name: "Rising",
+              medicinal: [
+                CatalogCurriculumEntryModel(id: 1, dosage: .medicinal, expression: "Curious"),
+              ],
+              toxic: [],
+              strategies: []
+            ),
+          ]
+        ),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
## Summary
Integrates LocalAnalyticsCalculator with AnalyticsViewModel to enable offline analytics calculation. When the backend fails, analytics are calculated from local SQLite storage using the same algorithms as the backend.

## Changes
- Add optional dependencies to AnalyticsViewModel:
  - `LocalAnalyticsCalculatorProtocol` for local calculation
  - `JournalRepositoryProtocol` for fetching local entries
  - `CatalogRepositoryProtocol` for accessing cached catalog
- Implement backend-first strategy with graceful local fallback
- Add `tryLocalCalculation()` private method for fallback logic
- Add 3 comprehensive tests:
  - Local fallback when backend fails
  - Error when both backend and local fail
  - Backend success without trying local

## Test Results
- ✅ All 24 test suites passing
- ✅ SwiftFormat passing
- ✅ Pre-commit hooks passing

## Architecture
**Strategy**: Backend-first with local fallback
1. Try backend for fresh data
2. If backend fails and local components available, calculate from local storage
3. If both fail, report error

This enables offline analytics while maintaining backend data freshness when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)