### PR TITLE
feat: Extend LocalAnalyticsCalculator for growth indicators (#252)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -285,6 +285,18 @@ struct AnalyticsViewModelTests {
         consistencyScore: 0.0
       )
     }
+
+    func calculateGrowthIndicators(
+      entries: [LocalJournalEntry],
+      startDate: Date,
+      endDate: Date
+    ) -> GrowthIndicators {
+      GrowthIndicators(
+        medicinalTrend: 0.0,
+        layerDiversity: 0,
+        phaseCoverage: 0
+      )
+    }
   }
 
   final class MockJournalRepository: JournalRepositoryProtocol {


### PR DESCRIPTION
## Summary

Extends `LocalAnalyticsCalculator` with offline growth indicators analytics support, enabling users to view medicinal trend, layer diversity, and phase coverage metrics without backend connectivity.

**Resolves #252** (Phase 4: Temporal Patterns & Growth - Offline Extensions)

**🎉 COMPLETES OFFLINE CALCULATOR EXTENSIONS (3/3)**

This is the final offline calculator extension, achieving full offline-first compliance per spec requirement (line 498): "On-Device First: Compute simple metrics on-device when possible"

## Changes

### Implementation
- ✅ Extended `LocalAnalyticsCalculatorProtocol` with `calculateGrowthIndicators()` method
- ✅ Implemented growth indicators algorithm matching backend `analytics.py:754-826`:
  - **Medicinal Trend**: Compares medicinal ratio between current period and equal-duration previous period. Returns decimal difference (e.g., 0.1667 for 16.67% improvement).
  - **Layer Diversity**: Counts unique layer IDs accessed within the date range using `curriculumLookup`
  - **Phase Coverage**: Counts unique phase IDs accessed within the date range using `curriculumLookup`
- ✅ Added 10 comprehensive test cases covering edge cases and core functionality
- ✅ Updated `MockLocalAnalyticsCalculator` to maintain protocol conformance

### Testing
- ✅ Added 10 comprehensive test cases:
  - Empty entries return zero values
  - Entries outside date range return zero
  - Layer diversity calculation (multiple layers)
  - Phase coverage calculation (multiple phases)
  - Positive medicinal trend (improvement)
  - Negative medicinal trend (decline)
  - Single layer handling
  - Single phase handling
  - Unknown curriculum ID handling
  - No previous period data handling

## Test Results

```
✅ All 35 test suites passed
✅ All pre-commit hooks passed
✅ SwiftFormat validation passed
```

## Spec Compliance

**Spec Requirement** (line 498): "On-Device First: Compute simple metrics on-device when possible"

**Status**: ✅ **COMPLETE - All analytics now available offline (5/5 types)**

- ✅ Overview analytics (Issue #231)
- ✅ Emotional landscape analytics (Issue #231)
- ✅ Self-care analytics (Issue #250)
- ✅ Temporal patterns analytics (Issue #251)
- ✅ Growth indicators analytics (Issue #252) **← THIS PR**

Users can now access **ALL** analytics features without backend connectivity!

## Algorithm Verification

Implementation mirrors backend `routers/analytics.py:754-826`:
- ✅ Medicinal trend calculation matches backend (period comparison logic)
- ✅ Layer diversity counting matches backend
- ✅ Phase coverage counting matches backend
- ✅ Date range filtering matches backend (inclusive)
- ✅ Empty state handling matches backend

## Breaking Changes

**Protocol Extension**: Added required method `calculateGrowthIndicators(entries:startDate:endDate:)` to `LocalAnalyticsCalculatorProtocol`. All conforming types updated.

## Files Modified

- `LocalAnalyticsCalculator.swift` (+63 lines): Protocol + Implementation
- `LocalAnalyticsCalculatorTests.swift` (+260 lines): Tests
- `AnalyticsViewModelTests.swift` (+10 lines): Mock conformance

**Total**: +333 lines

## Progress Update

**Offline Calculator Extensions**: ✅ **3/3 COMPLETE (100%)**
- ✅ #250: Self-care analytics
- ✅ #251: Temporal patterns analytics
- ✅ #252: Growth indicators analytics

**Next Phase**: ViewModel Creation
After merge, proceed to:
1. Issue #253: Create SelfCareViewModel with offline fallback
2. Issue #254: Create TemporalPatternsViewModel with offline fallback
3. Issue #255: Create GrowthIndicatorsViewModel with offline fallback
4. Issue #256: Integrate all analytics views into navigation hierarchy

## Impact

This PR completes a **critical milestone**: full offline-first analytics per the spec. Users who disable backend sync can now access:
- ✅ Overview metrics (streaks, frequency, medicinal ratio)
- ✅ Emotional landscape (layer/phase distribution, top emotions)
- ✅ Self-care insights (strategy usage, diversity)
- ✅ Temporal patterns (hourly distribution, consistency)
- ✅ Growth indicators (medicinal trend, layer/phase diversity)

**Privacy-first architecture achieved!** 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)