### PR TITLE
feat: Liquid Glass design system with backward compatibility (#294)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLButtonStyle.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLButtonStyle.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Primary action button style (Liquid Glass prominent or fallback).
+///
+/// Used for main CTAs like "Submit Entry", "Continue", etc.
+/// On watchOS 26+ this will use `.glassProminent` button style.
+struct WLPrimaryButtonStyle: ButtonStyle {
+  let tint: Color
+
+  init(tint: Color = .accentColor) {
+    self.tint = tint
+  }
+
+  func makeBody(configuration: Configuration) -> some View {
+    // TODO: watchOS 26 — Use .glassProminent style
+    configuration.label
+      .font(WLTypographyTokens.cardTitle)
+      .fontWeight(.semibold)
+      .foregroundColor(.white)
+      .padding(.horizontal, WLSpacingTokens.paddingL)
+      .padding(.vertical, WLSpacingTokens.paddingS)
+      .frame(maxWidth: .infinity)
+      .background(
+        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
+          .fill(tint.opacity(configuration.isPressed ? 0.5 : 0.8))
+      )
+      .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+      .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+  }
+}
+
+/// Secondary/subtle button style (Liquid Glass regular or fallback).
+///
+/// Used for less prominent actions, list items, option selectors.
+struct WLSecondaryButtonStyle: ButtonStyle {
+  let tint: Color
+
+  init(tint: Color = .secondary) {
+    self.tint = tint
+  }
+
+  func makeBody(configuration: Configuration) -> some View {
+    // TODO: watchOS 26 — Use .glass style
+    configuration.label
+      .foregroundColor(.white)
+      .padding(.horizontal, WLSpacingTokens.paddingM)
+      .padding(.vertical, WLSpacingTokens.paddingS)
+      .background(
+        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
+          .fill(tint.opacity(configuration.isPressed ? 0.2 : 0.1))
+          .overlay(
+            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
+              .stroke(
+                Color.white.opacity(0.1),
+                lineWidth: WLSpacingTokens.cardBorderWidth
+              )
+          )
+      )
+      .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+      .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+  }
+}
+
+// MARK: - View Extensions
+
+extension View {
+  /// Applies the primary CTA button style.
+  func wlPrimaryButtonStyle(tint: Color = .accentColor) -> some View {
+    buttonStyle(WLPrimaryButtonStyle(tint: tint))
+  }
+
+  /// Applies the secondary button style.
+  func wlSecondaryButtonStyle(tint: Color = .secondary) -> some View {
+    buttonStyle(WLSecondaryButtonStyle(tint: tint))
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLCardModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLCardModifier.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// Card style modifier for content containers.
+///
+/// Applies consistent padding, corner radius, glass background,
+/// and optional layer-color tinting. Replaces the inline
+/// `.background(RoundedRectangle(...).fill(...))` pattern.
+struct WLCardModifier: ViewModifier {
+  let tint: Color?
+  let isCompact: Bool
+
+  init(tint: Color? = nil, isCompact: Bool = false) {
+    self.tint = tint
+    self.isCompact = isCompact
+  }
+
+  private var cornerRadius: CGFloat {
+    isCompact
+      ? WLSpacingTokens.cardCornerRadiusCompact
+      : WLSpacingTokens.cardCornerRadius
+  }
+
+  private var padding: CGFloat {
+    isCompact
+      ? WLSpacingTokens.cardPaddingCompact
+      : WLSpacingTokens.cardPaddingStandard
+  }
+
+  func body(content: Content) -> some View {
+    content
+      .padding(padding)
+      .wlGlass(
+        .regular,
+        tint: tint,
+        cornerRadius: cornerRadius
+      )
+  }
+}
+
+// MARK: - View Extension
+
+extension View {
+  /// Applies card styling with optional tint color.
+  func wlCard(tint: Color? = nil, compact: Bool = false) -> some View {
+    modifier(WLCardModifier(tint: tint, isCompact: compact))
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLGlassModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLGlassModifier.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Glass effect intensity levels.
+///
+/// Maps to watchOS 26 `GlassEffectStyle` values when available,
+/// falls back to opacity-based translucency on older OS versions.
+enum WLGlassIntensity: Equatable {
+  /// Subtle glass for backgrounds
+  case regular
+  /// Prominent glass for interactive elements
+  case prominent
+}
+
+/// View modifier that applies Liquid Glass styling or a fallback.
+///
+/// On watchOS 26+, this will call `glassEffect(_:in:)`.
+/// On older versions, it applies a translucent material-like
+/// background with border and shadow.
+struct WLGlassModifier: ViewModifier {
+  let intensity: WLGlassIntensity
+  let tint: Color?
+  let cornerRadius: CGFloat
+
+  init(
+    intensity: WLGlassIntensity = .regular,
+    tint: Color? = nil,
+    cornerRadius: CGFloat = WLSpacingTokens.cardCornerRadius
+  ) {
+    self.intensity = intensity
+    self.tint = tint
+    self.cornerRadius = cornerRadius
+  }
+
+  func body(content: Content) -> some View {
+    if WLTheme.isGlassAvailable {
+      // TODO: watchOS 26 — Replace fallback with:
+      // content.glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+      // or .glassEffect(.prominent, ...) based on intensity
+      applyFallback(to: content)
+    } else {
+      applyFallback(to: content)
+    }
+  }
+
+  @ViewBuilder
+  private func applyFallback(to content: Content) -> some View {
+    let fillOpacity = intensity == .prominent
+      ? WLColorTokens.surfaceOpacityMedium
+      : WLColorTokens.surfaceOpacityLow
+
+    content
+      .background(
+        RoundedRectangle(cornerRadius: cornerRadius)
+          .fill((tint ?? Color.white).opacity(fillOpacity))
+          .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius)
+              .stroke(
+                Color.white.opacity(0.15),
+                lineWidth: WLSpacingTokens.cardBorderWidth
+              )
+          )
+      )
+  }
+}
+
+// MARK: - View Extension
+
+extension View {
+  /// Applies Liquid Glass styling (or fallback on older OS).
+  func wlGlass(
+    _ intensity: WLGlassIntensity = .regular,
+    tint: Color? = nil,
+    cornerRadius: CGFloat = WLSpacingTokens.cardCornerRadius
+  ) -> some View {
+    modifier(WLGlassModifier(
+      intensity: intensity,
+      tint: tint,
+      cornerRadius: cornerRadius
+    ))
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLNavigationBarModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLNavigationBarModifier.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Modifier for navigation bar / toolbar area styling.
+///
+/// On watchOS 26+, this will use `safeAreaBar` with glass effect.
+/// On older versions, it hides the default toolbar background.
+struct WLNavigationBarModifier: ViewModifier {
+  let tint: Color?
+
+  init(tint: Color? = nil) {
+    self.tint = tint
+  }
+
+  func body(content: Content) -> some View {
+    if WLTheme.isGlassAvailable {
+      // TODO: watchOS 26 — Apply safeAreaBar with glass:
+      // content.safeAreaBar(edge: .top) {
+      //   Color.clear.glassEffect(.regular, in: .rect)
+      // }
+      applyFallback(to: content)
+    } else {
+      applyFallback(to: content)
+    }
+  }
+
+  private func applyFallback(to content: Content) -> some View {
+    content
+      .toolbarBackground(.hidden, for: .navigationBar)
+  }
+}
+
+// MARK: - View Extension
+
+extension View {
+  /// Applies design-system navigation bar styling.
+  func wlNavigationBar(tint: Color? = nil) -> some View {
+    modifier(WLNavigationBarModifier(tint: tint))
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Preview/DesignSystemPreview.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Preview/DesignSystemPreview.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+// MARK: - Color Tokens Preview
+
+#Preview("Color Tokens") {
+  ScrollView {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("LAYER COLORS")
+        .font(WLTypographyTokens.sectionHeader)
+        .tracking(WLTypographyTokens.sectionHeaderTracking)
+        .foregroundColor(WLColorTokens.labelText)
+
+      LazyVGrid(columns: [
+        GridItem(.flexible()),
+        GridItem(.flexible()),
+        GridItem(.flexible()),
+      ], spacing: 6) {
+        colorSwatch("Beige", WLColorTokens.beige)
+        colorSwatch("Purple", WLColorTokens.purple)
+        colorSwatch("Red", WLColorTokens.red)
+        colorSwatch("Blue", WLColorTokens.blue)
+        colorSwatch("Orange", WLColorTokens.orange)
+        colorSwatch("Green", WLColorTokens.green)
+        colorSwatch("Yellow", WLColorTokens.yellow)
+        colorSwatch("Teal", WLColorTokens.teal)
+        colorSwatch("UV", WLColorTokens.ultraviolet)
+        colorSwatch("Clear", WLColorTokens.clearLight)
+        colorSwatch("Strat", WLColorTokens.strategies)
+      }
+    }
+    .padding()
+  }
+  .background(Color.black)
+}
+
+// MARK: - Card Styles Preview
+
+#Preview("Card Styles") {
+  ScrollView {
+    VStack(spacing: 12) {
+      Text("Standard Card")
+        .foregroundColor(.white)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .wlCard()
+
+      Text("Tinted Card")
+        .foregroundColor(.white)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .wlCard(tint: .blue)
+
+      Text("Compact Card")
+        .foregroundColor(.white)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .wlCard(compact: true)
+    }
+    .padding()
+  }
+  .background(Color.black)
+}
+
+// MARK: - Button Styles Preview
+
+#Preview("Button Styles") {
+  VStack(spacing: 16) {
+    Button("Primary Action") {}
+      .wlPrimaryButtonStyle()
+
+    Button("Primary Tinted") {}
+      .wlPrimaryButtonStyle(tint: .purple)
+
+    Button("Secondary") {}
+      .wlSecondaryButtonStyle()
+
+    Button("Secondary Tinted") {}
+      .wlSecondaryButtonStyle(tint: .blue)
+  }
+  .padding()
+  .background(Color.black)
+}
+
+// MARK: - Glass Intensities Preview
+
+#Preview("Glass Intensities") {
+  VStack(spacing: 16) {
+    Text("Regular Glass")
+      .foregroundColor(.white)
+      .padding()
+      .wlGlass(.regular)
+
+    Text("Prominent Glass")
+      .foregroundColor(.white)
+      .padding()
+      .wlGlass(.prominent)
+
+    Text("Tinted Glass")
+      .foregroundColor(.white)
+      .padding()
+      .wlGlass(.regular, tint: .purple)
+  }
+  .padding()
+  .background(Color.black)
+}
+
+// MARK: - Helper
+
+private func colorSwatch(_ name: String, _ color: Color) -> some View {
+  VStack(spacing: 2) {
+    Circle()
+      .fill(color)
+      .frame(width: 24, height: 24)
+      .shadow(color: color, radius: 2)
+    Text(name)
+      .font(.system(size: 8))
+      .foregroundColor(.white.opacity(0.7))
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Color tokens for the WavelengthWatch design system.
+///
+/// All layer colors, semantic colors, and surface opacities are
+/// defined here. Views should reference these tokens instead of
+/// constructing colors inline.
+enum WLColorTokens {
+  // MARK: - Layer Colors (Spiral Dynamics)
+
+  /// Returns the SwiftUI Color for a named layer, delegating to Color(stage:).
+  static func layer(_ name: String) -> Color {
+    Color(stage: name)
+  }
+
+  static let beige: Color = .brown
+  static let purple: Color = .purple
+  static let red: Color = .red
+  static let blue: Color = .blue
+  static let orange: Color = .orange
+  static let green: Color = .green
+  static let yellow: Color = .yellow
+  static let teal: Color = .teal
+  static let ultraviolet: Color = .indigo
+  static let clearLight: Color = .white
+  static let strategies: Color = .gray
+
+  // MARK: - Semantic Surface Colors
+
+  /// Card background fill (fallback for pre-Glass)
+  static let cardFill = Color.secondary.opacity(0.15)
+
+  /// Card background fill with layer tint
+  static func cardFill(tinted color: Color) -> Color {
+    color.opacity(surfaceOpacitySubtle)
+  }
+
+  /// Elevated card fill (for review sheets, etc.)
+  static let elevatedCardFill = Color.secondary.opacity(0.1)
+
+  // MARK: - Text Colors
+
+  static let primaryText: Color = .white
+  static let secondaryText = Color.white.opacity(0.7)
+  static let tertiaryText = Color.white.opacity(0.5)
+  static let labelText: Color = .secondary
+
+  // MARK: - Surface Opacities
+
+  static let surfaceOpacityHigh: Double = 0.6
+  static let surfaceOpacityMedium: Double = 0.3
+  static let surfaceOpacityLow: Double = 0.1
+  static let surfaceOpacitySubtle: Double = 0.08
+
+  // MARK: - Background Gradients
+
+  /// Standard dark page background gradient
+  static func pageBackground() -> LinearGradient {
+    LinearGradient(
+      gradient: Gradient(colors: [Color.black, Color.black.opacity(0.8)]),
+      startPoint: .top,
+      endPoint: .bottom
+    )
+  }
+
+  /// Layer-tinted card gradient
+  static func cardGradient(_ color: Color) -> LinearGradient {
+    LinearGradient(
+      gradient: Gradient(colors: [
+        color.opacity(surfaceOpacityMedium),
+        color.opacity(surfaceOpacityLow),
+      ]),
+      startPoint: .topLeading,
+      endPoint: .bottomTrailing
+    )
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLSpacingTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLSpacingTokens.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Spacing and layout tokens for consistent sizing.
+///
+/// These supplement `UIConstants` (which holds component-specific
+/// dimensions) with general-purpose spacing values.
+enum WLSpacingTokens {
+  // MARK: - Padding
+
+  static let paddingXS: CGFloat = 4
+  static let paddingS: CGFloat = 8
+  static let paddingM: CGFloat = 12
+  static let paddingL: CGFloat = 16
+  static let paddingXL: CGFloat = 20
+
+  // MARK: - Card Properties
+
+  static let cardCornerRadius: CGFloat = 12
+  static let cardCornerRadiusSmall: CGFloat = 8
+  static let cardCornerRadiusCompact: CGFloat = 6
+  static let cardBorderWidth: CGFloat = 0.5
+  static let cardPaddingStandard: CGFloat = 12
+  static let cardPaddingCompact: CGFloat = 8
+
+  // MARK: - Indicator Sizes
+
+  static let indicatorDotSmall: CGFloat = 6
+  static let indicatorDotMedium: CGFloat = 10
+
+  // MARK: - Component Spacing
+
+  static let listItemSpacing: CGFloat = 8
+  static let sectionSpacing: CGFloat = 16
+  static let cardContentSpacing: CGFloat = 4
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLTheme.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLTheme.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Central namespace for the WavelengthWatch design system.
+///
+/// Provides access to color, typography, and spacing tokens,
+/// plus the `isGlassAvailable` flag used by modifiers to
+/// branch between Liquid Glass and fallback styling.
+enum WLTheme {
+  typealias Colors = WLColorTokens
+  typealias Typography = WLTypographyTokens
+  typealias Spacing = WLSpacingTokens
+
+  /// Whether Liquid Glass APIs are available at runtime.
+  ///
+  /// Checks watchOS 26 availability. On older versions, all Glass
+  /// modifiers degrade to fallback styling automatically.
+  ///
+  /// - Note: Until Xcode 18 ships with the watchOS 26 SDK, this
+  ///   always returns `false`. Remove the early return when the
+  ///   SDK is available.
+  static var isGlassAvailable: Bool {
+    // TODO: watchOS 26 — Remove early return when Xcode 18 SDK ships
+    false
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLTypographyTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLTypographyTokens.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Typography tokens for consistent text styling.
+///
+/// Each token represents a semantic text role (page title,
+/// section header, body, caption, etc.) rather than a raw font size.
+enum WLTypographyTokens {
+  // MARK: - Page-Level
+
+  /// Page/section title (e.g., phase name hero text)
+  static let pageTitle: Font = .title3
+  static let pageTitleWeight: Font.Weight = .medium
+
+  /// Section header (e.g., "MEDICINAL", "STRATEGIES")
+  static let sectionHeader: Font = .caption
+  static let sectionHeaderWeight: Font.Weight = .medium
+  static let sectionHeaderTracking: CGFloat = 1.5
+
+  // MARK: - Card-Level
+
+  /// Card title (expression text)
+  static let cardTitle: Font = .body
+  static let cardTitleWeight: Font.Weight = .medium
+
+  /// Card title in compact mode
+  static let cardTitleCompact: Font = .body
+  static let cardTitleCompactWeight: Font.Weight = .bold
+
+  /// Card subtitle / context text
+  static let cardSubtitle: Font = .caption
+  static let cardSubtitleWeight: Font.Weight = .medium
+
+  // MARK: - Supporting
+
+  /// Tag / badge text
+  static let tag: Font = .caption2
+
+  /// Layer context label
+  static let contextLabel: Font = .caption2
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLButtonStyleTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLButtonStyleTests.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+struct WLButtonStyleTests {
+  @Test func primaryStyle_defaultTint_isAccentColor() {
+    let style = WLPrimaryButtonStyle()
+    #expect(style.tint == .accentColor)
+  }
+
+  @Test func primaryStyle_customTint_isPreserved() {
+    let style = WLPrimaryButtonStyle(tint: .red)
+    #expect(style.tint == .red)
+  }
+
+  @Test func secondaryStyle_defaultTint_isSecondary() {
+    let style = WLSecondaryButtonStyle()
+    #expect(style.tint == .secondary)
+  }
+
+  @Test func secondaryStyle_customTint_isPreserved() {
+    let style = WLSecondaryButtonStyle(tint: .blue)
+    #expect(style.tint == .blue)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLCardModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLCardModifierTests.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+struct WLCardModifierTests {
+  @Test func defaultCard_hasNoTint() {
+    let modifier = WLCardModifier()
+    #expect(modifier.tint == nil)
+  }
+
+  @Test func defaultCard_isNotCompact() {
+    let modifier = WLCardModifier()
+    #expect(modifier.isCompact == false)
+  }
+
+  @Test func tintedCard_preservesTint() {
+    let modifier = WLCardModifier(tint: .red)
+    #expect(modifier.tint == .red)
+  }
+
+  @Test func compactCard_isCompact() {
+    let modifier = WLCardModifier(isCompact: true)
+    #expect(modifier.isCompact == true)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLColorTokensTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLColorTokensTests.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+struct WLColorTokensTests {
+  @Test func namedLayerColors_areNotNil() {
+    let colors: [Color] = [
+      WLColorTokens.beige,
+      WLColorTokens.purple,
+      WLColorTokens.red,
+      WLColorTokens.blue,
+      WLColorTokens.orange,
+      WLColorTokens.green,
+      WLColorTokens.yellow,
+      WLColorTokens.teal,
+      WLColorTokens.ultraviolet,
+      WLColorTokens.clearLight,
+      WLColorTokens.strategies,
+    ]
+    #expect(colors.count == 11)
+  }
+
+  @Test func layerFunction_delegatesToColorStage() {
+    // Known mapping: "Red" -> .red (Color+Stage uses capitalized names)
+    let color = WLColorTokens.layer("Red")
+    #expect(color == Color.red)
+  }
+
+  @Test func layerFunction_unknownName_returnsGray() {
+    let color = WLColorTokens.layer("nonexistent")
+    #expect(color == Color.gray)
+  }
+
+  @Test func surfaceOpacities_areOrdered() {
+    #expect(WLColorTokens.surfaceOpacitySubtle < WLColorTokens.surfaceOpacityLow)
+    #expect(WLColorTokens.surfaceOpacityLow < WLColorTokens.surfaceOpacityMedium)
+    #expect(WLColorTokens.surfaceOpacityMedium < WLColorTokens.surfaceOpacityHigh)
+  }
+
+  @Test func surfaceOpacities_areInValidRange() {
+    let opacities = [
+      WLColorTokens.surfaceOpacitySubtle,
+      WLColorTokens.surfaceOpacityLow,
+      WLColorTokens.surfaceOpacityMedium,
+      WLColorTokens.surfaceOpacityHigh,
+    ]
+    for opacity in opacities {
+      #expect(opacity > 0 && opacity <= 1.0)
+    }
+  }
+
+  @Test func semanticColors_areDefined() {
+    // Verify semantic colors exist (compile-time check mostly, but validates they're accessible)
+    _ = WLColorTokens.cardFill
+    _ = WLColorTokens.elevatedCardFill
+    _ = WLColorTokens.primaryText
+    _ = WLColorTokens.secondaryText
+    _ = WLColorTokens.tertiaryText
+    _ = WLColorTokens.labelText
+  }
+
+  @Test func cardFillTinted_producesColor() {
+    let tinted = WLColorTokens.cardFill(tinted: .blue)
+    #expect(tinted != Color.clear)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLGlassModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLGlassModifierTests.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+struct WLGlassModifierTests {
+  @Test func defaultIntensity_isRegular() {
+    let modifier = WLGlassModifier()
+    #expect(modifier.intensity == .regular)
+  }
+
+  @Test func prominentIntensity_isDistinct() {
+    let regular = WLGlassModifier(intensity: .regular)
+    let prominent = WLGlassModifier(intensity: .prominent)
+    #expect(regular.intensity != prominent.intensity)
+  }
+
+  @Test func defaultCornerRadius_matchesToken() {
+    let modifier = WLGlassModifier()
+    #expect(modifier.cornerRadius == WLSpacingTokens.cardCornerRadius)
+  }
+
+  @Test func customCornerRadius_isPreserved() {
+    let modifier = WLGlassModifier(cornerRadius: 20)
+    #expect(modifier.cornerRadius == 20)
+  }
+
+  @Test func tint_defaultsToNil() {
+    let modifier = WLGlassModifier()
+    #expect(modifier.tint == nil)
+  }
+
+  @Test func tint_isPreserved() {
+    let modifier = WLGlassModifier(tint: .blue)
+    #expect(modifier.tint == .blue)
+  }
+
+  @Test func glassAvailable_returnsFalseOnCurrentSDK() {
+    // Until Xcode 18 ships, Glass APIs are not available
+    #expect(WLTheme.isGlassAvailable == false)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLSpacingTokensTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLSpacingTokensTests.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+struct WLSpacingTokensTests {
+  @Test func padding_isOrdered() {
+    #expect(WLSpacingTokens.paddingXS < WLSpacingTokens.paddingS)
+    #expect(WLSpacingTokens.paddingS < WLSpacingTokens.paddingM)
+    #expect(WLSpacingTokens.paddingM < WLSpacingTokens.paddingL)
+    #expect(WLSpacingTokens.paddingL < WLSpacingTokens.paddingXL)
+  }
+
+  @Test func cornerRadius_isOrdered() {
+    #expect(WLSpacingTokens.cardCornerRadiusCompact < WLSpacingTokens.cardCornerRadiusSmall)
+    #expect(WLSpacingTokens.cardCornerRadiusSmall < WLSpacingTokens.cardCornerRadius)
+  }
+
+  @Test func borderWidth_isPositive() {
+    #expect(WLSpacingTokens.cardBorderWidth > 0)
+  }
+
+  @Test func allValues_arePositive() {
+    let values: [CGFloat] = [
+      WLSpacingTokens.paddingXS,
+      WLSpacingTokens.paddingS,
+      WLSpacingTokens.paddingM,
+      WLSpacingTokens.paddingL,
+      WLSpacingTokens.paddingXL,
+      WLSpacingTokens.cardCornerRadius,
+      WLSpacingTokens.cardCornerRadiusSmall,
+      WLSpacingTokens.cardCornerRadiusCompact,
+      WLSpacingTokens.cardPaddingStandard,
+      WLSpacingTokens.cardPaddingCompact,
+      WLSpacingTokens.indicatorDotSmall,
+      WLSpacingTokens.indicatorDotMedium,
+      WLSpacingTokens.listItemSpacing,
+      WLSpacingTokens.sectionSpacing,
+      WLSpacingTokens.cardContentSpacing,
+    ]
+    for value in values {
+      #expect(value > 0)
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLTypographyTokensTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLTypographyTokensTests.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+struct WLTypographyTokensTests {
+  @Test func allFonts_areDefined() {
+    let fonts: [Font] = [
+      WLTypographyTokens.pageTitle,
+      WLTypographyTokens.sectionHeader,
+      WLTypographyTokens.cardTitle,
+      WLTypographyTokens.cardTitleCompact,
+      WLTypographyTokens.cardSubtitle,
+      WLTypographyTokens.tag,
+      WLTypographyTokens.contextLabel,
+    ]
+    #expect(fonts.count == 7)
+  }
+
+  @Test func sectionHeaderTracking_isPositive() {
+    #expect(WLTypographyTokens.sectionHeaderTracking > 0)
+  }
+
+  @Test func fontWeights_areDefined() {
+    let weights: [Font.Weight] = [
+      WLTypographyTokens.pageTitleWeight,
+      WLTypographyTokens.sectionHeaderWeight,
+      WLTypographyTokens.cardTitleWeight,
+      WLTypographyTokens.cardTitleCompactWeight,
+      WLTypographyTokens.cardSubtitleWeight,
+    ]
+    #expect(weights.count == 5)
+  }
+}

--- a/frontend/WavelengthWatch/run-tests-individually.sh
+++ b/frontend/WavelengthWatch/run-tests-individually.sh
@@ -67,6 +67,12 @@ ALL_SUITES=(
   "StrategyUsageViewTests"
   "TemporalPatternsViewTests"
   "GrowthIndicatorsViewTests"
+  "WLColorTokensTests"
+  "WLSpacingTokensTests"
+  "WLTypographyTokensTests"
+  "WLGlassModifierTests"
+  "WLCardModifierTests"
+  "WLButtonStyleTests"
 )
 
 # Parse arguments


### PR DESCRIPTION
## Summary
- Creates a complete design system layer under `DesignSystem/` with color, typography, and spacing tokens
- Implements Glass-ready modifiers (`wlGlass`, `wlCard`, `wlNavigationBar`, `wlPrimaryButtonStyle`, `wlSecondaryButtonStyle`) that degrade gracefully on pre-watchOS 26
- `WLTheme.isGlassAvailable` provides single branch point for Glass vs fallback — all `// TODO: watchOS 26` markers ready for Xcode 18 SDK
- Phase 1b of the Frontend Liquid Glass Rebuild epic (#292)

## Files Created

### Theme Tokens (4 files)
- `WLColorTokens.swift` — Layer colors, semantic surfaces, opacities, gradients
- `WLTypographyTokens.swift` — Semantic font/weight tokens
- `WLSpacingTokens.swift` — Padding, corner radius, indicator sizes
- `WLTheme.swift` — Central namespace with `isGlassAvailable` flag

### Modifiers (4 files)
- `WLGlassModifier.swift` — Core glass abstraction with `.wlGlass()` extension
- `WLCardModifier.swift` — Card styling with `.wlCard()` extension
- `WLNavigationBarModifier.swift` — Nav bar styling with `.wlNavigationBar()`
- `WLButtonStyle.swift` — Primary/secondary button styles

### Preview & Tests (7 files)
- `DesignSystemPreview.swift` — Visual catalog of all tokens and modifiers
- 6 test suites: color, spacing, typography, glass, card, button

## Test plan
- [x] All 43 test suites pass (37 existing + 6 new)
- [x] Pre-commit hooks pass (SwiftFormat, detect-secrets, etc.)
- [x] Build succeeds for watchOS target
- [x] No changes to existing views — additive only


🤖 Generated with [Claude Code](https://claude.com/claude-code)