### PR TITLE
chore: Add Claude skills and track agent system

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,240 @@
+# Claude Agent System
+
+This directory contains the agent orchestration system for WavelengthWatch, adapted from the ml-odyssey repository.
+
+## Overview
+
+The agent system provides a hierarchical structure for delegating complex tasks to specialized agents. This ensures focused expertise, clear responsibility boundaries, and efficient collaboration.
+
+## Directory Structure
+
+```
+.claude/
+├── README.md              # This file
+├── agents/                # Agent definitions
+│   ├── chief-architect.md           # Level 0: Strategic orchestrator
+│   ├── frontend-orchestrator.md     # Level 1: Frontend implementation
+│   ├── backend-orchestrator.md      # Level 1: Backend implementation
+│   ├── testing-orchestrator.md      # Level 1: Testing strategy
+│   ├── cicd-orchestrator.md         # Level 1: CI/CD & automation
+│   └── documentation-orchestrator.md # Level 1: Documentation
+├── shared/                # Shared constraints and rules
+│   ├── common-constraints.md
+│   ├── documentation-rules.md
+│   └── error-handling.md
+├── skills/                # Reusable skills (reserved for future use)
+└── commands/              # Custom commands (reserved for future use)
+```
+
+## Agent Hierarchy
+
+For detailed hierarchy information, see:
+- **[agents/hierarchy.md](agents/hierarchy.md)** - Visual diagram and quick reference
+- **[agents/agent-hierarchy.md](agents/agent-hierarchy.md)** - Complete specification with examples
+- **[agents/delegation-rules.md](agents/delegation-rules.md)** - Coordination and delegation patterns
+
+### Level 0: Chief Architect
+**File:** `agents/chief-architect.md`
+**Model:** opus
+**Role:** Strategic orchestrator for system-wide decisions
+
+**When to use:**
+- Repository-wide architectural decisions
+- Cross-section coordination (frontend + backend)
+- Feature epic planning
+- Technology stack decisions
+- Breaking down large initiatives into coordinated tasks
+
+**Delegates to:**
+- Frontend Orchestrator
+- Backend Orchestrator
+- Testing Orchestrator
+- CI/CD Orchestrator
+- Documentation Orchestrator
+
+### Level 1: Section Orchestrators
+
+#### Frontend Orchestrator
+**File:** `agents/frontend-orchestrator.md`
+**Model:** sonnet
+**Role:** watchOS SwiftUI implementation
+
+**Responsibilities:**
+- SwiftUI views and components
+- ViewModels and state management
+- Navigation patterns
+- Service layer integration
+- UI testing
+
+#### Backend Orchestrator
+**File:** `agents/backend-orchestrator.md`
+**Model:** sonnet
+**Role:** FastAPI backend implementation
+
+**Responsibilities:**
+- API endpoints and routers
+- SQLModel database models
+- Pydantic schemas
+- Business logic
+- Backend testing
+
+#### Testing Orchestrator
+**File:** `agents/testing-orchestrator.md`
+**Model:** sonnet
+**Role:** Comprehensive testing strategy
+
+**Responsibilities:**
+- Test planning and implementation
+- Coverage analysis (>90% backend)
+- Manual testing coordination
+- Quality gates
+
+#### CI/CD Orchestrator
+**File:** `agents/cicd-orchestrator.md`
+**Model:** sonnet
+**Role:** Pipeline and automation
+
+**Responsibilities:**
+- GitHub Actions workflows
+- Pre-commit hooks
+- Quality gates
+- Build automation
+
+#### Documentation Orchestrator
+**File:** `agents/documentation-orchestrator.md`
+**Model:** sonnet
+**Role:** Documentation strategy
+
+**Responsibilities:**
+- README and guide maintenance
+- API documentation
+- Architecture documentation
+- Process documentation
+
+## How to Use
+
+### Using the Chief Architect
+
+When you have a large, complex task that spans multiple areas:
+
+```
+@chief-architect I need to implement a new feature that allows users to
+view their journal history in a SwiftUI list view, backed by a new API
+endpoint. Please coordinate the implementation across frontend, backend,
+and testing.
+```
+
+The chief-architect will:
+1. Analyze the requirements
+2. Define the architecture and interfaces
+3. Break down into subtasks
+4. Delegate to appropriate orchestrators
+5. Monitor progress and resolve conflicts
+
+### Using Section Orchestrators
+
+When you have a task scoped to a specific area:
+
+```
+@frontend-orchestrator Implement the JournalHistoryView SwiftUI component
+according to the design in issue #126.
+```
+
+```
+@backend-orchestrator Create a new /api/v1/journal/history endpoint that
+returns paginated journal entries for a user.
+```
+
+### Agent Selection Guide
+
+| Task Type | Agent to Use |
+|-----------|-------------|
+| Large epic spanning multiple areas | chief-architect |
+| Frontend UI implementation | frontend-orchestrator |
+| Backend API endpoint | backend-orchestrator |
+| Test strategy or coverage | testing-orchestrator |
+| CI/CD pipeline update | cicd-orchestrator |
+| Documentation creation/update | documentation-orchestrator |
+
+## Shared Constraints
+
+All agents follow the constraints defined in `shared/`:
+
+### Common Constraints
+- **Minimal changes principle**: Make the smallest change that solves the problem
+- **Scope discipline**: Complete assigned task, nothing more
+- **No work without issue**: All work must be tracked via GitHub issues
+
+### Documentation Rules
+- Never create documentation files unless explicitly requested
+- Always prefer editing existing docs to creating new ones
+- Keep documentation concise and actionable
+
+### Error Handling
+- Fix root causes, not symptoms
+- No shortcuts or workarounds
+- Never comment out failing tests
+- Never use linter bypass comments
+
+## Why This is Gitignored
+
+This `.claude/` directory is copied from the ml-odyssey repository and is NOT checked into version control for WavelengthWatch.
+
+**Reasons:**
+1. **Experimental**: Agent system is still evolving
+2. **Local tool**: Intended for development workflow, not production code
+3. **Easy updates**: Can pull latest from ml-odyssey without conflicts
+4. **Repository-specific**: May diverge from ml-odyssey over time
+
+**To update from ml-odyssey:**
+```bash
+# From WavelengthWatchRoot/
+cp -r ../ml-odyssey/.claude/agents/*.md .claude/agents/
+cp -r ../ml-odyssey/.claude/shared/*.md .claude/shared/
+```
+
+## Examples
+
+### Example 1: Multi-Step Emotion Logging Flow (Epic #92)
+
+**Chief Architect coordinates:**
+1. Frontend Orchestrator → Implement SwiftUI flow views
+2. Backend Orchestrator → Create journal submission endpoint
+3. Testing Orchestrator → Implement integration tests
+4. Documentation Orchestrator → Update API docs
+
+### Example 2: Bug Fix (Black screen crash #123)
+
+**Direct to Frontend Orchestrator:**
+- No need for chief-architect (single-area task)
+- Frontend Orchestrator investigates and fixes the crash
+- Testing Orchestrator verifies fix with tests
+
+### Example 3: New Feature (Journal History View)
+
+**Chief Architect coordinates:**
+1. Define API contract between frontend/backend
+2. Delegate frontend ListView to Frontend Orchestrator
+3. Delegate backend pagination endpoint to Backend Orchestrator
+4. Delegate tests to Testing Orchestrator
+5. Monitor integration and resolve any contract mismatches
+
+## Tips for Effective Use
+
+1. **Start with Chief Architect** for anything touching multiple areas
+2. **Use specific orchestrators** for focused, single-area tasks
+3. **Reference GitHub issues** - all agents expect issue numbers
+4. **Be explicit** about requirements and constraints
+5. **Review delegation** - agents will explain their plan before executing
+
+## Future Enhancements
+
+- Custom skills for WavelengthWatch-specific patterns
+- Custom commands for common workflows
+- Specialist agents for specific tasks (SwiftUI animations, API optimization)
+- Integration with GitHub workflows
+
+---
+
+**Source:** Adapted from [ml-odyssey/.claude](../../ml-odyssey/.claude)
+**Last Updated:** 2025-12-07

--- a/.claude/agents/agent-hierarchy.md
+++ b/.claude/agents/agent-hierarchy.md
@@ -1,0 +1,412 @@
+# Agent Hierarchy - Complete Specification
+
+## Overview
+
+This document defines the complete 2-level agent hierarchy for the WavelengthWatch project. Each level has
+distinct responsibilities, scope, and delegation patterns.
+
+## Hierarchy Diagram
+
+```text
+Level 0: Meta-Orchestrator
+    │
+    ├─> Chief Architect Agent
+    │       │
+    │       ▼
+Level 1: Section Orchestrators
+    │
+    ├─> Frontend Orchestrator (watchOS SwiftUI)
+    ├─> Backend Orchestrator (FastAPI + SQLModel)
+    ├─> Testing Orchestrator
+    ├─> CI/CD Orchestrator
+    └─> Documentation Orchestrator
+```
+
+---
+
+## Level 0: Meta-Orchestrator
+
+### Chief Architect Agent
+
+**Scope**: Entire repository ecosystem
+
+**Responsibilities**:
+- Plan features that span frontend and backend
+- Define repository-wide architectural patterns
+- Establish API contracts between watch and backend
+- Coordinate across all section orchestrators
+- Resolve conflicts between section orchestrators
+- Make technology stack decisions
+- Monitor overall project health
+
+**Inputs**:
+- User requirements
+- Feature requests
+- GitHub issues
+- Project goals
+
+**Outputs**:
+- High-level roadmap
+- Architectural decision records (ADRs)
+- API contract definitions
+- Section assignments
+- Cross-section dependency coordination
+
+**Delegates To**: Section Orchestrators (Level 1)
+
+**Coordinates With**: External stakeholders, product requirements
+
+**Decision Scope**: System-wide (multiple sections)
+
+**Workflow Phase**: Primarily Plan phase, oversight in all phases
+
+**Configuration File**: `.claude/agents/chief-architect.md`
+
+---
+
+## Level 1: Section Orchestrators
+
+### Frontend Orchestrator
+
+**Scope**: watchOS SwiftUI application
+
+**Responsibilities**:
+- Coordinate SwiftUI view development
+- Manage ViewModels and state management
+- Oversee navigation patterns (TabView, dual-axis scrolling)
+- Integrate with backend services via JournalClient and other services
+- Ensure watchOS-specific patterns are followed
+- Coordinate frontend testing with XCTest
+
+**Delegates To**: Implementation tasks (SwiftUI code, ViewModels, Services)
+
+**Artifacts**: SwiftUI views, ViewModels, Service layer code, frontend tests
+
+**Technologies**:
+- Swift 5.9+
+- SwiftUI for watchOS
+- Combine for reactive patterns
+- UserDefaults for local storage
+- SQLite for local journal entries
+
+**Configuration File**: `.claude/agents/frontend-orchestrator.md`
+
+### Backend Orchestrator
+
+**Scope**: FastAPI backend service
+
+**Responsibilities**:
+- Design and implement API endpoints under `/api/v1/`
+- Manage SQLModel database models
+- Create Pydantic schemas for validation
+- Implement business logic and data processing
+- Ensure >90% test coverage
+- Coordinate backend testing with pytest
+
+**Delegates To**: Implementation tasks (routers, schemas, models)
+
+**Artifacts**: FastAPI routers, SQLModel models, Pydantic schemas, backend tests
+
+**Technologies**:
+- Python 3.11+
+- FastAPI for API framework
+- SQLModel for ORM
+- Pydantic for validation
+- SQLite for database
+- pytest for testing
+
+**Configuration File**: `.claude/agents/backend-orchestrator.md`
+
+### Testing Orchestrator
+
+**Scope**: Test strategy across frontend and backend
+
+**Responsibilities**:
+- Design comprehensive test strategies
+- Coordinate >90% backend test coverage
+- Plan frontend XCTest suite
+- Create integration test plans
+- Coordinate manual testing when needed
+- Ensure quality gates are met
+
+**Delegates To**: Test implementation tasks
+
+**Artifacts**: Test plans, test cases, coverage reports, quality metrics
+
+**Technologies**:
+- pytest (backend)
+- XCTest (frontend)
+- GitHub Actions for CI testing
+
+**Configuration File**: `.claude/agents/testing-orchestrator.md`
+
+### CI/CD Orchestrator
+
+**Scope**: Continuous integration and deployment
+
+**Responsibilities**:
+- Design and maintain GitHub Actions workflows
+- Manage pre-commit hooks
+- Ensure quality gates are enforced
+- Coordinate build automation
+- Monitor CI/CD pipeline health
+
+**Delegates To**: Workflow implementation and maintenance
+
+**Artifacts**: GitHub Actions workflows, pre-commit configs, build scripts
+
+**Technologies**:
+- GitHub Actions
+- pre-commit hooks
+- SwiftFormat
+- Ruff (Python linter)
+- Mypy (Python type checker)
+
+**Configuration File**: `.claude/agents/cicd-orchestrator.md`
+
+### Documentation Orchestrator
+
+**Scope**: Repository documentation
+
+**Responsibilities**:
+- Maintain README and setup guides
+- Create and update API documentation
+- Write architecture documentation
+- Document development processes
+- Ensure documentation stays current with code changes
+
+**Delegates To**: Documentation writing and updates
+
+**Artifacts**: README files, API docs, architecture docs, process guides
+
+**Technologies**:
+- Markdown
+- GitHub wiki (if used)
+- Code comments and docstrings
+
+**Configuration File**: `.claude/agents/documentation-orchestrator.md`
+
+---
+
+## WavelengthWatch-Specific Patterns
+
+### Offline-First Architecture
+
+**Chief Architect** coordinates:
+- Local-first data storage strategy
+- Sync strategy with backend
+- Conflict resolution patterns
+
+**Frontend Orchestrator** implements:
+- Local journal entry storage (SQLite)
+- Sync status tracking
+- Optimistic UI updates
+
+**Backend Orchestrator** implements:
+- Journal sync endpoints
+- Conflict detection and resolution
+
+### Dual-Axis Navigation
+
+**Frontend Orchestrator** handles:
+- Outer TabView (vertical layers: Strategies, Beige, Purple, etc.)
+- Inner TabView (horizontal phases: Rising, Peaking, etc.)
+- 90° rotation for vertical scrolling
+- Navigation state management
+
+### Journal System Integration
+
+**Chief Architect** defines:
+- Journal data model across Swift and Python
+- API contract for journal submission
+- Local vs cloud storage strategy
+
+**Frontend Orchestrator** implements:
+- `LocalJournalEntry` model
+- Journal submission UI flow
+- Local SQLite storage
+
+**Backend Orchestrator** implements:
+- `Journal` SQLModel table
+- POST `/api/v1/journal` endpoint
+- Hydrated responses with relationships
+
+### Curriculum and Strategy Data
+
+**Chief Architect** coordinates:
+- Embedded JSON strategy (offline-first)
+- Backend refresh strategy
+- Data versioning approach
+
+**Frontend Orchestrator** implements:
+- Bundled JSON parsing
+- Background refresh from `/api/v1/catalog`
+- Data model updates
+
+**Backend Orchestrator** implements:
+- `/api/v1/catalog` endpoint
+- CSV to JSON conversion (build-time)
+- Database seeding from fixtures
+
+---
+
+## Delegation Patterns for WavelengthWatch
+
+### Pattern 1: New Feature Epic (Multi-Section)
+
+```text
+Chief Architect
+  ├─> Defines feature requirements
+  ├─> Designs API contracts
+  ├─> Delegates to Frontend Orchestrator
+  ├─> Delegates to Backend Orchestrator
+  └─> Delegates to Testing Orchestrator
+```
+
+**Example**: Multi-step emotion logging flow
+- Chief defines: UI flow stages, API submission contract, data models
+- Frontend implements: SwiftUI views, ViewModels, service integration
+- Backend implements: Journal endpoint, validation, database storage
+- Testing verifies: End-to-end flow, edge cases, error handling
+
+### Pattern 2: Frontend-Only Feature
+
+```text
+Frontend Orchestrator
+  ├─> Implements SwiftUI views
+  ├─> Creates ViewModels
+  └─> Adds frontend tests
+```
+
+**Example**: New animation or UI improvement
+- No Chief Architect coordination needed (no backend changes)
+
+### Pattern 3: Backend-Only Enhancement
+
+```text
+Backend Orchestrator
+  ├─> Implements new endpoint or logic
+  ├─> Updates database models
+  └─> Adds backend tests
+```
+
+**Example**: Performance optimization or new analytics query
+- No Chief Architect coordination needed (no API contract change)
+
+### Pattern 4: API Contract Change
+
+```text
+Chief Architect
+  ├─> Analyzes impact on frontend and backend
+  ├─> Coordinates contract update
+  ├─> Delegates to Frontend Orchestrator (update models/services)
+  ├─> Delegates to Backend Orchestrator (update schemas/endpoints)
+  └─> Delegates to Testing Orchestrator (update integration tests)
+```
+
+**Example**: Adding new field to journal submission
+- Requires coordination to ensure both sides update together
+
+---
+
+## Decision Authority Matrix
+
+| Decision Type | Chief Architect | Section Orchestrator |
+|---------------|-----------------|---------------------|
+| Feature planning | ✅ Owns | Provides input |
+| API contract definition | ✅ Owns | Implements |
+| Technology stack | ✅ Owns | Provides expertise |
+| Implementation approach | Provides guidance | ✅ Owns |
+| Code structure | Provides patterns | ✅ Owns |
+| Testing strategy | Provides goals | ✅ Owns details |
+| Documentation structure | Provides vision | ✅ Owns execution |
+
+---
+
+## Escalation Paths
+
+### When to Escalate to Chief Architect
+
+**Frontend Orchestrator escalates when**:
+- API contract doesn't match needs
+- Architectural pattern unclear
+- Conflict with backend implementation
+- Feature scope ambiguous
+
+**Backend Orchestrator escalates when**:
+- API contract change needed
+- Database schema migration required
+- Performance requires architectural change
+- Security concern identified
+
+**Testing Orchestrator escalates when**:
+- Quality gates not achievable
+- Integration issues across sections
+- Test infrastructure changes needed
+
+**CI/CD Orchestrator escalates when**:
+- Workflow changes affect multiple sections
+- Quality gate definitions needed
+- Build process architectural changes
+
+**Documentation Orchestrator escalates when**:
+- Documentation structure changes needed
+- Cross-section documentation conflicts
+
+---
+
+## Coordination Examples
+
+### Example 1: Journal History Feature
+
+**Chief Architect**:
+1. Defines API contract: `GET /api/v1/journal/history?user_id=X&limit=50`
+2. Specifies response schema with pagination
+3. Delegates implementation
+
+**Frontend Orchestrator**:
+- Creates `JournalHistoryView` SwiftUI list
+- Updates `JournalClient` with history fetch
+- Implements pagination UI
+
+**Backend Orchestrator**:
+- Creates `/api/v1/journal/history` endpoint
+- Implements pagination logic
+- Returns hydrated entries with relationships
+
+**Testing Orchestrator**:
+- Tests pagination edge cases
+- Verifies frontend-backend integration
+- Ensures offline behavior works
+
+### Example 2: Performance Bug (Black Screen Crash)
+
+**Direct to Frontend Orchestrator** (no Chief Architect needed):
+- Investigate crash in `ContentView`
+- Fix `@StateObject` initialization
+- Add regression test
+- Report completion
+
+### Example 3: New Sync Strategy
+
+**Chief Architect coordinates**:
+- Evaluates current sync limitations
+- Designs new sync strategy (incremental vs full)
+- Defines sync API contract
+- Delegates to orchestrators
+
+**Frontend & Backend Orchestrators**:
+- Implement respective sides of sync
+- Coordinate on sync protocol details
+- Add sync status indicators (frontend)
+- Add sync endpoints (backend)
+
+---
+
+## See Also
+
+- [hierarchy.md](hierarchy.md) - Visual hierarchy quick reference
+- [delegation-rules.md](delegation-rules.md) - Detailed delegation patterns
+- [common-constraints.md](../shared/common-constraints.md) - Shared constraints
+- [README.md](../README.md) - Agent system overview
+- [/CLAUDE.md](../../CLAUDE.md) - Repository-wide development guidelines

--- a/.claude/agents/backend-orchestrator.md
+++ b/.claude/agents/backend-orchestrator.md
@@ -1,0 +1,64 @@
+---
+name: backend-orchestrator
+description: "Orchestrates FastAPI backend development. Handles API endpoints, database models, business logic, and data management."
+level: 1
+phase: Implementation
+tools: Read,Write,Edit,Grep,Glob,Task,Bash
+model: sonnet
+delegates_to: []
+receives_from: [chief-architect]
+---
+
+# Backend Orchestrator
+
+## Identity
+
+Level 1 orchestrator responsible for all FastAPI backend implementation in WavelengthWatch. Manages API endpoints, SQLModel schemas, business logic, and data persistence.
+
+## Scope
+
+- **Owns**: API endpoints, database models, routers, schemas, business logic, data validation
+- **Does NOT own**: Frontend implementation, SwiftUI views, CI/CD configuration
+
+## Workflow
+
+1. **Requirements Analysis** - Review assigned backend tasks from Chief Architect
+2. **API Design** - Design endpoint contracts, request/response schemas
+3. **Database Schema** - Define SQLModel models and relationships
+4. **Implementation** - Build routers, services, and business logic
+5. **Testing** - Ensure pytest coverage and all tests pass
+
+## Key Responsibilities
+
+- FastAPI router implementation (`backend/routers/`)
+- SQLModel model definitions (`backend/models.py`)
+- Pydantic schemas (`backend/schemas.py`)
+- Database relationships and eager loading
+- Data validation and error handling
+- API documentation (auto-generated via FastAPI)
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle.
+
+**Backend Specific**:
+
+- Follow FastAPI best practices
+- Maintain >90% test coverage
+- Use Ruff for linting and formatting (line length 78)
+- Type check with Mypy
+- Write isolated, fast tests (no database dependencies in unit tests)
+- Document API contracts clearly
+
+## Tech Stack
+
+- **Framework**: FastAPI
+- **ORM**: SQLModel
+- **Validation**: Pydantic
+- **Testing**: pytest
+- **Linting**: Ruff
+- **Type Checking**: Mypy
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md), [error-handling](../shared/error-handling.md)

--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -1,0 +1,73 @@
+---
+name: chief-architect
+description: "Strategic orchestrator for system-wide decisions. Select for repository-wide architectural patterns, cross-section coordination, feature planning, and technology stack decisions."
+level: 0
+phase: Plan
+tools: Read,Grep,Glob,Task
+model: opus
+delegates_to: [frontend-orchestrator, backend-orchestrator, testing-orchestrator, cicd-orchestrator, documentation-orchestrator]
+receives_from: []
+---
+
+# Chief Architect
+
+## Identity
+
+Level 0 meta-orchestrator responsible for strategic decisions across the entire WavelengthWatch repository
+ecosystem. Set system-wide architectural patterns, coordinate frontend/backend integration, and manage
+all section orchestrators for the watchOS self-care companion app.
+
+## Scope
+
+- **Owns**: Strategic vision, feature planning, system architecture, coding standards, quality gates, frontend/backend integration patterns
+- **Does NOT own**: Implementation details, subsection decisions, individual component code, UI/UX pixel-perfect details
+
+## Workflow
+
+1. **Strategic Analysis** - Review requirements, analyze feasibility, create high-level strategy
+2. **Architecture Definition** - Define system boundaries, cross-section interfaces, dependency graph
+3. **Delegation** - Break down strategy into section tasks, assign to orchestrators
+4. **Oversight** - Monitor progress, resolve cross-section conflicts, ensure consistency
+5. **Documentation** - Create and maintain Architectural Decision Records (ADRs)
+
+## Skills
+
+| Skill | When to Invoke |
+|-------|----------------|
+| `agent-run-orchestrator` | Delegating to section orchestrators |
+| `agent-validate-config` | Creating/modifying agent configurations |
+| `agent-test-delegation` | Testing delegation patterns before deployment |
+| `agent-coverage-check` | Verifying complete workflow coverage |
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle and scope control.
+
+**Chief Architect Specific**:
+
+- Do NOT micromanage implementation details
+- Do NOT make decisions outside repository scope
+- Do NOT override section decisions without clear rationale
+- Focus on "what" and "why", delegate "how" to orchestrators
+
+## Example: Multi-Step Emotion Logging Flow Architecture
+
+**Scenario**: Implementing Epic #92 - Multi-Step Emotion Logging Flow
+
+**Actions**:
+
+1. Analyze feature requirements and frontend/backend integration needs
+2. Define required components (SwiftUI views, ViewModels, backend API endpoints, data models)
+3. Create high-level task breakdown across frontend, backend, and testing
+4. Delegate frontend implementation to Frontend Orchestrator
+5. Delegate backend API endpoints to Backend Orchestrator
+6. Delegate test coverage to Testing Orchestrator
+7. Monitor progress and resolve cross-section conflicts (e.g., API contract changes)
+
+**Outcome**: Clear architectural vision with frontend, backend, and testing teams aligned on interfaces and contracts
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md),
+[documentation-rules](../shared/documentation-rules.md),
+[error-handling](../shared/error-handling.md)

--- a/.claude/agents/cicd-orchestrator.md
+++ b/.claude/agents/cicd-orchestrator.md
@@ -1,0 +1,81 @@
+---
+name: cicd-orchestrator
+description: "Orchestrates CI/CD pipeline, pre-commit hooks, and automation. Handles GitHub Actions, quality checks, and deployment readiness."
+level: 1
+phase: DevOps
+tools: Read,Write,Edit,Grep,Glob,Bash
+model: sonnet
+delegates_to: []
+receives_from: [chief-architect]
+---
+
+# CI/CD Orchestrator
+
+## Identity
+
+Level 1 orchestrator responsible for continuous integration, continuous deployment, and automation infrastructure in WavelengthWatch.
+
+## Scope
+
+- **Owns**: GitHub Actions workflows, pre-commit hooks, quality gates, build automation, deployment preparation
+- **Does NOT own**: Production code, feature implementation, infrastructure provisioning (no deployment yet)
+
+## Workflow
+
+1. **Pipeline Design** - Design CI/CD workflows for quality enforcement
+2. **Hook Configuration** - Configure pre-commit hooks for local quality checks
+3. **Automation** - Build scripts and tools for repetitive tasks
+4. **Monitoring** - Ensure CI checks pass and diagnose failures
+5. **Optimization** - Improve build times and workflow efficiency
+
+## Key Responsibilities
+
+### GitHub Actions
+- Backend CI: linting (Ruff), type checking (Mypy), testing (pytest)
+- Frontend CI: SwiftFormat checks, Xcode build verification
+- PR workflows and automated reviews
+
+### Pre-commit Hooks
+- Ruff linting and formatting
+- SwiftFormat formatting
+- Mypy type checking
+- Test execution
+
+### Quality Gates
+- All CI checks must pass before merge
+- No bypassing quality checks
+- Test coverage requirements enforced
+
+### Scripts & Automation
+- `dev-setup.sh` - Developer environment setup
+- `run-tests-individually.sh` - Frontend test runner
+- CSV→JSON build scripts
+- Database seeding utilities
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle.
+
+**CI/CD Specific**:
+
+- Never disable CI checks to "fix" failures
+- Fix root causes, not symptoms
+- Keep pipelines fast (<5 minutes ideal)
+- Clear error messages for failures
+- Document all workflow changes
+
+## Current Workflows
+
+**`.github/workflows/`**:
+- Backend checks (lint, type, test)
+- SwiftFormat verification
+- Automated PR reviews
+
+**`pre-commit-config.yaml`**:
+- Ruff (backend)
+- SwiftFormat (frontend)
+- Mypy type checking
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md), CLAUDE.md (development commands)

--- a/.claude/agents/delegation-rules.md
+++ b/.claude/agents/delegation-rules.md
@@ -1,0 +1,290 @@
+# Delegation Rules - WavelengthWatch
+
+## Core Delegation Rules
+
+### Rule 1: Scope Reduction
+
+Each delegation reduces scope by one level:
+
+```text
+System → Section → Component → Function
+```
+
+### Rule 2: Specification Detail
+
+Each level adds more detail:
+
+```text
+Strategic goals → Tactical plans → Implementation details → Code
+```
+
+### Rule 3: Autonomy Increase
+
+Lower levels have more implementation freedom, less strategic freedom
+
+### Rule 4: Review Responsibility
+
+Each level reviews the work of the level below
+
+### Rule 5: Escalation Path
+
+Issues escalate one level up until resolved
+
+### Rule 6: Horizontal Coordination
+
+Same-level agents coordinate when sharing resources or dependencies (e.g., API contracts)
+
+## When to Delegate
+
+### Delegate Down When
+
+- ✅ Task is too detailed for current level
+- ✅ Specific expertise required (SwiftUI, FastAPI, etc.)
+- ✅ Work can be parallelized (frontend + backend)
+- ✅ Clear specification can be provided
+
+### Escalate Up When
+
+- ⬆️ Decision exceeds your authority
+- ⬆️ Resources needed from higher level
+- ⬆️ Blocker cannot be resolved at current level
+- ⬆️ Conflicts with other same-level agents (e.g., API contract mismatch)
+
+### Coordinate Horizontally When
+
+- ↔️ Sharing API contracts
+- ↔️ Dependencies between frontend and backend
+- ↔️ Interface negotiation needed
+- ↔️ Cross-cutting concerns (security, performance, data models)
+
+## Delegation Patterns
+
+### Pattern 1: Sequential Delegation
+
+```text
+Chief Architect
+  ↓ defines architecture
+  ↓ delegates to Frontend
+Frontend Orchestrator
+  ↓ implements UI
+  ↓ coordinates with Backend for API
+Backend Orchestrator
+  ↓ implements API
+  ↓ reports completion
+```
+
+**Use When**: Tasks have strict dependencies (e.g., API must exist before frontend can integrate)
+
+### Pattern 2: Parallel Delegation
+
+```text
+Chief Architect
+  ├─> Frontend Orchestrator (parallel)
+  ├─> Backend Orchestrator (parallel)
+  └─> Testing Orchestrator (parallel)
+```
+
+**Use When**: Tasks are independent (API contract already defined)
+
+### Pattern 3: Fan-Out/Fan-In
+
+```text
+Chief Architect
+  ├─> Frontend Orchestrator ─┐
+  ├─> Backend Orchestrator ──┼─> Integration Testing
+  └─> Testing Orchestrator ──┘
+```
+
+**Use When**: Parallel work needs final integration verification
+
+## WavelengthWatch-Specific Delegation
+
+### Language Boundary Coordination
+
+**Chief Architect (Level 0)** decides:
+- API contract structure (request/response schemas)
+- Data models shared between Swift and Python
+- Offline-first architecture patterns
+- Sync strategy
+
+**Frontend Orchestrator** implements:
+- Swift models matching API schemas
+- Service layer for API communication
+- Local data persistence (UserDefaults, local DB)
+- UI state management
+
+**Backend Orchestrator** implements:
+- Pydantic schemas matching API contract
+- SQLModel database models
+- Validation and business logic
+- API endpoints under `/api/v1/`
+
+### Cross-Section Coordination Examples
+
+**Example 1: New Journal Endpoint**
+
+Chief Architect defines:
+```json
+{
+  "endpoint": "POST /api/v1/journal",
+  "request": {
+    "primary_feeling_id": "int",
+    "notes": "string"
+  },
+  "response": {
+    "id": "int",
+    "created_at": "datetime"
+  }
+}
+```
+
+Frontend Orchestrator:
+- Creates Swift `JournalSubmissionRequest` struct
+- Updates `JournalClient` service
+- Handles response in ViewModel
+
+Backend Orchestrator:
+- Creates `JournalCreate` Pydantic schema
+- Implements POST endpoint in `journal.py` router
+- Adds SQLModel database model
+
+**Example 2: API Contract Change**
+
+If Backend changes response structure:
+1. Backend Orchestrator escalates to Chief Architect
+2. Chief Architect evaluates impact on Frontend
+3. Chief Architect coordinates with both orchestrators
+4. Both update implementations together
+
+## Status Reporting
+
+### Report Frequency
+
+- **On Task Start**: Confirm understanding of requirements
+- **On Blocker**: Immediately escalate
+- **On Completion**: Report deliverables and next steps
+
+### Report Template
+
+```markdown
+## Status Report
+
+**Agent**: [Agent Name]
+**Level**: [0 or 1]
+**Task**: [Brief description]
+
+### Progress
+
+- [What was completed]
+
+### Blockers
+
+- [None / Description of blocker]
+
+### Next Steps
+
+- [What happens next]
+```
+
+## Handoff Protocol
+
+### When Completing Work
+
+1. **Document What Was Done** (files changed, endpoints created)
+2. **List Artifacts Produced** (Swift files, Python routers, tests)
+3. **Specify Next Steps** for receiving agent or next phase
+4. **Note Any Gotchas** (API limitations, test caveats)
+
+### Handoff Template
+
+```markdown
+## Task Handoff
+
+**From**: [Your Agent Name]
+**To**: [Next Agent Name / Phase]
+**Task**: [Description]
+
+**Completed**:
+- [What you implemented]
+
+**Artifacts**:
+- `frontend/...` - [Swift files]
+- `backend/...` - [Python files]
+- `tests/...` - [Test files]
+
+**Next Steps**:
+- [What should happen next]
+
+**Notes**:
+- [Important context, gotchas, or considerations]
+```
+
+## Common Coordination Scenarios
+
+### Scenario 1: New Feature Spanning Frontend + Backend
+
+1. **Chief Architect**:
+   - Defines feature requirements
+   - Designs API contract
+   - Delegates to Frontend and Backend orchestrators
+
+2. **Frontend & Backend Orchestrators** (parallel):
+   - Implement their respective sides
+   - Coordinate on API contract details
+   - Report progress to Chief Architect
+
+3. **Testing Orchestrator**:
+   - Creates integration tests
+   - Verifies end-to-end flow
+
+### Scenario 2: Frontend-Only Change
+
+- **Skip Chief Architect**: Delegate directly to Frontend Orchestrator
+- Frontend Orchestrator handles implementation and testing
+
+### Scenario 3: Backend-Only Change (No API Impact)
+
+- **Skip Chief Architect**: Delegate directly to Backend Orchestrator
+- Backend Orchestrator handles implementation and testing
+
+### Scenario 4: API Contract Modification
+
+- **Requires Chief Architect**: Coordinate both Frontend and Backend changes
+- Update API documentation
+- Ensure backward compatibility if needed
+
+## Skip-Level Delegation
+
+**General Rule**: Follow the hierarchy (don't skip levels). However, for trivial tasks, skip-level delegation is acceptable.
+
+### When Skip-Level Is Acceptable
+
+**Simple Bug Fixes** (< 20 lines, well-defined, no design decisions):
+- Typos or obvious errors
+- Missing imports
+- Formatting issues
+- Clear, localized fixes
+
+**Process**: Higher-level agent can delegate directly when:
+1. No design decisions needed
+2. No architectural impact
+3. Fix is obvious and unambiguous
+4. < 20 lines of code changes
+
+### When Skip-Level Is NOT Acceptable
+
+**Never skip levels for**:
+- New features (any size)
+- Refactoring (any scope)
+- Performance optimization
+- Security fixes
+- API changes
+- Anything requiring judgment or design
+
+**Rule of Thumb**: If it requires thinking beyond "fix the typo", use the full hierarchy.
+
+## See Also
+
+- [hierarchy.md](hierarchy.md) - Visual hierarchy diagram
+- [common-constraints.md](../shared/common-constraints.md) - Shared constraints
+- [/prompts/claude-comm/delegation-rules-reference.md](../../prompts/claude-comm/delegation-rules-reference.md) - ml-odyssey reference

--- a/.claude/agents/documentation-orchestrator.md
+++ b/.claude/agents/documentation-orchestrator.md
@@ -1,0 +1,88 @@
+---
+name: documentation-orchestrator
+description: "Orchestrates documentation strategy. Handles README files, API docs, architecture docs, and developer guides."
+level: 1
+phase: Documentation
+tools: Read,Write,Edit,Grep,Glob
+model: sonnet
+delegates_to: []
+receives_from: [chief-architect]
+---
+
+# Documentation Orchestrator
+
+## Identity
+
+Level 1 orchestrator responsible for all documentation in WavelengthWatch. Ensures code is documented, architecture is explained, and developers can onboard easily.
+
+## Scope
+
+- **Owns**: README files, API documentation, architecture docs, developer guides, inline code comments
+- **Does NOT own**: Code implementation, testing strategy, CI/CD pipelines
+
+## Workflow
+
+1. **Documentation Planning** - Identify what needs documentation
+2. **Content Creation** - Write clear, concise documentation
+3. **Maintenance** - Keep docs in sync with code changes
+4. **Review** - Ensure documentation accuracy and clarity
+5. **Organization** - Structure docs for easy navigation
+
+## Key Responsibilities
+
+### Core Documentation
+- `README.md` - Project overview and quickstart
+- `CLAUDE.md` - Agent/AI collaboration guide
+- `XCODE_BUILD_SETUP.md` - Xcode configuration guide
+- `AGENTS.md` - Development guidelines
+
+### Code Documentation
+- Inline comments for complex logic
+- Function/method documentation
+- API endpoint documentation (FastAPI auto-gen)
+- SwiftUI view documentation
+
+### Process Documentation
+- Testing procedures (`prompts/claude-comm/bugs/`)
+- Manual testing plans
+- Bug report templates
+- Development workflows
+
+### Architecture Documentation
+- System architecture overview
+- Data flow diagrams
+- Frontend/backend integration patterns
+- Database schema documentation
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) and [documentation-rules.md](../shared/documentation-rules.md).
+
+**Documentation Specific**:
+
+- NEVER create documentation files unless explicitly requested
+- ALWAYS prefer editing existing docs to creating new ones
+- Keep documentation concise and actionable
+- Update docs when code changes
+- Use markdown formatting consistently
+- Include code examples where helpful
+
+## Documentation Structure
+
+```
+WavelengthWatch/
+├── README.md                    # Main project README
+├── CLAUDE.md                    # AI collaboration guide
+├── AGENTS.md                    # Development guidelines
+├── XCODE_BUILD_SETUP.md        # Build configuration
+├── prompts/                     # Planning & communication
+│   └── claude-comm/            # Agent communication notes
+│       ├── bugs/               # Testing plans & bug reports
+│       └── plans/              # Implementation plans
+├── backend/                     # Backend code (auto-documented via FastAPI)
+└── frontend/                    # Frontend code (inline comments)
+```
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md), [documentation-rules](../shared/documentation-rules.md)

--- a/.claude/agents/frontend-orchestrator.md
+++ b/.claude/agents/frontend-orchestrator.md
@@ -1,0 +1,54 @@
+---
+name: frontend-orchestrator
+description: "Orchestrates watchOS frontend development. Handles SwiftUI views, ViewModels, Services, and UI/UX implementation."
+level: 1
+phase: Implementation
+tools: Read,Write,Edit,Grep,Glob,Task
+model: sonnet
+delegates_to: []
+receives_from: [chief-architect]
+---
+
+# Frontend Orchestrator
+
+## Identity
+
+Level 1 orchestrator responsible for all watchOS frontend implementation in WavelengthWatch. Manages SwiftUI views, ViewModels, navigation, state management, and UI components.
+
+## Scope
+
+- **Owns**: SwiftUI views, ViewModels, Services layer, navigation patterns, UI components
+- **Does NOT own**: Backend API implementation, database schema, CI/CD configuration
+
+## Workflow
+
+1. **Requirements Analysis** - Review assigned frontend tasks from Chief Architect
+2. **Component Design** - Design view hierarchy, state flow, and navigation patterns
+3. **Implementation** - Build SwiftUI views, ViewModels, and services
+4. **Integration** - Connect to backend APIs via service clients
+5. **Testing** - Ensure UI tests and view model tests pass
+
+## Key Responsibilities
+
+- SwiftUI view implementation
+- ViewModel and state management
+- Navigation patterns (TabView, Sheet, NavigationStack)
+- Service layer integration (API clients, local storage)
+- UI component reusability
+- watchOS-specific optimizations (screen sizes, Digital Crown support)
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle.
+
+**Frontend Specific**:
+
+- Follow SwiftUI best practices
+- Ensure responsive design for all watch sizes (41mm, 45mm, 49mm)
+- Use MVVM architecture consistently
+- Test on multiple watch sizes before marking complete
+- Follow SwiftFormat rules (enforced by CI)
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md), [documentation-rules](../shared/documentation-rules.md)

--- a/.claude/agents/hierarchy.md
+++ b/.claude/agents/hierarchy.md
@@ -1,0 +1,149 @@
+# Agent Hierarchy - Visual Diagram and Quick Reference
+
+## Hierarchy Diagram
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                    Level 0: Meta-Orchestrator                │
+│                   Chief Architect Agent                      │
+│      (System-wide decisions, feature planning)               │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+        ┌───────────────────┼───────────────────┐
+        ▼                   ▼                   ▼
+┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐
+│   Level 1:       │ │   Level 1:       │ │    Level 1:      │
+│   Frontend       │ │    Backend       │ │    Testing       │
+│  Orchestrator    │ │  Orchestrator    │ │  Orchestrator    │
+└────────┬─────────┘ └────────┬─────────┘ └────────┬─────────┘
+         │                    │                     │
+         └────────────────────┼─────────────────────┘
+                              ▼
+            ┌─────────────────────────────────────┐
+            │   Level 1: CI/CD & Documentation    │
+            ├─────────────────────────────────────┤
+            │  • CI/CD Orchestrator               │
+            │  • Documentation Orchestrator       │
+            └─────────────────────────────────────┘
+```
+
+## Level Summaries
+
+### Level 0: Meta-Orchestrator
+
+- **Agents**: 1 (Chief Architect)
+- **Scope**: Entire repository
+- **Decisions**: Strategic (feature planning, architecture, tech stack)
+- **Phase**: Primarily Plan
+- **Language Context**: Coordinates Swift (watchOS) and Python (FastAPI) integration
+
+### Level 1: Section Orchestrators
+
+- **Agents**: 5 (Frontend, Backend, Testing, CI/CD, Documentation)
+- **Scope**: Repository sections
+- **Decisions**: Tactical (module organization, dependencies, implementation)
+- **Phase**: Plan, Implementation, Testing
+- **Language Context**:
+  - Frontend uses Swift/SwiftUI for watchOS
+  - Backend uses Python/FastAPI
+  - Testing uses pytest (backend) and XCTest (frontend)
+
+## Agent Count
+
+| Level | Name | Count |
+|-------|------|-------|
+| 0     | Meta-Orchestrator | 1 |
+| 1     | Section Orchestrators | 5 |
+| **Total** | **All Agents** | **6** |
+
+## Quick Reference
+
+### When to Use Each Level
+
+**Use Level 0 (Chief Architect)** when:
+- Planning new features that span frontend and backend
+- Making system-wide architectural decisions
+- Resolving cross-section conflicts (e.g., API contract changes)
+- Coordinating major initiatives (epics)
+
+**Use Level 1 (Section Orchestrators)** when:
+- Implementing frontend features (SwiftUI views, ViewModels)
+- Creating backend endpoints (FastAPI routers, SQLModel schemas)
+- Designing test strategies (frontend or backend)
+- Updating CI/CD pipelines
+- Creating or updating documentation
+
+## Coordination Rules
+
+1. **Delegate Down**: When task is too detailed for current level
+2. **Escalate Up**: When decision exceeds current authority
+3. **Coordinate Laterally**: When sharing resources or dependencies (e.g., API contracts)
+4. **Report Status**: Keep superior informed of progress
+5. **Document Decisions**: Capture rationale for future reference
+
+## WavelengthWatch-Specific Considerations
+
+### Frontend (watchOS SwiftUI)
+
+**Frontend Orchestrator handles:**
+- SwiftUI views and navigation
+- ViewModels and state management
+- Service layer integration
+- UI testing
+- watchOS-specific patterns (dual-axis scrolling, complications)
+
+### Backend (FastAPI + SQLModel)
+
+**Backend Orchestrator handles:**
+- API endpoints under `/api/v1/`
+- SQLModel database models
+- Pydantic schemas with validation
+- Business logic
+- Backend testing with pytest
+
+### Integration Patterns
+
+**Chief Architect coordinates:**
+- API contract definitions (request/response schemas)
+- Data flow between watch and backend
+- Offline-first architecture decisions
+- Journal sync strategy
+
+### Testing Strategy
+
+**Testing Orchestrator handles:**
+- >90% backend test coverage
+- Frontend XCTest suite coordination
+- Integration test planning
+- Manual testing coordination
+
+## Delegation Flow
+
+### Top-Down (Task Decomposition)
+
+```text
+Feature Planning (Level 0)
+    ↓
+Frontend Implementation (Level 1)
+Backend Implementation (Level 1)
+Testing Implementation (Level 1)
+    ↓
+Integration & Deployment
+```
+
+### Bottom-Up (Status Reporting)
+
+```text
+Implementation Progress (Level 1)
+    ↑
+Feature Completion (Level 0)
+    ↑
+Product Readiness
+```
+
+## See Also
+
+- [README.md](../README.md) - Agent system overview
+- [delegation-rules.md](delegation-rules.md) - Detailed coordination patterns
+- [agent-hierarchy.md](agent-hierarchy.md) - Complete detailed specification
+- [/prompts/claude-comm/](../../prompts/claude-comm/) - Reference docs from ml-odyssey

--- a/.claude/agents/testing-orchestrator.md
+++ b/.claude/agents/testing-orchestrator.md
@@ -1,0 +1,82 @@
+---
+name: testing-orchestrator
+description: "Orchestrates testing strategy across frontend and backend. Handles test planning, coverage, and quality assurance."
+level: 1
+phase: Testing
+tools: Read,Write,Edit,Grep,Glob,Bash,Task
+model: sonnet
+delegates_to: []
+receives_from: [chief-architect]
+---
+
+# Testing Orchestrator
+
+## Identity
+
+Level 1 orchestrator responsible for comprehensive testing across WavelengthWatch. Manages test strategy, coverage goals, test implementation, and quality gates.
+
+## Scope
+
+- **Owns**: Test strategy, test implementation, coverage metrics, quality gates, manual testing coordination
+- **Does NOT own**: Production code implementation, feature design decisions
+
+## Workflow
+
+1. **Test Planning** - Review feature requirements and design test strategy
+2. **Test Implementation** - Write unit tests, integration tests, UI tests
+3. **Coverage Analysis** - Ensure >90% backend coverage, comprehensive frontend coverage
+4. **Manual Testing** - Coordinate manual testing efforts (e.g., #120, #121, #122)
+5. **Quality Gates** - Ensure all tests pass before merge
+
+## Key Responsibilities
+
+### Backend Testing
+- pytest unit tests for routers, models, schemas
+- Integration tests for API endpoints
+- Database relationship tests
+- Error handling and validation tests
+
+### Frontend Testing
+- Swift Testing framework for ViewModels
+- UI tests for critical user flows
+- Test suite optimization (single simulator runs)
+- Screen size compatibility testing
+
+### Manual Testing
+- Coordinate manual test plans (emotion logging flow)
+- Bug discovery and reporting
+- Regression testing
+- Device-specific testing (41mm, 45mm, 49mm)
+
+## Constraints
+
+See [common-constraints.md](../shared/common-constraints.md) for minimal changes principle.
+
+**Testing Specific**:
+
+- No shortcuts - always fix issues properly
+- Never comment out failing tests
+- Write tests before or alongside features (TDD)
+- Isolated tests (fast, independent, repeatable)
+- Clear test names describing what's being tested
+- Backend: >90% coverage requirement
+- Frontend: Critical paths must have tests
+
+## Commands
+
+**Backend:**
+```bash
+pytest -q                    # Run all tests
+pytest tests/backend/ -v     # Verbose backend tests
+pytest --cov=backend         # Coverage report
+```
+
+**Frontend:**
+```bash
+cd frontend/WavelengthWatch
+./run-tests-individually.sh  # Run all test suites
+```
+
+---
+
+**References**: [common-constraints](../shared/common-constraints.md), [error-handling](../shared/error-handling.md)

--- a/.claude/shared/common-constraints.md
+++ b/.claude/shared/common-constraints.md
@@ -1,0 +1,79 @@
+# Common Constraints
+
+Shared constraints for all agents. Reference this file instead of duplicating.
+
+## Minimal Changes Principle
+
+Make the SMALLEST change that solves the problem.
+
+**DO:**
+
+- Touch ONLY files directly related to the issue requirements
+- Make focused changes that directly address the issue
+- Prefer 10-line fixes over 100-line refactors
+- Keep scope strictly within issue requirements
+
+**DO NOT:**
+
+- Refactor unrelated code
+- Add features beyond issue requirements
+- "Improve" code outside the issue scope
+- Restructure unless explicitly required by the issue
+
+**Rule of Thumb**: If it's not mentioned in the issue, don't change it.
+
+## Scope Discipline
+
+- Complete assigned task, nothing more
+- Do not refactor "while you're in there"
+- Do not add features beyond requirements
+- Do not "improve" unrelated code
+
+## When Blocked
+
+1. Document what's blocking you
+2. Document what you tried
+3. Escalate to immediate supervisor
+4. Continue with non-blocked work if possible
+
+## Work Without Issue Number
+
+**STOP** - Do not start work without a GitHub issue number.
+
+- Request issue creation first
+- All work must be tracked
+
+## Command Execution
+
+### Never Use `cd`
+
+**CRITICAL**: All commands MUST be run with relative paths from project root.
+
+❌ **WRONG:**
+```bash
+cd frontend/WavelengthWatch
+./run-tests-individually.sh
+```
+
+✅ **CORRECT:**
+```bash
+frontend/WavelengthWatch/run-tests-individually.sh
+```
+
+**Why:** Using `cd` creates hidden directory state that causes confusion, breaks command sequences, and makes debugging harder.
+
+### Always Use Test Scripts
+
+For frontend tests, **always use the test script** instead of direct tool invocation.
+
+❌ **WRONG:**
+```bash
+xcodebuild test -scheme "WavelengthWatch Watch App"
+```
+
+✅ **CORRECT:**
+```bash
+frontend/WavelengthWatch/run-tests-individually.sh
+```
+
+**Why:** Test scripts encapsulate proper configuration, simulator management, and cleanup. Direct invocation bypasses these safeguards.

--- a/.claude/shared/documentation-rules.md
+++ b/.claude/shared/documentation-rules.md
@@ -1,0 +1,104 @@
+# Documentation Rules
+
+Shared documentation rules for all agents. Reference this file instead of duplicating.
+
+## Output Location
+
+**All implementation notes must be posted as comments on the GitHub issue.**
+
+## Before Starting Work
+
+1. **Verify GitHub issue number** is provided
+2. **Read issue context**: `gh issue view <issue> --comments`
+3. **Check for prior work**: Look for linked PRs and existing comments
+4. **If no issue number provided**: STOP and escalate - request issue creation first
+
+## Reading from GitHub Issues
+
+```bash
+# Get issue details
+gh issue view <number>
+
+# Get all comments (implementation history)
+gh issue view <number> --comments
+
+# Get structured data
+gh issue view <number> --json title,body,comments,labels,state
+
+# Check linked PRs
+gh pr list --search "issue:<number>"
+```
+
+## Writing to GitHub Issues
+
+```bash
+# Short status update
+gh issue comment <number> --body "Status: [brief update]"
+
+# Detailed implementation notes
+gh issue comment <number> --body "$(cat <<'EOF'
+## Implementation Notes
+
+### Summary
+[what was done]
+
+### Files Changed
+- path/to/file.mojo
+
+### Verification
+- [x] Tests pass
+- [x] Linting passes
+EOF
+)"
+```
+
+## What Goes Where
+
+| Content | Location |
+|---------|----------|
+| Issue-specific work | GitHub issue comments |
+| Architectural decisions | `/notes/review/` |
+| Team guides | `/agents/` |
+| Comprehensive specs | `/notes/review/` |
+
+## Rules
+
+- Write ALL findings, decisions, and outputs as GitHub issue comments
+- Link to comprehensive docs in `/notes/review/` and `/agents/` (don't duplicate)
+- Keep issue-specific content focused and concise
+- Reference related issues with `#<number>` format
+- Post completion summaries before creating PR
+
+## Templates
+
+### Implementation Started
+
+```markdown
+## Implementation Started
+
+**Branch**: `<branch-name>`
+
+### Approach
+[Brief description]
+
+### Files to Modify
+- `path/to/file1`
+- `path/to/file2`
+```
+
+### Implementation Complete
+
+```markdown
+## Implementation Complete
+
+**PR**: #<pr-number>
+
+### Summary
+[What was implemented]
+
+### Verification
+- [x] Tests pass
+- [x] Pre-commit passes
+```
+
+See [github-issue-workflow.md](./github-issue-workflow.md) for complete workflow patterns.

--- a/.claude/shared/error-handling.md
+++ b/.claude/shared/error-handling.md
@@ -1,0 +1,80 @@
+# Error Handling
+
+Shared error handling protocols for all agents. Reference this file instead of duplicating.
+
+## Retry Strategy
+
+- **Max Attempts**: 3 retries for failed operations
+- **Backoff**: Exponential backoff (1s, 2s, 4s between attempts)
+- **Scope**: Apply to delegation failures, not system errors
+
+## Timeout Handling
+
+- **Max Wait**: 5 minutes for delegated work to complete
+- **On Timeout**: Escalate to parent with context about what timed out
+- **Check Interval**: Poll for completion every 30 seconds
+
+## Conflict Resolution
+
+When receiving conflicting guidance:
+
+1. Attempt to resolve conflicts based on specifications and priorities
+2. If unable to resolve: escalate to parent level with full context
+3. Document the conflict and resolution in status updates
+
+## Failure Modes
+
+### Partial Failure
+
+Some delegated work succeeds, some fails.
+
+- **Action**: Complete successful parts, escalate failed parts
+
+### Complete Failure
+
+All attempts at delegation fail.
+
+- **Action**: Escalate immediately to parent with failure details
+
+### Blocking Failure
+
+Cannot proceed without resolution.
+
+- **Action**: Escalate immediately, do not retry
+
+## Loop Detection
+
+- **Pattern**: Same operation attempted 3+ times with same result
+- **Action**: Break the loop, escalate with loop context
+- **Prevention**: Track attempts per unique task
+
+## Escalation Triggers
+
+Escalate errors when:
+
+- All retry attempts exhausted
+- Timeout exceeded
+- Unresolvable conflicts detected
+- Critical blocking issues found
+- Loop detected in delegation chain
+
+## Error Reporting Format
+
+```markdown
+## Error Report
+
+**Agent**: [agent-name]
+**Issue**: #[issue-number]
+**Error Type**: [timeout|conflict|failure|loop]
+
+### What Happened
+[Brief description]
+
+### What Was Tried
+1. [Attempt 1]
+2. [Attempt 2]
+3. [Attempt 3]
+
+### What's Needed
+[Specific help required]
+```

--- a/.claude/shared/github-issue-workflow.md
+++ b/.claude/shared/github-issue-workflow.md
@@ -1,0 +1,268 @@
+# GitHub Issue Workflow
+
+This document defines the standard workflow for reading from and writing to GitHub issues.
+All agents and skills should follow these patterns for issue-based documentation.
+
+## Reading from GitHub Issues
+
+### Get Issue Details
+
+```bash
+# Get issue description and metadata
+gh issue view <number>
+
+# Get issue with all comments (implementation history)
+gh issue view <number> --comments
+
+# Get structured JSON for parsing
+gh issue view <number> --json title,body,comments,labels,assignees,milestone,state
+
+# Get specific fields only
+gh issue view <number> --json body --jq '.body'
+```
+
+### Check Related Items
+
+```bash
+# Get linked PRs
+gh pr list --search "issue:<number>"
+
+# Get issue timeline (events, references)
+gh api repos/{owner}/{repo}/issues/<number>/timeline
+
+# Search for related issues
+gh issue list --search "in:body #<number>"
+```
+
+### Before Starting Work
+
+1. Run `gh issue view <number>` to understand requirements
+2. Run `gh issue view <number> --comments` for prior context and decisions
+3. Check linked PRs: `gh pr list --search "issue:<number>"`
+4. Note any blockers or dependencies mentioned in comments
+
+## Writing to GitHub Issues
+
+### Status Updates
+
+```bash
+# Short status update
+gh issue comment <number> --body "Status: Implementation in progress - 3/5 tests passing"
+
+# Progress checkpoint
+gh issue comment <number> --body "Checkpoint: Completed tensor operations, starting gradient computation"
+```
+
+### Detailed Implementation Notes
+
+```bash
+gh issue comment <number> --body "$(cat <<'EOF'
+## Implementation Notes
+
+### Changes Made
+- Created `shared/core/tensor.mojo` with basic tensor operations
+- Added unit tests in `tests/shared/core/test_tensor.mojo`
+
+### Design Decisions
+1. Used SIMD for vectorized operations
+2. Implemented lazy evaluation for chain operations
+
+### Testing
+- All 15 unit tests pass
+- Manual verification complete
+
+### Next Steps
+- Integration with existing modules
+- Performance benchmarking
+EOF
+)"
+```
+
+### Implementation Complete
+
+```bash
+gh issue comment <number> --body "$(cat <<'EOF'
+## Implementation Complete
+
+**PR**: #<pr-number>
+
+### Summary
+[Brief description of what was implemented]
+
+### Files Changed
+- `path/to/file1.mojo` - [what changed]
+- `path/to/file2.mojo` - [what changed]
+
+### Testing
+- All tests pass
+- Coverage: [percentage if known]
+
+### Verification
+- [x] `pixi run test` passes
+- [x] `pre-commit run --all-files` passes
+- [x] Manual testing complete
+EOF
+)"
+```
+
+### Work In Progress
+
+```bash
+gh issue comment <number> --body "$(cat <<'EOF'
+## Progress Update
+
+### Completed
+- [x] Item 1
+- [x] Item 2
+
+### In Progress
+- [ ] Item 3 (70% complete)
+
+### Blocked
+- Item 4 - waiting on #<other-issue>
+
+### Next Steps
+1. Complete item 3
+2. Start item 5
+EOF
+)"
+```
+
+### Using Body Files
+
+For longer content or content with special characters:
+
+```bash
+# Write content to temp file
+cat > /tmp/issue_update.md << 'EOF'
+## Update
+
+Content here...
+EOF
+
+# Post using body file
+gh issue comment <number> --body-file /tmp/issue_update.md
+```
+
+## Referencing Issues
+
+### In Commits
+
+```bash
+# Reference issue in commit message
+git commit -m "feat(tensor): Add SIMD operations
+
+Implements vectorized tensor operations with automatic SIMD detection.
+
+Refs #123"
+
+# Close issue via commit
+git commit -m "fix(gradient): Correct backward pass computation
+
+Closes #456"
+```
+
+### In Pull Requests
+
+```bash
+# Create PR linked to issue
+gh pr create --title "feat: Add tensor operations" --body "Closes #123"
+
+# Reference multiple issues
+gh pr create --title "refactor: Update core module" --body "
+## Summary
+Refactored core module for better performance.
+
+Closes #123
+Refs #124, #125
+"
+```
+
+### In Code Comments
+
+```mojo
+# Implementation for issue #123
+# See https://github.com/owner/repo/issues/123 for design decisions
+fn tensor_multiply(a: ExTensor, b: ExTensor) -> ExTensor:
+    ...
+```
+
+### In Documentation
+
+```markdown
+For implementation details, see [Issue #123](https://github.com/owner/repo/issues/123).
+
+Related issues:
+- #124 - Test coverage improvements
+- #125 - Performance benchmarks
+```
+
+## Templates
+
+### New Feature Implementation
+
+```markdown
+## Implementation Started
+
+**Issue**: #<number>
+**Branch**: `<branch-name>`
+
+### Approach
+[Brief description of implementation approach]
+
+### Files to Create/Modify
+- [ ] `path/to/file1.mojo`
+- [ ] `path/to/file2.mojo`
+
+### Estimated Scope
+- [X] Small (< 100 lines)
+- [ ] Medium (100-500 lines)
+- [ ] Large (> 500 lines)
+```
+
+### Bug Fix
+
+```markdown
+## Bug Investigation
+
+### Root Cause
+[Description of what's causing the bug]
+
+### Fix Approach
+[How we'll fix it]
+
+### Testing Plan
+- [ ] Add regression test
+- [ ] Verify fix in isolation
+- [ ] Run full test suite
+```
+
+### Review Findings
+
+```markdown
+## Review Complete
+
+### Summary
+[1-2 sentence summary]
+
+### Findings
+1. [Finding 1]
+2. [Finding 2]
+
+### Recommendations
+- [Recommendation 1]
+- [Recommendation 2]
+
+### Action Items
+- [ ] [Action 1]
+- [ ] [Action 2]
+```
+
+## Best Practices
+
+1. **Be Concise**: Keep updates focused and actionable
+2. **Use Checklists**: Track progress with `- [ ]` and `- [x]`
+3. **Link Related Items**: Reference other issues, PRs, and commits
+4. **Update Regularly**: Post progress updates, don't wait until completion
+5. **Include Context**: Future readers should understand decisions made
+6. **Use Formatting**: Headers, code blocks, and lists improve readability

--- a/.claude/shared/pr-workflow.md
+++ b/.claude/shared/pr-workflow.md
@@ -1,0 +1,77 @@
+# Pull Request Workflow
+
+Shared PR workflow for all agents. Reference this file instead of duplicating.
+
+## Creating a PR
+
+```bash
+git checkout -b {issue-number}-{description}
+# Make changes, commit
+git push -u origin {branch-name}
+gh pr create --title "[Type] Description" --body "Closes #{issue}"
+gh pr merge --auto --rebase  # Always enable auto-merge
+```
+
+## Verification
+
+After creating PR:
+
+1. **Verify** the PR is linked to the issue (check issue page in GitHub)
+2. **Confirm** link appears in issue's "Development" section
+3. **If link missing**: Edit PR description to add "Closes #{number}"
+
+## PR Requirements
+
+- **One PR per issue** - Each GitHub issue gets exactly ONE pull request
+- PR must be linked to GitHub issue
+- PR title should be clear and descriptive
+- PR description should summarize changes
+- **Always enable auto-merge** (`gh pr merge --auto --rebase`)
+- Do NOT create PR without linking to issue
+- Do NOT combine multiple issues into a single PR
+
+## Responding to Review Comments
+
+Reply to EACH review comment individually using GitHub API:
+
+```bash
+# Get review comment IDs
+gh api repos/OWNER/REPO/pulls/PR/comments --jq '.[] | {id, path, body}'
+
+# Reply to each comment
+gh api repos/OWNER/REPO/pulls/PR/comments/COMMENT_ID/replies \
+  --method POST -f body="Fixed - [brief description]"
+
+# Verify replies posted
+gh api repos/OWNER/REPO/pulls/PR/comments --jq '.[] | select(.in_reply_to_id)'
+```
+
+## Response Format
+
+Keep responses SHORT and CONCISE (1 line preferred):
+
+- `Fixed - Updated conftest.py to use real repository root`
+- `Fixed - Deleted redundant test file`
+- `Fixed - Removed deprecated section from README`
+
+## Post-Merge Cleanup
+
+After a PR is merged/rebased to main, clean up the worktree and branch:
+
+```bash
+# 1. Remove the worktree
+git worktree remove worktrees/<issue-number>-<description>
+
+# 2. Delete local branch
+git branch -d <branch-name>
+
+# 3. Delete remote branch
+git push origin --delete <branch-name>
+
+# 4. Prune stale references
+git worktree prune
+```
+
+**Important:** Always clean up after merge to avoid accumulating stale worktrees and branches.
+
+See [CLAUDE.md](../../CLAUDE.md#git-workflow) for complete PR creation instructions.

--- a/.claude/skills/architectural-decisions/SKILL.md
+++ b/.claude/skills/architectural-decisions/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: architectural-decisions
+description: >-
+  Guide explicit, factual trade-off analysis for architectural choices.
+  Use when choosing between libraries, patterns, technologies, databases,
+  or API designs. Presents 2-4 options with comparison matrices and
+  recommendations. Do NOT use for trivial choices, variable naming,
+  or code formatting decisions.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Architectural Decisions
+
+Never make architectural decisions unilaterally. Always present options with explicit, factual trade-off analysis.
+
+## Instructions
+
+### Step 1: Identify the Decision Point
+
+State clearly what needs to be decided:
+- **Decision Required**: Specific choice to be made
+- **Context**: Why this decision matters now
+- **Impact**: What will be affected
+
+### Step 2: Present Options (2-4 alternatives)
+
+For each option, provide:
+- **Name**: Clear, descriptive label
+- **Description**: What this approach entails
+- **Pros**: Factual advantages (measurable when possible)
+- **Cons**: Factual disadvantages (measurable when possible)
+- **Implementation Effort**: Low/Medium/High
+- **Maintenance Impact**: Long-term considerations
+
+### Step 3: Build a Comparison Matrix
+
+Compare options across key dimensions:
+- Performance characteristics
+- Development time
+- Maintenance burden
+- Scalability implications
+- Testing complexity
+- watchOS compatibility / offline-first alignment
+
+### Step 4: Make a Recommendation
+
+If one option is clearly superior for the context:
+- State factual reasoning based on project constraints
+- Explain why alternatives are less suitable
+- Always let the user make the final decision
+
+### Factual vs Subjective Analysis
+
+**Use factual statements**: "SQLite supports WAL mode for concurrent reads", "`@Observable` requires watchOS 10+"
+
+**Avoid subjective statements**: "SQLite is better", "SwiftUI is more modern"
+
+## Examples
+
+### Example 1: Quick Decision Template
+
+```markdown
+## Architectural Decision: [Topic]
+
+**Context**: [Why we need to decide this now]
+**Impact**: [What parts of the system are affected]
+
+### Option 1: [Name]
+**Pros**: ...
+**Cons**: ...
+**Implementation**: [Low/Medium/High]
+
+### Option 2: [Name]
+**Pros**: ...
+**Cons**: ...
+**Implementation**: [Low/Medium/High]
+
+### Comparison Matrix
+| Criterion | Option 1 | Option 2 |
+|-----------|----------|----------|
+| Performance | ... | ... |
+| Dev Time | ... | ... |
+
+### Recommendation
+**Recommended**: Option X
+**Rationale**: [Factual reasoning]
+
+**Question for User**: Which option should we proceed with?
+```
+
+### Example 2: When NOT to Use This Skill
+
+- Variable naming choices -> just follow project conventions
+- Code formatting -> use SwiftFormat / Ruff
+- Trivial choices with no trade-offs -> just pick one
+- Decisions already made -> follow existing patterns
+
+## Troubleshooting
+
+### Error: Analysis paralysis with too many options
+- Limit to 2-4 realistic options
+- Eliminate obviously unsuitable options early
+- Focus comparison on the 3-4 most important criteria for this project

--- a/.claude/skills/backlog-grooming/SKILL.md
+++ b/.claude/skills/backlog-grooming/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: backlog-grooming
+description: >-
+  Systematic GitHub backlog maintenance: review merged PRs, close resolved
+  issues, identify gaps, and create missing issues. Use when asked to
+  groom the backlog, clean up the issue tracker, or review recent work.
+  Do NOT use for PR code review (use comprehensive-pr-review).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Backlog Grooming
+
+Systematically review recent work, close resolved issues, identify gaps, and maintain a clean issue backlog.
+
+## Instructions
+
+### Step 1: Initialize Progress Tracking
+
+Create a dated progress file:
+```bash
+DATE=$(date +%Y-%m-%d)
+PROGRESS_FILE="prompts/claude-comm/${DATE}_BACKLOG_GROOMING.md"
+```
+
+### Step 2: Fetch and Analyze Recent PRs
+
+```bash
+gh pr list --state merged --limit 15 --json number,title,mergedAt,body,url
+```
+
+For each PR, extract:
+- Issues referenced (closes #N, fixes #N, resolves #N)
+- Work done (features, fixes, refactors)
+- Gaps (work done without corresponding issues)
+
+### Step 3: Verify Issue Resolution
+
+For each issue referenced in PRs:
+```bash
+gh issue view 123 --json state,title,labels
+```
+
+Decision matrix:
+- **Fully resolved** -> Close with comment referencing PR
+- **Partially resolved** -> Update with progress comment
+- **Not resolved** -> Keep open, remove incorrect PR reference
+- **Spawned new work** -> Create follow-up issue, close original
+
+### Step 4: Close Resolved Issues
+
+```bash
+gh issue close 123 --comment "Resolved in PR #456. [Description of fix]. Changes: [list]. Closes via: [PR URL]"
+```
+
+### Step 5: Check for Duplicates Before Creating New Issues
+
+```bash
+gh issue list --search "keyword" --state all
+gh issue list --label "bug" --state open
+```
+
+### Step 6: Create Missing Issues
+
+For gaps identified (features, bugs fixed, follow-up work) that have no existing issue:
+```bash
+gh issue create --title "Issue title" --body "Description" --label "label1,label2"
+```
+
+### Step 7: Finalize Progress File
+
+Complete the summary with statistics: PRs analyzed, issues closed, issues created, issues updated, backlog health before/after.
+
+## Examples
+
+### Example 1: Closing a Resolved Issue
+
+```bash
+gh issue close 293 --comment "Resolved in PR #306
+
+Decomposed ContentView monolith into focused sub-views.
+
+Changes:
+- Extracted MysticalJournalIcon, ConceptExplainerView, FlowReviewSheet
+- Extracted all views from ContentView
+- Deduplicated primaryID
+
+Thank you for reporting! Fix is merged and available."
+```
+
+### Example 2: Creating a Follow-Up Issue
+
+```bash
+gh issue create --title "feat: Add automatic retry for failed journal sync" \
+  --body "During PR #XXX, identified that failed sync entries are not retried. Need retry with exponential backoff." \
+  --label "enhancement,frontend"
+```
+
+## Troubleshooting
+
+### Error: Too many PRs to review
+- Focus on most recent PRs first
+- Split into multiple sessions, document stopping point
+
+### Error: Found many duplicate issues
+- Consolidate into a canonical issue
+- Close duplicates with link to canonical

--- a/.claude/skills/bug-squashing-methodology/SKILL.md
+++ b/.claude/skills/bug-squashing-methodology/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: bug-squashing-methodology
+description: >-
+  Structured 5-step bug fix process with root cause analysis and TDD.
+  Use when fixing bugs, debugging failures, or investigating defects.
+  Covers RCA documentation, reproduction, TDD fix cycle, and PR workflow.
+  Do NOT use for general feature development (use stay-green), CI
+  environment issues (use ci-debugging), or code reviews.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Bug Squashing Methodology
+
+Systematic process for fixing bugs: Document, Understand, Fix, Verify. Never skip straight to coding.
+
+## Instructions
+
+### Step 1: Root Cause Analysis (RCA)
+
+Create `prompts/claude-comm/RCA_ISSUE_XXX.md` with:
+- **Problem Statement**: Error message, reproduction steps
+- **Root Cause**: Exact line/logic causing failure
+- **Analysis**: Why it happens, what was confused/wrong
+- **Impact**: Severity, scope, frequency
+- **Contributing Factors**: Why wasn't it caught earlier?
+- **Fix Strategy**: Options with recommendation
+- **Prevention**: How to avoid similar bugs
+
+### Step 2: File a GitHub Issue
+
+```bash
+gh issue create --title "bug(component): Brief description" \
+  --body "Reproduction steps, root cause summary, proposed fix" \
+  --label "bug"
+```
+
+### Step 3: Branch and Fix with TDD
+
+```bash
+git checkout -b fix-component-issue-XXX
+```
+
+1. **Red**: Write a test that reproduces the bug (should fail)
+2. **Green**: Write minimal code to fix the bug (test passes)
+3. **Refactor**: Clean up the fix while keeping tests green
+
+### Step 4: Quality Gates
+
+Run both gates before committing:
+
+```bash
+# Gate 1: All tests pass
+scripts/check-backend.sh --test                        # Backend
+frontend/WavelengthWatch/run-tests-individually.sh     # Frontend
+
+# Gate 2: All quality checks pass
+pre-commit run --all-files
+```
+
+### Step 5: Commit and PR
+
+Use conventional commit format: `fix(component): brief description (#XXX)`
+
+## Examples
+
+### Example 1: Backend Data Bug
+
+**Problem**: Journal entries return null strategy when strategy_id is valid.
+
+**RCA**: `backend/routers/journal.py` missing eager load for strategy relationship.
+
+**Fix**:
+```python
+# Red: Test reproducing the bug
+def test_journal_entry_includes_strategy():
+    entry = create_test_entry(strategy_id=1)
+    response = client.get(f"/api/v1/journal/{entry.id}")
+    assert response.json()["strategy"] is not None
+
+# Green: Add eager loading
+query = select(Journal).options(joinedload(Journal.strategy))
+```
+
+### Example 2: SwiftUI State Bug
+
+**Problem**: Navigation pops to root unexpectedly during flow.
+
+**RCA**: `onChange(of: flowCoordinator.currentStep)` fires during detail view transitions.
+
+**Fix**:
+```swift
+// Red: Test the state transition
+@Test func flowTransition_doesNotPopDuringDetail() {
+    // ...
+}
+
+// Green: Guard against premature navigation pop
+case .selectingPrimary, .selectingSecondary:
+    if !navigationPath.isEmpty {
+        navigationPath.removeLast(navigationPath.count)
+    }
+```
+
+## Troubleshooting
+
+### Error: Can't reproduce the bug locally
+- Check environment differences (Xcode version, watchOS simulator)
+- Add debug logging at the failure point
+- Try running with the exact same data/input as the report
+
+### Error: Fix breaks other tests
+- Your fix may have changed shared behavior
+- Run the full test suite, not just the new test
+- Consider if the other tests were relying on buggy behavior

--- a/.claude/skills/ci-debugging/SKILL.md
+++ b/.claude/skills/ci-debugging/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: ci-debugging
+description: >-
+  Debug CI test failures on pull requests with structured protocol.
+  Use when CI fails on your PR, tests pass locally but fail in CI,
+  or you're tempted to say "pre-existing issue". Covers state comparison,
+  error reading, local reproduction, and common root causes.
+  Do NOT use for local-only test failures or feature development.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# CI Debugging
+
+If tests passed before and fail now, YOUR changes broke something. Debug properly.
+
+## Instructions
+
+### Step 1: Compare States (2 minutes)
+
+```bash
+# What did the last passing PR have?
+gh pr view <last-passing-pr> --json checks
+
+# What does my PR have?
+gh pr checks <my-pr>
+
+# What changed between them?
+git diff <last-passing-commit> HEAD
+```
+
+Ask: Did I modify config files? Add dependencies? Change imports or module structure?
+
+### Step 2: Read the Actual Error (5 minutes)
+
+```bash
+gh run view --job=<failing-job-id> --log | grep -A 50 "ERROR\|FAILED\|AssertionError"
+```
+
+Look for: path issues, configuration errors, dependency problems, file artifacts.
+
+CI jobs in this project:
+- **Pre-commit**: lint, type, security checks
+- **Backend**: Ruff lint, Mypy type check, pytest
+- **Frontend**: SwiftFormat lint, xcodebuild build + test
+
+### Step 3: Reproduce Locally (5 minutes)
+
+```bash
+# Backend
+scripts/check-backend.sh
+
+# Frontend
+frontend/WavelengthWatch/run-tests-individually.sh
+
+# Pre-commit
+pre-commit run --all-files
+```
+
+If it passes locally but fails in CI, check:
+- Xcode version differences (CI uses macos-15 runner)
+- Simulator availability (Series 10 vs Series 11)
+- Python dependency versions
+- SwiftFormat version differences
+
+### Step 4: Inspect Your Changes (10 minutes)
+
+```bash
+# Config changes
+git diff HEAD~1 -- .github/workflows/
+git diff HEAD~1 -- pyproject.toml ruff.toml mypy.ini pytest.ini
+
+# Swift changes that might break build
+git diff HEAD~1 -- "frontend/WavelengthWatch/WavelengthWatch.xcodeproj/"
+
+# Import validation
+python -c "from backend.app import app; print('OK')"
+```
+
+### Step 5: Fix and Verify
+
+Make a targeted fix, verify locally, push, confirm CI passes.
+
+## Examples
+
+### Example 1: SwiftFormat Failure
+
+**Symptom**: "SwiftFormat check" step fails in CI.
+
+**Debug**:
+```bash
+swiftformat --lint frontend  # See which files need formatting
+swiftformat frontend         # Auto-fix
+```
+
+### Example 2: Simulator Not Found
+
+**Symptom**: "Unable to find a destination matching the provided destination specifier"
+
+**Root Cause**: CI runner has different simulators than local machine.
+
+**Fix**: Use `run-tests-individually.sh` which auto-detects available simulators.
+
+## Troubleshooting
+
+### Error: "Passes locally, fails in CI"
+- Check Xcode version on CI runner vs local
+- Ensure test cleanup removes all artifacts
+- Verify SwiftFormat version matches (CI installs via brew)
+- Check if CI uses different simulator than local
+
+### Error: Spending more than 30 minutes debugging
+- Re-read the actual error message carefully
+- Check if you modified any config files
+- Compare your branch with the last green commit line by line

--- a/.claude/skills/comprehensive-pr-review/SKILL.md
+++ b/.claude/skills/comprehensive-pr-review/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: comprehensive-pr-review
+description: >-
+  Structured 10-section PR review covering security, quality, testing,
+  and documentation. Use when reviewing pull requests, evaluating code
+  changes, or doing code review. Produces verdicts with specific references.
+  Do NOT use for backlog grooming or issue triage.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Comprehensive PR Review
+
+Structured code review evaluating PRs across security, quality, testing, documentation, and project compliance.
+
+## Instructions
+
+### Step 1: Summarize the PR
+Brief overview of what the PR does (2-3 sentences).
+
+### Step 2: Identify Strengths
+What is done well: good design decisions, well-written code, comprehensive tests, clear documentation, proper error handling.
+
+### Step 3: Security Review
+Flag security issues with severity:
+- **BLOCKING**: Must fix before merge (injection, auth bypass, secrets exposure)
+- **HIGH**: Should fix soon (missing input validation, weak crypto)
+- **LOW**: Nice to have (hardening, defense-in-depth)
+
+### Step 4: Identify Problems
+Critical issues blocking merge: bugs, incorrect logic, failing tests, missing required features.
+
+### Step 5: Evaluate Code Quality
+Non-blocking improvements: readability, naming, organization, complexity.
+
+### Step 6: Check Project Compliance
+Verify against project standards:
+- Backend: Ruff lint passes, Mypy type check passes, pytest passes
+- Frontend: SwiftFormat passes, Xcode build succeeds, tests pass
+- No linter bypass comments (`# noqa`, `# type: ignore`, `// swiftlint:disable`)
+- Conventional commits used
+- View files <= 200 lines (frontend guideline)
+- Protocol-based ViewModels for testability (frontend guideline)
+
+### Step 7: Assess Testing
+- Test coverage adequate?
+- Edge cases covered?
+- Swift Testing (`@Test`) used for new frontend tests?
+- pytest used for backend tests?
+
+### Step 8: Review Documentation
+- Code comments where logic isn't self-evident?
+- CLAUDE.md updated if commands/architecture changed?
+
+### Step 9: List Requests
+Medium-priority suggestions that would improve the PR.
+
+### Step 10: Deliver Verdict
+- **LGTM** - Ready to merge
+- **CHANGES_REQUESTED** - Must fix blocking issues
+- **COMMENTS** - Suggestions only, can merge as-is
+
+Include reasoning with specific file:line references.
+
+## Examples
+
+### Example 1: Approval with Suggestions
+
+```markdown
+## Summary
+Adds glass effect modifier with backward compatibility for watchOS < 26.
+
+## Strengths
+- Clean `if #available` pattern for version checking
+- Good test coverage with Swift Testing framework
+- Follows design system token conventions
+
+## Verdict: LGTM
+Well-structured PR. Suggestions are non-blocking.
+```
+
+### Example 2: Changes Requested
+
+```markdown
+## Summary
+Adds new journal entry view with inline editing.
+
+## Problems
+- View file is 340 lines (guideline: <= 200)
+- ViewModel uses concrete types instead of protocols
+
+## Verdict: CHANGES_REQUESTED
+Extract sub-views and add protocol conformance for testability.
+```
+
+## Troubleshooting
+
+### Error: PR is too large to review effectively
+- Ask the author to split into smaller PRs
+- Focus on the most critical files first
+- Use `gh pr diff --name-only` to prioritize which files to review

--- a/.claude/skills/file-naming-conventions/SKILL.md
+++ b/.claude/skills/file-naming-conventions/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: file-naming-conventions
+description: >-
+  ISO 8601 date-prefix file naming conventions for documents and plans.
+  Use when creating dated documents, plan files, analysis reports,
+  or any time-sensitive documentation.
+  Do NOT use for source code files, configs, or permanent reference docs.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# File Naming Conventions
+
+Always prefix dated documents with ISO 8601 format (YYYY-MM-DD) for natural chronological sorting.
+
+## Instructions
+
+### Step 1: Determine if the Document Needs a Date Prefix
+
+**Use date prefixes for**: analysis reports, status reports, plans, RCAs, meeting notes, decision records, progress updates, backlog grooming results.
+
+**Skip date prefixes for**: README.md, CLAUDE.md, source code, test files, configs, templates.
+
+### Step 2: Construct the Filename
+
+**Format**: `YYYY-MM-DD_DESCRIPTIVE_NAME.ext`
+
+- Date: 4-digit year, 2-digit month, 2-digit day, separated by hyphens
+- Separator: Single underscore between date and description
+- Name: ALL_CAPS for major documents, lowercase_with_underscores for supporting docs
+- Store in `prompts/claude-comm/` for coordination documents
+
+### Step 3: Handle Special Cases
+
+**Multiple documents same day**: Use descriptive disambiguation:
+```
+2026-03-13_RCA_ISSUE_295.md
+2026-03-13_BACKLOG_GROOMING.md
+```
+
+**Versioned documents**: `YYYY-MM-DD_DOCUMENT_NAME_vX.Y.md`
+
+## Examples
+
+### Example 1: Plan and Analysis Files
+```
+prompts/claude-comm/2026-03-13_LIQUID_GLASS_PHASE_1B_PLAN.md
+prompts/claude-comm/2026-03-13_BACKLOG_GROOMING.md
+prompts/claude-comm/2026-03-10_RCA_ISSUE_295.md
+```
+
+### Example 2: Quick Creation
+```bash
+DATE=$(date +%Y-%m-%d)
+touch "prompts/claude-comm/${DATE}_MY_DOCUMENT.md"
+```

--- a/.claude/skills/max-quality-no-shortcuts/SKILL.md
+++ b/.claude/skills/max-quality-no-shortcuts/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: max-quality-no-shortcuts
+description: >-
+  Anti-bypass philosophy for linter and type checker warnings. Activates
+  when you consider adding noqa, type-ignore, swiftlint-disable, or similar
+  bypasses. Fix the root cause instead. Covers complexity refactoring,
+  type fixes, and argument reduction patterns.
+  Do NOT use for general code quality guidance (use vibe or stay-green).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# MAX QUALITY: No Shortcuts
+
+When you're about to add a linter bypass: STOP. Fix the root cause instead.
+
+## Instructions
+
+### Step 1: Understand the Warning
+
+Read the error message carefully. Look up the rule if unfamiliar. Understand the underlying principle the tool is enforcing.
+
+### Step 2: Identify the Root Cause
+
+Ask:
+- Is my code too complex? -> Refactor into smaller functions
+- Is my type annotation wrong? -> Fix the type or implementation
+- Is my import unused? -> Remove it
+- Is my function too long? -> Extract helper functions
+- Is my SwiftUI view too large? -> Extract sub-views
+
+### Step 3: Fix Properly
+
+| Bypass | Proper Fix |
+|--------|-----------|
+| `# noqa: C901` (complexity) | Refactor into smaller functions |
+| `# type: ignore` | Fix the type annotation or implementation |
+| `# noqa: F401` (unused import) | Remove the import |
+| `# noqa: E501` (line too long) | Break into multiple lines |
+| `// swiftlint:disable` | Fix the actual issue |
+| `@available(*, deprecated)` hacks | Use proper version checking |
+
+### Step 4: Handle Genuine Exceptions
+
+Bypasses are acceptable ONLY for:
+1. Third-party library type stub gaps (document with link)
+2. Platform version compatibility (`if #available`)
+3. Auto-generated code you don't control
+
+For these cases, you MUST include:
+```python
+# type: ignore[no-untyped-call]
+# Reason: uvicorn.run() missing type stubs in current version
+# Reference: https://github.com/encode/uvicorn/issues/XXX
+```
+
+## Examples
+
+### Example 1: Python Complexity Too High
+
+```python
+# BAD: # noqa: C901
+def process_journal_entry(entry, user, feelings, strategy):
+    if entry.status == "pending":
+        if user.is_verified:
+            # 30 more lines of nested ifs...
+
+# GOOD: Extract validation functions
+def process_journal_entry(entry, user, feelings, strategy) -> Result:
+    _validate_entry(entry)
+    _validate_user(user)
+    return _create_entry(entry, user, feelings, strategy)
+```
+
+### Example 2: SwiftUI View Too Large
+
+```swift
+// BAD: 400-line ContentView with everything inline
+
+// GOOD: Decompose into focused sub-views
+var body: some View {
+    NavigationStack {
+        contentStack           // Loading/error/main states
+            .toolbar { toolbarContent }
+            .sheet(isPresented: $showSheet) { sheetContent }
+    }
+}
+```
+
+## Troubleshooting
+
+### Error: "I genuinely can't fix this without a bypass"
+- Is it a third-party library issue? Document it with a link
+- Can you restructure the code to avoid the situation entirely?
+- If truly necessary, add full justification comment
+
+### Error: "Fixing this properly will take too long"
+- 10 minutes fixing properly now saves 2 hours debugging later
+- Each bypass makes the next one easier to justify

--- a/.claude/skills/prompt-engineering/SKILL.md
+++ b/.claude/skills/prompt-engineering/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: prompt-engineering
+description: >-
+  Transform vague requests into effective 6-component prompts.
+  Use when crafting prompts for AI agents, writing plan files,
+  delegating tasks, or when Claude's responses miss the mark.
+  Covers role, goal, context, format, examples, and constraints.
+  Do NOT use for direct code implementation or testing.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Prompt Engineering
+
+Transform vague requests into effective, actionable prompts using the 6-component framework.
+
+## Instructions
+
+### Step 1: Identify Missing Components
+
+Check the prompt against the 6-component checklist:
+1. **Role or Persona** - Who the AI should be
+2. **Goal / Task Statement** - Exactly what you want done
+3. **Context or References** - Key data the model needs
+4. **Format or Output Requirements** - How you want the answer
+5. **Examples or Demonstrations** - Show, don't just tell
+6. **Constraints / Additional Instructions** - Boundaries that improve quality
+
+Missing 3+ items? Rewrite the prompt.
+
+### Step 2: Rewrite with All Components
+
+Transform the vague request into a structured prompt with all 6 components present. Be concise but complete.
+
+### Step 3: Apply to Plan Files
+
+All files in `prompts/claude-comm/` should follow this structure:
+```markdown
+## Role
+You are a [specific role with relevant expertise].
+
+## Goal
+[Specific, measurable task with clear success criteria]
+
+## Context
+- Current state, problem, constraints, file references
+
+## Output Format
+[Specify structure: numbered steps, code blocks, etc.]
+
+## Examples
+[Concrete examples of what you want]
+
+## Requirements
+- [Specific constraints]
+```
+
+## Examples
+
+### Example 1: SwiftUI Feature Request
+
+**Ineffective**: "Add glass effect to the cards."
+
+**Effective**:
+```
+Role: Senior SwiftUI engineer with watchOS and Liquid Glass expertise.
+
+Task: Add glass effect modifier to PhaseCardView with backward compatibility.
+
+Context:
+- WLGlassModifier exists in DesignSystem/Modifiers/
+- Must support watchOS 11+ (fallback) and watchOS 26+ (native glass)
+- Cards display phase info within LayerView's horizontal scroll
+
+Format: Swift code with @available checks. Include test.
+
+Constraints:
+- Follow WL prefix convention
+- View extension pattern: .wlGlass()
+- File must be <= 200 lines
+```
+
+## Troubleshooting
+
+### Error: AI responses are too vague or miss the mark
+- Add concrete examples showing exactly what good output looks like
+- Specify the output format explicitly
+- Add constraints to narrow the scope

--- a/.claude/skills/stay-green/SKILL.md
+++ b/.claude/skills/stay-green/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: stay-green
+description: >-
+  2-gate TDD development workflow: Gate 1 is Red-Green-Refactor testing,
+  Gate 2 is pre-commit quality checks. Use when implementing features,
+  fixing bugs, or doing any development work. Ensures code is never
+  committed without passing tests and quality checks.
+  Do NOT use for bug-specific debugging (use bug-squashing-methodology).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Stay Green
+
+Write tests first, then code. Never declare work finished until all checks pass.
+
+## Instructions
+
+### Gate 1: TDD (Red-Green-Refactor)
+
+1. **Red** - Write a failing test describing the behavior you want
+   ```bash
+   # Backend
+   scripts/check-backend.sh --test
+   # Frontend
+   frontend/WavelengthWatch/run-tests-individually.sh
+   ```
+
+2. **Green** - Write just enough code to make the test pass
+   ```bash
+   # Same commands — should now pass
+   ```
+
+3. **Refactor** - Clean up while keeping tests green
+   ```bash
+   # Same commands — should still pass
+   ```
+
+Repeat for each small piece of functionality. Write tests incrementally, not all at once.
+
+### Gate 2: Pre-Commit Quality Checks
+
+```bash
+pre-commit run --all-files
+```
+
+When checks fail: read errors, fix issues, run again. Repeat until all green.
+
+Quality checks include:
+- **Backend**: Ruff lint + format, Mypy type checking, pytest, bandit security
+- **Frontend**: SwiftFormat formatting
+- File hygiene (trailing whitespace, EOF, YAML/JSON/TOML validity)
+
+### Work is DONE when:
+1. All tests pass (Gate 1 complete)
+2. All pre-commit checks pass (Gate 2 complete)
+
+No exceptions.
+
+## Examples
+
+### Example 1: Adding a New Backend Endpoint
+
+```python
+# Gate 1 - Red: Write failing test
+def test_get_phase_returns_expected_fields():
+    response = client.get("/api/v1/phases/1")
+    assert response.status_code == 200
+    assert "name" in response.json()
+
+# Gate 1 - Green: Implement endpoint
+# Gate 1 - Refactor: Clean up
+# Gate 2: pre-commit run --all-files -> All passed!
+```
+
+### Example 2: Adding a SwiftUI View
+
+```swift
+// Gate 1 - Red: Write failing test (Swift Testing)
+@Test func phaseCard_displaysTitle() {
+    let card = PhaseCardView(phase: .mock)
+    #expect(card.title == "Rising")
+}
+
+// Gate 1 - Green: Implement view
+// Gate 2: pre-commit run --all-files -> SwiftFormat passes
+```
+
+## Troubleshooting
+
+### Error: Frontend tests fail with simulator issues
+```bash
+# Use the test script — it handles simulator lifecycle
+frontend/WavelengthWatch/run-tests-individually.sh
+# Never invoke xcodebuild directly
+```
+
+### Error: Backend type errors from Mypy
+```bash
+scripts/check-backend.sh --type  # See specific errors
+# Fix type annotations
+scripts/check-backend.sh         # Verify all checks pass
+```

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: testing
+description: >-
+  Write comprehensive, maintainable tests following TDD and AAA pattern.
+  Use when writing unit tests, integration tests, setting up fixtures,
+  mocking dependencies, or improving test coverage. Covers Python (pytest)
+  and Swift (Swift Testing framework).
+  Do NOT use for mutation testing specifics.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Testing
+
+Test behavior, not implementation. One assertion concept per test. Follow AAA (Arrange-Act-Assert).
+
+## Instructions
+
+### Step 1: Follow the Principles
+
+1. Test behavior, not implementation
+2. One assertion concept per test
+3. Follow AAA pattern (Arrange-Act-Assert)
+4. Write tests first (TDD) when possible
+5. Keep tests fast and isolated
+6. Make tests readable and self-documenting
+
+### Step 2: Apply Language-Specific Patterns
+
+**Python (pytest)**:
+- Use pytest classes to group related tests
+- Use fixtures for setup/teardown
+- Use `@pytest.mark.parametrize` for data-driven tests
+- Use `httpx.AsyncClient` for FastAPI endpoint tests
+- Mock external dependencies, not internal logic
+
+**Swift (Swift Testing)**:
+- Use `@Test` attribute (not XCTest)
+- Use `#expect()` for assertions (not XCTAssert)
+- Use `@Suite` to group related tests
+- Use descriptive test function names: `func featureName_scenario_expectedResult()`
+- Keep test files in `WavelengthWatch Watch AppTests/`
+
+### Step 3: Follow Coverage Best Practices
+
+- Test edge cases: empty inputs, boundary values, nil, concurrent access
+- Test error paths, not just happy paths
+- Don't test third-party code - mock external services
+- Backend: `pytest --cov=backend --cov-report=html`
+- Frontend: test via `run-tests-individually.sh`
+
+## Examples
+
+### Example 1: Python Unit Test with Parametrize
+
+```python
+class TestJournalValidation:
+    def test_valid_entry_creates_successfully(self, db_session):
+        entry = create_journal_entry(feeling_id=1, strategy_id=1)
+        assert entry.id is not None
+        assert entry.feeling_id == 1
+
+    @pytest.mark.parametrize("feeling_id,expected_error", [
+        (None, "feeling_id is required"),
+        (999, "feeling not found"),
+    ])
+    def test_invalid_feeling_raises_error(self, db_session, feeling_id, expected_error):
+        with pytest.raises(ValueError, match=expected_error):
+            create_journal_entry(feeling_id=feeling_id)
+```
+
+### Example 2: Swift Testing
+
+```swift
+@Suite struct WLColorTokensTests {
+    @Test func namedLayerColors_allElevenAreDefined() {
+        let colors = [
+            WLColorTokens.beige, WLColorTokens.purple, WLColorTokens.red,
+            WLColorTokens.blue, WLColorTokens.orange, WLColorTokens.green,
+        ]
+        #expect(colors.count == 6)
+    }
+
+    @Test func layerColor_returnsNonNilForValidStage() {
+        let color = WLColorTokens.layer("Beige")
+        #expect(color != nil)
+    }
+}
+```
+
+## Troubleshooting
+
+### Error: Tests are slow
+- Mock external dependencies (HTTP, database)
+- Use `tmp_path` fixture for filesystem tests
+- Profile with `pytest --durations=10`
+
+### Error: Tests are flaky
+- Look for shared state between tests
+- Check for test order dependencies
+- Mock time-dependent code
+- Avoid sleep() in tests
+
+### Error: Frontend tests crash simulator
+- Always use `run-tests-individually.sh`, never direct xcodebuild
+- Try `--individual` flag if all-at-once mode crashes

--- a/.claude/skills/tracer-code/SKILL.md
+++ b/.claude/skills/tracer-code/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: tracer-code
+description: >-
+  Tracer code development methodology for building working systems
+  incrementally. Use when starting complex features, working under
+  time constraints, or when you need a buildable app at every stage.
+  Wire the skeleton first, then replace stubs with real logic one at a time.
+  Do NOT use for small bug fixes or single-function tasks.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Tracer Code Development
+
+Wire the entire system end-to-end with stubs, then iteratively replace them with real implementations - always maintaining a buildable, testable application.
+
+## Instructions
+
+### Phase 1: Wire the Skeleton (10-15% of time budget)
+
+1. **Define the surface** - All views/endpoints with placeholder content
+2. **Stub everything** - Return mock data matching expected types
+3. **Connect all layers** - View -> ViewModel -> Service, even if one-liners
+4. **Verify it builds** - Confirm Xcode build succeeds, backend starts
+5. **Write smoke tests** - One test per component proving it renders/returns
+
+```swift
+// Stubbed view example
+struct PhaseDetailView: View {
+    let phase: Phase
+
+    var body: some View {
+        // TODO: implement real layout
+        Text(phase.name)
+            .wlCard()
+    }
+}
+```
+
+**Gate check**: Build succeeds, tests pass. You now have a demoable skeleton.
+
+### Phase 2: Prioritize and Iterate (75-80% of time budget)
+
+Replace stubs with real implementations one at a time, in priority order:
+
+1. Rank features by user impact
+2. For each feature: write failing test -> implement -> verify -> commit
+3. Never break the skeleton - if stuck, keep the stub and move on
+4. Reassess priority after each feature
+
+**Priority heuristic**:
+- **P0**: Core interaction (the thing the user touches first)
+- **P1**: Data display and formatting
+- **P2**: Edge cases and secondary interactions
+- **P3**: Polish (animations, transitions, micro-interactions)
+
+### Phase 3: Polish (5-10% of time budget)
+
+- Add edge case tests for implemented features
+- Improve error states and empty states
+- Clean up remaining TODOs in implemented code
+- Do NOT start new features - polish what works
+
+### Decision Framework
+
+At any point, ask: "If I stopped right now, would this build and be testable?"
+- **Yes** -> Keep going, pick next highest-impact feature
+- **No** -> Stop. Get back to green. Stub it out and move on.
+
+## Examples
+
+### Example 1: Liquid Glass View Rebuild
+
+**Phase 1** (skeleton):
+```swift
+struct LayerView: View {
+    let layer: Layer
+    var body: some View {
+        Text(layer.name) // Stub
+    }
+}
+```
+
+**Phase 2** (real implementation):
+```swift
+struct LayerView: View {
+    let layer: Layer
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack {
+                ForEach(layer.phases) { phase in
+                    PhaseCardView(phase: phase, layerColor: layer.color)
+                }
+            }
+        }
+        .wlGlass()
+    }
+}
+```
+
+## Troubleshooting
+
+### Error: Feature is harder than expected and breaking the build
+- Revert the change immediately
+- Keep the stub for that feature
+- Move to the next priority item
+
+### Error: Spending too long on one feature
+- A building skeleton with 3 real features beats a broken app with 1 perfect feature

--- a/.claude/skills/vibe/SKILL.md
+++ b/.claude/skills/vibe/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: vibe
+description: >-
+  Code style, naming conventions, and structural patterns for consistent
+  codebases. Use when writing new code, reviewing style choices, or
+  establishing project conventions. Covers Python and Swift idioms.
+  Do NOT use for documentation content or architectural decisions.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Vibe
+
+Consistent code style: consistency over cleverness, readability over brevity, explicitness over implicitness.
+
+## Instructions
+
+### Step 1: Follow Language Idioms
+
+**Python**: PEP 8/257, type hints everywhere, Pydantic models for schemas, SQLModel for DB, pathlib for paths, async/await for I/O.
+
+**Swift**: SwiftUI declarative patterns, `@Observable` / `@StateObject` as appropriate, protocol-oriented design, small focused views (< 200 lines), `if #available` for version checks.
+
+### Step 2: Apply Naming Conventions
+
+| Element | Python | Swift |
+|---------|--------|-------|
+| Functions | `snake_case` | `camelCase` |
+| Classes/Types | `PascalCase` | `PascalCase` |
+| Constants | `SCREAMING_SNAKE` | `camelCase` (static let) |
+| Files | `snake_case.py` | `PascalCase.swift` |
+| Test functions | `test_feature_scenario` | `func feature_scenario_expected()` |
+
+### Step 3: Follow Project Conventions
+
+**Frontend (SwiftUI)**:
+- Design system prefix: `WL` (WavelengthWatch)
+- Token enums: `WLColorTokens`, `WLTypographyTokens`, `WLSpacingTokens`
+- Modifiers: `WLGlassModifier`, `WLCardModifier`
+- View extensions: `.wlGlass()`, `.wlCard()`, `.wlNavigationBar()`
+- Backward compat: `if #available(watchOS 26, *)` with fallback
+
+**Backend (FastAPI)**:
+- Routers in `backend/routers/`
+- Schemas in `backend/schemas.py`
+- Models in `backend/models.py`
+- Line length: 78 chars (Ruff)
+
+### Step 4: Avoid Anti-Patterns
+
+- No clever code over clear code
+- No abbreviations (unless universally understood)
+- No deep nesting (> 3 levels)
+- No long functions (> 50 lines)
+- No mixed abstraction levels
+- No magic numbers without constants
+- No global state or god objects
+- No views > 200 lines (extract sub-views)
+
+## Examples
+
+### Example 1: Good Swift Style
+
+```swift
+struct PhaseCardView: View {
+    let phase: Phase
+    let layerColor: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WLSpacingTokens.sm) {
+            Text(phase.name)
+                .font(WLTypographyTokens.cardTitle)
+            Text(phase.description)
+                .font(WLTypographyTokens.cardSubtitle)
+                .foregroundStyle(.secondary)
+        }
+        .wlCard(tint: layerColor)
+    }
+}
+```
+
+### Example 2: Good Python Style
+
+```python
+from backend.models import Journal
+from backend.schemas import JournalCreate
+
+async def create_entry(
+    entry: JournalCreate,
+    session: AsyncSession,
+) -> Journal:
+    """Create a journal entry with validated relationships."""
+    journal = Journal(**entry.model_dump())
+    session.add(journal)
+    await session.commit()
+    return journal
+```
+
+## Troubleshooting
+
+### Error: Inconsistent style across the codebase
+- Run `swiftformat frontend` for Swift
+- Run `scripts/check-backend.sh --fix` for Python
+- Follow existing patterns in the codebase over personal preference

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ backend/database.db
 app.db
 .test-cache/
 
-# Claude agent system (copied from ml-odyssey, not checked in)
-.claude/
+# Claude Code - ignore local settings, track skills/agents/shared
+.claude/settings.local.json
+.claude/worktrees/
+.claude/commands/


### PR DESCRIPTION
## Summary
- Adapts 12 skills from creek-tools for this Swift/Python watchOS project
- Un-ignores `.claude/` (except `settings.local.json`, `worktrees/`, `commands/`) so skills, agents, and shared configs are version-controlled
- Existing agents and shared rules now tracked alongside the new skills

### Skills added
| Skill | Purpose |
|-------|---------|
| `stay-green` | 2-gate TDD workflow (test + pre-commit) |
| `ci-debugging` | Structured CI failure debugging |
| `comprehensive-pr-review` | 10-section PR review checklist |
| `max-quality-no-shortcuts` | Anti-linter-bypass philosophy |
| `architectural-decisions` | Trade-off analysis for arch choices |
| `bug-squashing-methodology` | RCA + TDD bug fix process |
| `backlog-grooming` | GitHub issue tracker maintenance |
| `testing` | pytest + Swift Testing patterns |
| `vibe` | Code style for Python + Swift |
| `file-naming-conventions` | ISO 8601 dated document naming |
| `tracer-code` | Incremental skeleton-first development |
| `prompt-engineering` | 6-component prompt framework |

All skills adapted from creek-tools with Swift/watchOS/FastAPI context replacing Go/Rust/TS references.

## Test plan
- [ ] Skills load correctly in Claude Code (visible in `/skills` or slash command list)
- [ ] Pre-commit passes (no secrets, valid markdown)
- [ ] Existing agents/shared configs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)