### PR TITLE
chore: Xcode 26.3 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+      - name: Select latest Xcode
+        run: |
+          # Prefer Xcode 18 (26.x) if available, fall back to 16.4
+          if [ -d /Applications/Xcode_26.app ]; then
+            sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
+          else
+            sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+          fi
 
       - name: Install SwiftFormat
         run: brew install swiftformat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ swiftformat frontend
 swiftformat --lint frontend  # Check formatting without modifying
 
 # Build (use Xcode for running)
-# Open frontend/WavelengthWatch/WavelengthWatch.xcodeproj in Xcode 16.4+
+# Open frontend/WavelengthWatch/WavelengthWatch.xcodeproj in Xcode 16.4+ (or Xcode 18+)
 # Select Apple Watch target and build/run
 
 # Testing

--- a/frontend/WavelengthWatch/WavelengthWatch.xcodeproj/project.pbxproj
+++ b/frontend/WavelengthWatch/WavelengthWatch.xcodeproj/project.pbxproj
@@ -225,8 +225,8 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1640;
-				LastUpgradeCheck = 1640;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					676DA3A92E7204A500C63894 = {
 						CreatedOnToolsVersion = 16.4;

--- a/frontend/WavelengthWatch/run-tests-individually.sh
+++ b/frontend/WavelengthWatch/run-tests-individually.sh
@@ -22,8 +22,13 @@ set -e  # Exit on first failure
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 SCHEME="WavelengthWatch Watch App"
-# Use a commonly available simulator across different Xcode/CI versions
-DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)"
+# Pick the best available large-face watchOS simulator.
+# Xcode 18+ (watchOS 26) ships Series 11; Xcode 16.x ships Series 10.
+if xcrun simctl list devices available 2>/dev/null | grep -q "Apple Watch Series 11 (46mm)"; then
+  DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)"
+else
+  DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)"
+fi
 TEST_TARGET="WavelengthWatch Watch AppTests"
 PROJECT_PATH="$SCRIPT_DIR/WavelengthWatch.xcodeproj"
 DERIVED_DATA_PATH="$SCRIPT_DIR/.test-cache"


### PR DESCRIPTION
## Summary
- Bump `LastUpgradeCheck` / `LastSwiftUpdateCheck` from 1640 → 2630 in pbxproj (suppresses "Update to recommended settings" nag)
- CI workflow: auto-detect Xcode 26 (`Xcode_26.app`) with fallback to 16.4
- Test script: auto-detect Apple Watch Series 11 simulator with fallback to Series 10
- CLAUDE.md: note Xcode 18+ support

Keeps `SWIFT_VERSION = 5.0` and all deployment targets unchanged.

## Test plan
- [ ] Open project in Xcode 26.3 — confirm no "recommended settings" prompt
- [ ] Build and run on watchOS 26.2 simulator (Series 11)
- [ ] Run `frontend/WavelengthWatch/run-tests-individually.sh` — passes with Series 11 sim
- [ ] CI passes on GitHub Actions (macos-15 runner with Xcode 16.4 fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)