### PR TITLE
feat: add scripts/pr-status.sh for multi-PR status checks (#232)

### DIFF
--- a/scripts/pr-status.sh
+++ b/scripts/pr-status.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+#
+# pr-status.sh — concise, multi-PR status check for efficient CI monitoring.
+#
+# Usage:
+#   scripts/pr-status.sh [options] <pr-number> [<pr-number>...]
+#   echo "64 65 66" | scripts/pr-status.sh
+#
+# Options:
+#   -h, --help        Show this help and exit
+#   -v, --verbose     Show every individual check name and conclusion
+#       --json        Emit a JSON array instead of human-readable text
+#       --summary     One-line summary per PR
+#       --ci-only     Only CI status (omit reviews/mergeable/timestamps)
+#       --reviews-only  Only review status (omit CI rollup)
+#       --no-cache    Skip reading/writing the local cache
+#       --no-color    Disable ANSI colors (also auto-disabled when stdout
+#                     is not a terminal or NO_COLOR is set)
+#
+# Environment:
+#   GH_CMD                  Path to the gh binary (default: gh). Tests inject
+#                           a stub here.
+#   PR_STATUS_CACHE_DIR     Cache directory (default: ${TMPDIR:-/tmp}/pr-status-cache)
+#   PR_STATUS_CACHE_TTL     Cache lifetime in seconds (default: 30)
+#
+# Exit codes:
+#   0  All PRs passing / merged / closed without failures
+#   1  At least one PR has a failing check or unmergeable conflict
+#   2  No failures, but at least one PR has pending checks
+#   3  Usage error (bad option, no PRs, non-numeric PR number)
+
+set -euo pipefail
+
+GH_CMD="${GH_CMD:-gh}"
+CACHE_DIR="${PR_STATUS_CACHE_DIR:-${TMPDIR:-/tmp}/pr-status-cache}"
+CACHE_TTL="${PR_STATUS_CACHE_TTL:-30}"
+
+VERBOSE=0
+JSON=0
+SUMMARY=0
+CI_ONLY=0
+REVIEWS_ONLY=0
+USE_CACHE=1
+USE_COLOR=1
+
+if [[ -n "${NO_COLOR:-}" ]] || ! [[ -t 1 ]]; then
+    USE_COLOR=0
+fi
+
+usage() {
+    sed -n '3,31p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die_usage() {
+    if [[ $# -gt 0 ]]; then
+        printf 'Error: %s\n\n' "$*" >&2
+    fi
+    usage >&2
+    exit 3
+}
+
+PR_NUMBERS=()
+while (( $# > 0 )); do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        -v|--verbose) VERBOSE=1 ;;
+        --json) JSON=1 ;;
+        --summary) SUMMARY=1 ;;
+        --ci-only) CI_ONLY=1 ;;
+        --reviews-only) REVIEWS_ONLY=1 ;;
+        --no-cache) USE_CACHE=0 ;;
+        --no-color) USE_COLOR=0 ;;
+        --)
+            shift
+            while (( $# > 0 )); do
+                PR_NUMBERS+=("$1"); shift
+            done
+            break
+            ;;
+        -*)
+            die_usage "unknown option: $1"
+            ;;
+        *)
+            PR_NUMBERS+=("$1")
+            ;;
+    esac
+    shift
+done
+
+if (( ${#PR_NUMBERS[@]} == 0 )) && ! [[ -t 0 ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # split on whitespace
+        # shellcheck disable=SC2206
+        toks=( $line )
+        for tok in "${toks[@]}"; do
+            PR_NUMBERS+=("$tok")
+        done
+    done
+fi
+
+if (( ${#PR_NUMBERS[@]} == 0 )); then
+    die_usage "no PR numbers supplied"
+fi
+
+for n in "${PR_NUMBERS[@]}"; do
+    if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+        die_usage "'$n' is not a valid PR number"
+    fi
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required but not found in PATH" >&2
+    exit 3
+fi
+
+if (( USE_COLOR )); then
+    C_RESET=$'\033[0m'
+    C_BOLD=$'\033[1m'
+    C_DIM=$'\033[2m'
+    C_GREEN=$'\033[32m'
+    C_RED=$'\033[31m'
+    C_YELLOW=$'\033[33m'
+    C_CYAN=$'\033[36m'
+else
+    C_RESET=''
+    C_BOLD=''
+    C_DIM=''
+    C_GREEN=''
+    C_RED=''
+    C_YELLOW=''
+    C_CYAN=''
+fi
+
+file_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
+}
+
+fetch_pr() {
+    local num="$1"
+    local cache_file="$CACHE_DIR/$num.json"
+    if (( USE_CACHE )) && [[ -f "$cache_file" ]]; then
+        local mtime now age
+        mtime=$(file_mtime "$cache_file" || echo 0)
+        now=$(date +%s)
+        age=$(( now - mtime ))
+        if (( age >= 0 && age < CACHE_TTL )); then
+            cat "$cache_file"
+            return 0
+        fi
+    fi
+
+    local fields
+    fields="number,title,state,url,author,headRefName,baseRefName,createdAt,updatedAt,mergeable,mergeStateStatus,reviewDecision,reviews,comments,statusCheckRollup"
+    local data
+    if ! data=$("$GH_CMD" pr view "$num" --json "$fields" 2>&1); then
+        printf 'Error: failed to fetch PR #%s: %s\n' "$num" "$data" >&2
+        return 1
+    fi
+    if (( USE_CACHE )); then
+        mkdir -p "$CACHE_DIR"
+        printf '%s' "$data" > "$cache_file"
+    fi
+    printf '%s' "$data"
+}
+
+map_mergeable() {
+    case "$1" in
+        MERGEABLE) echo "YES" ;;
+        CONFLICTING) echo "NO" ;;
+        "") echo "UNKNOWN" ;;
+        *) echo "UNKNOWN" ;;
+    esac
+}
+
+# Input: raw gh JSON for one PR on stdin.
+# Output: a normalized JSON object on stdout containing the fields the rest
+# of the script (and the --json mode) needs.
+normalize_pr() {
+    jq '
+      def passing_conclusions: ["SUCCESS", "NEUTRAL", "SKIPPED"];
+      def failing_conclusions: ["FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE"];
+
+      def short_updated: (.updatedAt // "" | sub("T"; " ") | sub("Z$"; "") | .[0:16]);
+
+      def mergeable_label:
+        (.mergeable // "") as $m
+        | if $m == "MERGEABLE" then "YES"
+          elif $m == "CONFLICTING" then "NO"
+          else "UNKNOWN" end;
+
+      (.statusCheckRollup // []) as $checks
+      | ($checks | length) as $total
+      | ([$checks[] | select((.status // "") == "COMPLETED" and ((.conclusion // "") | IN(passing_conclusions[])))] | length) as $passing
+      | ([$checks[] | select((.status // "") == "COMPLETED" and ((.conclusion // "") | IN(failing_conclusions[])))] | length) as $failing
+      | ([$checks[] | select((.status // "") != "COMPLETED")] | length) as $pending
+      | ([(.reviews // [])[] | select(.state == "APPROVED")] | length) as $approvals
+      | ((.comments // []) | length) as $comment_count
+      | (if $total == 0 then "none"
+         elif $failing > 0 then "failing"
+         elif $pending > 0 then "pending"
+         else "passing" end) as $ci_state
+      | {
+          number: .number,
+          title: (.title // ""),
+          state: (.state // ""),
+          url: (.url // ""),
+          author: ((.author // {}).login // ""),
+          headRefName: (.headRefName // ""),
+          baseRefName: (.baseRefName // ""),
+          createdAt: (.createdAt // ""),
+          updatedAt: (.updatedAt // ""),
+          updatedShort: short_updated,
+          mergeable: mergeable_label,
+          mergeStateStatus: (.mergeStateStatus // ""),
+          ci: {
+            total: $total,
+            passing: $passing,
+            failing: $failing,
+            pending: $pending,
+            state: $ci_state,
+            checks: [$checks[] | {
+              name: (.name // ""),
+              status: (.status // ""),
+              conclusion: (.conclusion // "")
+            }]
+          },
+          reviews: {
+            approvals: $approvals,
+            decision: (.reviewDecision // ""),
+            comments: $comment_count
+          }
+        }
+    '
+}
+
+ci_human_line() {
+    local total="$1" passing="$2" failing="$3" pending="$4" state="$5"
+    case "$state" in
+        passing)
+            printf '%s✅ All passing (%d/%d checks)%s' \
+                "$C_GREEN" "$passing" "$total" "$C_RESET"
+            ;;
+        failing)
+            printf '%s❌ %d failing (%d/%d checks)%s' \
+                "$C_RED" "$failing" "$failing" "$total" "$C_RESET"
+            ;;
+        pending)
+            local started=$(( total - pending ))
+            printf '%s⏳ Pending (%d/%d checks started)%s' \
+                "$C_YELLOW" "$started" "$total" "$C_RESET"
+            ;;
+        none|*)
+            printf '%s— No checks reported%s' "$C_DIM" "$C_RESET"
+            ;;
+    esac
+}
+
+pluralize() {
+    # $1 count, $2 singular, $3 plural
+    if [[ "$1" == "1" ]]; then
+        printf '%s' "$2"
+    else
+        printf '%s' "$3"
+    fi
+}
+
+render_default() {
+    local norm="$1"
+    local number title state approvals decision comments mergeable updated
+    local ci_total ci_pass ci_fail ci_pending ci_state
+
+    number=$(jq -r '.number' <<<"$norm")
+    title=$(jq -r '.title' <<<"$norm")
+    state=$(jq -r '.state' <<<"$norm")
+    approvals=$(jq -r '.reviews.approvals' <<<"$norm")
+    decision=$(jq -r '.reviews.decision' <<<"$norm")
+    comments=$(jq -r '.reviews.comments' <<<"$norm")
+    mergeable=$(jq -r '.mergeable' <<<"$norm")
+    updated=$(jq -r '.updatedShort' <<<"$norm")
+    ci_total=$(jq -r '.ci.total' <<<"$norm")
+    ci_pass=$(jq -r '.ci.passing' <<<"$norm")
+    ci_fail=$(jq -r '.ci.failing' <<<"$norm")
+    ci_pending=$(jq -r '.ci.pending' <<<"$norm")
+    ci_state=$(jq -r '.ci.state' <<<"$norm")
+
+    printf '%s=== PR #%s: %s ===%s\n' "$C_BOLD" "$number" "$title" "$C_RESET"
+
+    if (( ! REVIEWS_ONLY )); then
+        printf 'Status: %s\n' "$state"
+    fi
+
+    if (( ! REVIEWS_ONLY )); then
+        printf 'CI: '
+        ci_human_line "$ci_total" "$ci_pass" "$ci_fail" "$ci_pending" "$ci_state"
+        printf '\n'
+
+        if (( VERBOSE )); then
+            local checks
+            checks=$(jq -c '.ci.checks[]' <<<"$norm")
+            while IFS= read -r chk; do
+                [[ -z "$chk" ]] && continue
+                local cname cstatus cconclusion badge
+                cname=$(jq -r '.name' <<<"$chk")
+                cstatus=$(jq -r '.status' <<<"$chk")
+                cconclusion=$(jq -r '.conclusion' <<<"$chk")
+                case "$cconclusion" in
+                    SUCCESS|NEUTRAL|SKIPPED) badge="${C_GREEN}✓${C_RESET}" ;;
+                    FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE) badge="${C_RED}✗${C_RESET}" ;;
+                    "") badge="${C_YELLOW}…${C_RESET}" ;;
+                    *) badge="${C_DIM}?${C_RESET}" ;;
+                esac
+                local label="$cconclusion"
+                [[ -z "$label" ]] && label="$cstatus"
+                printf '  %b %s: %s\n' "$badge" "$cname" "$label"
+            done <<<"$checks"
+        fi
+    fi
+
+    if (( ! CI_ONLY )); then
+        local approval_word comment_word
+        approval_word=$(pluralize "$approvals" "approval" "approvals")
+        comment_word=$(pluralize "$comments" "comment" "comments")
+        if [[ -n "$decision" && "$decision" != "null" ]]; then
+            printf 'Reviews: %s %s, %s %s (%s)\n' \
+                "$approvals" "$approval_word" \
+                "$comments" "$comment_word" \
+                "$decision"
+        else
+            printf 'Reviews: %s %s, %s %s\n' \
+                "$approvals" "$approval_word" \
+                "$comments" "$comment_word"
+        fi
+        printf 'Mergeable: %s\n' "$mergeable"
+        if [[ -n "$updated" && "$updated" != "null" ]]; then
+            printf 'Last updated: %s\n' "$updated"
+        fi
+    fi
+
+    if (( VERBOSE )); then
+        local url author head base
+        url=$(jq -r '.url' <<<"$norm")
+        author=$(jq -r '.author' <<<"$norm")
+        head=$(jq -r '.headRefName' <<<"$norm")
+        base=$(jq -r '.baseRefName' <<<"$norm")
+        printf 'Author: %s\n' "$author"
+        printf 'Branch: %s -> %s\n' "$head" "$base"
+        printf 'URL: %s\n' "$url"
+    fi
+
+    printf '\n'
+}
+
+render_summary() {
+    local norm="$1"
+    local number state ci_state ci_total ci_pass ci_fail ci_pending
+    local approvals comments mergeable badge
+    number=$(jq -r '.number' <<<"$norm")
+    state=$(jq -r '.state' <<<"$norm")
+    ci_total=$(jq -r '.ci.total' <<<"$norm")
+    ci_pass=$(jq -r '.ci.passing' <<<"$norm")
+    ci_fail=$(jq -r '.ci.failing' <<<"$norm")
+    ci_pending=$(jq -r '.ci.pending' <<<"$norm")
+    ci_state=$(jq -r '.ci.state' <<<"$norm")
+    approvals=$(jq -r '.reviews.approvals' <<<"$norm")
+    comments=$(jq -r '.reviews.comments' <<<"$norm")
+    mergeable=$(jq -r '.mergeable' <<<"$norm")
+    case "$ci_state" in
+        passing) badge="${C_GREEN}✅${C_RESET} ${ci_pass}/${ci_total}" ;;
+        failing) badge="${C_RED}❌${C_RESET} ${ci_fail}/${ci_total} fail" ;;
+        pending) badge="${C_YELLOW}⏳${C_RESET} $(( ci_total - ci_pending ))/${ci_total}" ;;
+        *) badge="${C_DIM}—${C_RESET}" ;;
+    esac
+    printf '#%s %-6s %b  %s approvals, %s comments  mergeable=%s\n' \
+        "$number" "$state" "$badge" "$approvals" "$comments" "$mergeable"
+}
+
+OVERALL="passing"   # 0 => passing
+update_overall() {
+    local incoming="$1"
+    case "$incoming" in
+        failing) OVERALL="failing" ;;
+        pending)
+            if [[ "$OVERALL" != "failing" ]]; then
+                OVERALL="pending"
+            fi
+            ;;
+    esac
+}
+
+# Accumulate normalized PRs so we can emit JSON at the end if requested.
+NORMALIZED=()
+
+for num in "${PR_NUMBERS[@]}"; do
+    raw=$(fetch_pr "$num")
+    norm=$(printf '%s' "$raw" | normalize_pr)
+    NORMALIZED+=("$norm")
+    ci_state=$(jq -r '.ci.state' <<<"$norm")
+    update_overall "$ci_state"
+    mergeable=$(jq -r '.mergeable' <<<"$norm")
+    if [[ "$mergeable" == "NO" ]]; then
+        OVERALL="failing"
+    fi
+done
+
+if (( JSON )); then
+    printf '%s\n' "${NORMALIZED[@]}" | jq -s '.'
+elif (( SUMMARY )); then
+    for norm in "${NORMALIZED[@]}"; do
+        render_summary "$norm"
+    done
+else
+    for norm in "${NORMALIZED[@]}"; do
+        render_default "$norm"
+    done
+fi
+
+case "$OVERALL" in
+    failing) exit 1 ;;
+    pending) exit 2 ;;
+    *) exit 0 ;;
+esac

--- a/scripts/pr-status.sh
+++ b/scripts/pr-status.sh
@@ -2,6 +2,7 @@
 #
 # pr-status.sh — concise, multi-PR status check for efficient CI monitoring.
 #
+# === USAGE ===
 # Usage:
 #   scripts/pr-status.sh [options] <pr-number> [<pr-number>...]
 #   echo "64 65 66" | scripts/pr-status.sh
@@ -28,6 +29,7 @@
 #   1  At least one PR has a failing check or unmergeable conflict
 #   2  No failures, but at least one PR has pending checks
 #   3  Usage error (bad option, no PRs, non-numeric PR number)
+# === END USAGE ===
 
 set -euo pipefail
 
@@ -48,7 +50,11 @@ if [[ -n "${NO_COLOR:-}" ]] || ! [[ -t 1 ]]; then
 fi
 
 usage() {
-    sed -n '3,31p' "$0" | sed 's/^# \{0,1\}//'
+    # Extract the block between the === USAGE === sentinels so the help text
+    # survives future edits to this header without line-number fixups.
+    sed -n '/^# === USAGE ===$/,/^# === END USAGE ===$/p' "$0" \
+        | sed '1d;$d' \
+        | sed 's/^# \{0,1\}//'
 }
 
 die_usage() {
@@ -89,7 +95,8 @@ done
 
 if (( ${#PR_NUMBERS[@]} == 0 )) && ! [[ -t 0 ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
-        # split on whitespace
+        # Intentional word-splitting so ``echo "64 65 66" | pr-status.sh`` works.
+        # Safe because every token is validated against ^[0-9]+$ below.
         # shellcheck disable=SC2206
         toks=( $line )
         for tok in "${toks[@]}"; do
@@ -151,6 +158,10 @@ fetch_pr() {
 
     local fields
     fields="number,title,state,url,author,headRefName,baseRefName,createdAt,updatedAt,mergeable,mergeStateStatus,reviewDecision,reviews,comments,statusCheckRollup"
+    # ``local data`` is declared on its own line so the subsequent command
+    # substitution's exit status propagates to ``set -e``. Combining
+    # ``local data=$(...)`` would mask the gh failure because ``local``
+    # always succeeds.
     local data
     if ! data=$("$GH_CMD" pr view "$num" --json "$fields" 2>&1); then
         printf 'Error: failed to fetch PR #%s: %s\n' "$num" "$data" >&2
@@ -158,7 +169,12 @@ fetch_pr() {
     fi
     if (( USE_CACHE )); then
         mkdir -p "$CACHE_DIR"
-        printf '%s' "$data" > "$cache_file"
+        # Write via a tempfile + rename so a crash/interrupt can't leave a
+        # truncated cache file that the next run would read as valid JSON.
+        local tmp_file
+        tmp_file=$(mktemp "${CACHE_DIR}/.pr-${num}-XXXXXX.json")
+        printf '%s' "$data" > "$tmp_file"
+        mv "$tmp_file" "$cache_file"
     fi
     printf '%s' "$data"
 }

--- a/tests/backend/test_pr_status_script.py
+++ b/tests/backend/test_pr_status_script.py
@@ -1,0 +1,349 @@
+"""End-to-end tests for ``scripts/pr-status.sh``.
+
+The script shells out to ``gh pr view`` for each PR it is asked about. We
+replace ``gh`` with a tiny Python stub (selected via ``GH_CMD``) so the
+tests can run offline and assert deterministic output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = PROJECT_ROOT / "scripts" / "pr-status.sh"
+
+
+def _write_stub(tmp_path: Path, fixtures: dict[int, dict]) -> Path:
+    """Write a Python ``gh`` stub that replays canned JSON per PR number.
+
+    The stub accepts ``gh pr view <NUM> --json <fields>`` invocations and
+    prints the matching fixture as JSON. Any other invocation exits 2 so
+    tests notice unexpected arguments.
+    """
+
+    fixtures_path = tmp_path / "fixtures.json"
+    fixtures_path.write_text(
+        json.dumps({str(num): payload for num, payload in fixtures.items()})
+    )
+
+    stub_path = tmp_path / "gh-stub.py"
+    stub_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "argv = sys.argv[1:]\n"
+        "if len(argv) < 3 or argv[0] != 'pr' or argv[1] != 'view':\n"
+        "    sys.stderr.write(f'unexpected gh args: {argv}\\n')\n"
+        "    sys.exit(2)\n"
+        "number = argv[2]\n"
+        "with open(os.environ['GH_STUB_FIXTURES']) as fh:\n"
+        "    fixtures = json.load(fh)\n"
+        "if number not in fixtures:\n"
+        "    sys.stderr.write(f'no fixture for PR {number}\\n')\n"
+        "    sys.exit(1)\n"
+        "print(json.dumps(fixtures[number]))\n"
+    )
+    stub_path.chmod(0o755)
+
+    wrapper = tmp_path / "gh-stub"
+    wrapper.write_text(
+        f'#!/usr/bin/env bash\nexec "{sys.executable}" "{stub_path}" "$@"\n'
+    )
+    wrapper.chmod(0o755)
+
+    os.environ["GH_STUB_FIXTURES"] = str(fixtures_path)
+    return wrapper
+
+
+def _passing_pr(number: int = 64, title: str = "Passing PR") -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "state": "OPEN",
+        "url": f"https://github.com/example/repo/pull/{number}",
+        "author": {"login": "alice"},
+        "headRefName": "feature/x",
+        "baseRefName": "main",
+        "createdAt": "2026-01-05T10:00:00Z",
+        "updatedAt": "2026-01-05T20:40:00Z",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "APPROVED",
+        "reviews": [
+            {"state": "APPROVED", "author": {"login": "bob"}},
+        ],
+        "comments": [{"id": 1}, {"id": 2}, {"id": 3}],
+        "statusCheckRollup": [
+            {
+                "name": "lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "name": "test",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "name": "typecheck",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "name": "build",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+        ],
+    }
+
+
+def _failing_pr(number: int = 65) -> dict:
+    payload = _passing_pr(number=number, title="Failing PR")
+    payload["mergeable"] = "CONFLICTING"
+    payload["reviewDecision"] = "CHANGES_REQUESTED"
+    payload["statusCheckRollup"] = [
+        {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "test", "status": "COMPLETED", "conclusion": "FAILURE"},
+        {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "type", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    ]
+    return payload
+
+
+def _pending_pr(number: int = 66) -> dict:
+    payload = _passing_pr(number=number, title="Pending PR")
+    payload["reviewDecision"] = ""
+    payload["reviews"] = []
+    payload["comments"] = [{"id": 1}, {"id": 2}]
+    payload["mergeable"] = "UNKNOWN"
+    payload["statusCheckRollup"] = [
+        {"name": "lint", "status": "IN_PROGRESS", "conclusion": ""},
+        {"name": "test", "status": "QUEUED", "conclusion": ""},
+        {"name": "build", "status": "QUEUED", "conclusion": ""},
+        {"name": "type", "status": "QUEUED", "conclusion": ""},
+    ]
+    return payload
+
+
+@pytest.fixture()
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Isolate cache dir and ensure the script exists before each test."""
+
+    assert SCRIPT.exists(), f"pr-status.sh missing at {SCRIPT}"
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("PR_STATUS_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("NO_COLOR", "1")
+    yield tmp_path
+
+
+def _run(
+    stub: Path, *args: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    kwargs: dict = {
+        "env": {**os.environ, "GH_CMD": str(stub)},
+        "capture_output": True,
+        "text": True,
+        "check": False,
+    }
+    if stdin is None:
+        kwargs["stdin"] = subprocess.DEVNULL
+    else:
+        kwargs["input"] = stdin
+    return subprocess.run([str(SCRIPT), *args], **kwargs)
+
+
+def test_script_is_executable() -> None:
+    assert SCRIPT.exists(), "scripts/pr-status.sh must exist"
+    assert os.access(SCRIPT, os.X_OK), "scripts/pr-status.sh must be executable"
+
+
+def test_usage_on_no_args(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr()})
+    result = _run(stub)
+    assert result.returncode == 3
+    assert "Usage" in result.stderr or "Usage" in result.stdout
+
+
+def test_help_flag(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr()})
+    result = _run(stub, "--help")
+    assert result.returncode == 0
+    assert "Usage" in result.stdout
+
+
+def test_default_output_passing_pr(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr(title="User Story Suggestions")})
+    result = _run(stub, "64")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "PR #64" in out
+    assert "User Story Suggestions" in out
+    assert "OPEN" in out
+    assert "4/4" in out
+    assert "passing" in out.lower()
+    assert "1 approval" in out
+    assert "3 comments" in out
+    assert "Mergeable" in out
+    assert "YES" in out
+
+
+def test_failing_pr_exit_code_and_output(env: Path) -> None:
+    stub = _write_stub(env, {65: _failing_pr()})
+    result = _run(stub, "65")
+    assert result.returncode == 1, result.stderr
+    out = result.stdout
+    assert "PR #65" in out
+    assert "failing" in out.lower()
+    assert "1/4" in out  # 1 of 4 failing
+    assert "NO" in out  # mergeable NO due to conflict
+
+
+def test_pending_pr_exit_code_and_output(env: Path) -> None:
+    stub = _write_stub(env, {66: _pending_pr()})
+    result = _run(stub, "66")
+    assert result.returncode == 2, result.stderr
+    out = result.stdout
+    assert "PR #66" in out
+    assert "pending" in out.lower()
+    assert "UNKNOWN" in out
+
+
+def test_multiple_prs_aggregate_exit_codes(env: Path) -> None:
+    stub = _write_stub(
+        env,
+        {
+            64: _passing_pr(),
+            65: _failing_pr(),
+            66: _pending_pr(),
+        },
+    )
+    result = _run(stub, "64", "65", "66")
+    # failing wins over pending which wins over passing
+    assert result.returncode == 1
+    out = result.stdout
+    assert "PR #64" in out
+    assert "PR #65" in out
+    assert "PR #66" in out
+
+
+def test_pending_wins_when_no_failures(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr(), 66: _pending_pr()})
+    result = _run(stub, "64", "66")
+    assert result.returncode == 2
+
+
+def test_summary_flag_one_line_per_pr(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr(title="A"), 65: _failing_pr()})
+    result = _run(stub, "--summary", "64", "65")
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 2, result.stdout
+    assert "#64" in lines[0]
+    assert "#65" in lines[1]
+
+
+def test_json_flag_emits_valid_array(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr(), 65: _failing_pr()})
+    result = _run(stub, "--json", "64", "65")
+    assert result.returncode == 1, result.stderr
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert len(data) == 2
+    numbers = {entry["number"] for entry in data}
+    assert numbers == {64, 65}
+    pr64 = next(e for e in data if e["number"] == 64)
+    assert pr64["ci"]["total"] == 4
+    assert pr64["ci"]["passing"] == 4
+    assert pr64["reviews"]["approvals"] == 1
+    assert pr64["mergeable"] == "YES"
+
+
+def test_ci_only_flag_suppresses_reviews(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr()})
+    result = _run(stub, "--ci-only", "64")
+    assert result.returncode == 0
+    out = result.stdout
+    assert "CI" in out
+    assert "approval" not in out.lower()
+    assert "Mergeable" not in out
+
+
+def test_reviews_only_flag_suppresses_ci(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr()})
+    result = _run(stub, "--reviews-only", "64")
+    assert result.returncode == 0
+    out = result.stdout
+    assert "Reviews" in out or "approval" in out.lower()
+    # CI rollup details should not appear
+    assert "/4 checks" not in out
+
+
+def test_verbose_lists_individual_checks(env: Path) -> None:
+    stub = _write_stub(env, {65: _failing_pr()})
+    result = _run(stub, "--verbose", "65")
+    assert result.returncode == 1
+    out = result.stdout
+    # verbose must enumerate each check name with its result
+    assert "lint" in out
+    assert "test" in out
+    assert "build" in out
+    assert "FAILURE" in out or "fail" in out.lower()
+
+
+def test_stdin_accepts_pr_numbers(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr(), 65: _failing_pr()})
+    result = _run(stub, stdin="64 65\n")
+    assert result.returncode == 1, result.stderr
+    assert "PR #64" in result.stdout
+    assert "PR #65" in result.stdout
+
+
+def test_rejects_non_numeric_pr(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr()})
+    result = _run(stub, "abc")
+    assert result.returncode == 3
+    assert "abc" in (result.stderr + result.stdout)
+
+
+def test_cache_reuses_result_within_ttl(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr()})
+    # First run populates cache
+    first = _run(stub, "64")
+    assert first.returncode == 0
+    # Replace stub with one that fails if invoked — cache must prevent calls
+    broken = env / "gh-broken"
+    broken.write_text("#!/usr/bin/env bash\nexit 77\n")
+    broken.chmod(0o755)
+    cached = subprocess.run(
+        [str(SCRIPT), "64"],
+        env={**os.environ, "GH_CMD": str(broken)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert cached.returncode == 0, cached.stderr
+    assert "PR #64" in cached.stdout
+
+
+def test_no_cache_flag_bypasses_cache(env: Path) -> None:
+    stub = _write_stub(env, {64: _passing_pr()})
+    first = _run(stub, "64")
+    assert first.returncode == 0
+    broken = env / "gh-broken"
+    broken.write_text("#!/usr/bin/env bash\nexit 77\n")
+    broken.chmod(0o755)
+    result = subprocess.run(
+        [str(SCRIPT), "--no-cache", "64"],
+        env={**os.environ, "GH_CMD": str(broken)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # Without cache, the broken stub should cause failure
+    assert result.returncode != 0

--- a/tests/backend/test_pr_status_script.py
+++ b/tests/backend/test_pr_status_script.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import sys
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -20,7 +21,15 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = PROJECT_ROOT / "scripts" / "pr-status.sh"
 
 
-def _write_stub(tmp_path: Path, fixtures: dict[int, dict]) -> Path:
+@dataclass
+class ScriptEnv:
+    """Per-test bundle of the tmp dir and the active ``monkeypatch``."""
+
+    tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch
+
+
+def _write_stub(env: ScriptEnv, fixtures: dict[int, dict]) -> Path:
     """Write a Python ``gh`` stub that replays canned JSON per PR number.
 
     The stub accepts ``gh pr view <NUM> --json <fields>`` invocations and
@@ -28,12 +37,12 @@ def _write_stub(tmp_path: Path, fixtures: dict[int, dict]) -> Path:
     tests notice unexpected arguments.
     """
 
-    fixtures_path = tmp_path / "fixtures.json"
+    fixtures_path = env.tmp_path / "fixtures.json"
     fixtures_path.write_text(
         json.dumps({str(num): payload for num, payload in fixtures.items()})
     )
 
-    stub_path = tmp_path / "gh-stub.py"
+    stub_path = env.tmp_path / "gh-stub.py"
     stub_path.write_text(
         "#!/usr/bin/env python3\n"
         "import json, os, sys\n"
@@ -51,13 +60,14 @@ def _write_stub(tmp_path: Path, fixtures: dict[int, dict]) -> Path:
     )
     stub_path.chmod(0o755)
 
-    wrapper = tmp_path / "gh-stub"
+    wrapper = env.tmp_path / "gh-stub"
     wrapper.write_text(
         f'#!/usr/bin/env bash\nexec "{sys.executable}" "{stub_path}" "$@"\n'
     )
     wrapper.chmod(0o755)
 
-    os.environ["GH_STUB_FIXTURES"] = str(fixtures_path)
+    # Route through monkeypatch so the variable cannot leak to later tests.
+    env.monkeypatch.setenv("GH_STUB_FIXTURES", str(fixtures_path))
     return wrapper
 
 
@@ -133,14 +143,14 @@ def _pending_pr(number: int = 66) -> dict:
 
 
 @pytest.fixture()
-def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[ScriptEnv]:
     """Isolate cache dir and ensure the script exists before each test."""
 
     assert SCRIPT.exists(), f"pr-status.sh missing at {SCRIPT}"
     cache_dir = tmp_path / "cache"
     monkeypatch.setenv("PR_STATUS_CACHE_DIR", str(cache_dir))
     monkeypatch.setenv("NO_COLOR", "1")
-    yield tmp_path
+    yield ScriptEnv(tmp_path=tmp_path, monkeypatch=monkeypatch)
 
 
 def _run(
@@ -164,21 +174,21 @@ def test_script_is_executable() -> None:
     assert os.access(SCRIPT, os.X_OK), "scripts/pr-status.sh must be executable"
 
 
-def test_usage_on_no_args(env: Path) -> None:
+def test_usage_on_no_args(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr()})
     result = _run(stub)
     assert result.returncode == 3
     assert "Usage" in result.stderr or "Usage" in result.stdout
 
 
-def test_help_flag(env: Path) -> None:
+def test_help_flag(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr()})
     result = _run(stub, "--help")
     assert result.returncode == 0
     assert "Usage" in result.stdout
 
 
-def test_default_output_passing_pr(env: Path) -> None:
+def test_default_output_passing_pr(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr(title="User Story Suggestions")})
     result = _run(stub, "64")
     assert result.returncode == 0, result.stderr
@@ -194,7 +204,7 @@ def test_default_output_passing_pr(env: Path) -> None:
     assert "YES" in out
 
 
-def test_failing_pr_exit_code_and_output(env: Path) -> None:
+def test_failing_pr_exit_code_and_output(env: ScriptEnv) -> None:
     stub = _write_stub(env, {65: _failing_pr()})
     result = _run(stub, "65")
     assert result.returncode == 1, result.stderr
@@ -205,7 +215,7 @@ def test_failing_pr_exit_code_and_output(env: Path) -> None:
     assert "NO" in out  # mergeable NO due to conflict
 
 
-def test_pending_pr_exit_code_and_output(env: Path) -> None:
+def test_pending_pr_exit_code_and_output(env: ScriptEnv) -> None:
     stub = _write_stub(env, {66: _pending_pr()})
     result = _run(stub, "66")
     assert result.returncode == 2, result.stderr
@@ -215,7 +225,7 @@ def test_pending_pr_exit_code_and_output(env: Path) -> None:
     assert "UNKNOWN" in out
 
 
-def test_multiple_prs_aggregate_exit_codes(env: Path) -> None:
+def test_multiple_prs_aggregate_exit_codes(env: ScriptEnv) -> None:
     stub = _write_stub(
         env,
         {
@@ -233,13 +243,13 @@ def test_multiple_prs_aggregate_exit_codes(env: Path) -> None:
     assert "PR #66" in out
 
 
-def test_pending_wins_when_no_failures(env: Path) -> None:
+def test_pending_wins_when_no_failures(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr(), 66: _pending_pr()})
     result = _run(stub, "64", "66")
     assert result.returncode == 2
 
 
-def test_summary_flag_one_line_per_pr(env: Path) -> None:
+def test_summary_flag_one_line_per_pr(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr(title="A"), 65: _failing_pr()})
     result = _run(stub, "--summary", "64", "65")
     lines = [line for line in result.stdout.splitlines() if line.strip()]
@@ -248,7 +258,7 @@ def test_summary_flag_one_line_per_pr(env: Path) -> None:
     assert "#65" in lines[1]
 
 
-def test_json_flag_emits_valid_array(env: Path) -> None:
+def test_json_flag_emits_valid_array(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr(), 65: _failing_pr()})
     result = _run(stub, "--json", "64", "65")
     assert result.returncode == 1, result.stderr
@@ -264,7 +274,7 @@ def test_json_flag_emits_valid_array(env: Path) -> None:
     assert pr64["mergeable"] == "YES"
 
 
-def test_ci_only_flag_suppresses_reviews(env: Path) -> None:
+def test_ci_only_flag_suppresses_reviews(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr()})
     result = _run(stub, "--ci-only", "64")
     assert result.returncode == 0
@@ -274,7 +284,7 @@ def test_ci_only_flag_suppresses_reviews(env: Path) -> None:
     assert "Mergeable" not in out
 
 
-def test_reviews_only_flag_suppresses_ci(env: Path) -> None:
+def test_reviews_only_flag_suppresses_ci(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr()})
     result = _run(stub, "--reviews-only", "64")
     assert result.returncode == 0
@@ -284,7 +294,7 @@ def test_reviews_only_flag_suppresses_ci(env: Path) -> None:
     assert "/4 checks" not in out
 
 
-def test_verbose_lists_individual_checks(env: Path) -> None:
+def test_verbose_lists_individual_checks(env: ScriptEnv) -> None:
     stub = _write_stub(env, {65: _failing_pr()})
     result = _run(stub, "--verbose", "65")
     assert result.returncode == 1
@@ -296,7 +306,7 @@ def test_verbose_lists_individual_checks(env: Path) -> None:
     assert "FAILURE" in out or "fail" in out.lower()
 
 
-def test_stdin_accepts_pr_numbers(env: Path) -> None:
+def test_stdin_accepts_pr_numbers(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr(), 65: _failing_pr()})
     result = _run(stub, stdin="64 65\n")
     assert result.returncode == 1, result.stderr
@@ -304,20 +314,20 @@ def test_stdin_accepts_pr_numbers(env: Path) -> None:
     assert "PR #65" in result.stdout
 
 
-def test_rejects_non_numeric_pr(env: Path) -> None:
+def test_rejects_non_numeric_pr(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr()})
     result = _run(stub, "abc")
     assert result.returncode == 3
     assert "abc" in (result.stderr + result.stdout)
 
 
-def test_cache_reuses_result_within_ttl(env: Path) -> None:
+def test_cache_reuses_result_within_ttl(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr()})
     # First run populates cache
     first = _run(stub, "64")
     assert first.returncode == 0
     # Replace stub with one that fails if invoked — cache must prevent calls
-    broken = env / "gh-broken"
+    broken = env.tmp_path / "gh-broken"
     broken.write_text("#!/usr/bin/env bash\nexit 77\n")
     broken.chmod(0o755)
     cached = subprocess.run(
@@ -331,11 +341,11 @@ def test_cache_reuses_result_within_ttl(env: Path) -> None:
     assert "PR #64" in cached.stdout
 
 
-def test_no_cache_flag_bypasses_cache(env: Path) -> None:
+def test_no_cache_flag_bypasses_cache(env: ScriptEnv) -> None:
     stub = _write_stub(env, {64: _passing_pr()})
     first = _run(stub, "64")
     assert first.returncode == 0
-    broken = env / "gh-broken"
+    broken = env.tmp_path / "gh-broken"
     broken.write_text("#!/usr/bin/env bash\nexit 77\n")
     broken.chmod(0o755)
     result = subprocess.run(
@@ -347,3 +357,15 @@ def test_no_cache_flag_bypasses_cache(env: Path) -> None:
     )
     # Without cache, the broken stub should cause failure
     assert result.returncode != 0
+
+
+def test_verbose_with_no_checks(env: ScriptEnv) -> None:
+    """A PR with zero checks exercises the ``none`` CI-state branch."""
+
+    payload = _passing_pr()
+    payload["statusCheckRollup"] = []
+    stub = _write_stub(env, {64: payload})
+    result = _run(stub, "--verbose", "64")
+    assert result.returncode == 0, result.stderr
+    assert "PR #64" in result.stdout
+    assert "No checks" in result.stdout


### PR DESCRIPTION
## Summary

- New `scripts/pr-status.sh` for concise, multi-PR CI status checks — the utility requested in #232.
- Supports the full option surface from the issue: default human-readable view, `--summary`, `--json`, `--ci-only`, `--reviews-only`, `--verbose`, plus stdin input, 30-second local caching, and `NO_COLOR`-aware output.
- Aggregate exit codes make the command scriptable (0 = all clear, 1 = any failing, 2 = any pending, 3 = usage error).

## Implementation notes

- Pure Bash + `jq`; no new runtime deps.
- The `gh` binary is invoked via a `GH_CMD` env var (defaults to `gh`), which also lets tests inject a stub to run fully offline.
- Cache location/TTL are configurable via `PR_STATUS_CACHE_DIR` / `PR_STATUS_CACHE_TTL` and can be bypassed with `--no-cache`.
- Colors auto-disable when stdout isn't a TTY or `NO_COLOR` is set.

## Tests

Added `tests/backend/test_pr_status_script.py` — 17 end-to-end tests that drive the script with a `gh` stub and canned JSON fixtures. They cover:

- Script presence + executable bit
- Usage / `--help`
- Default format for passing / failing / pending PRs (including exit codes)
- Multi-PR aggregation (failing > pending > passing)
- `--summary`, `--json`, `--ci-only`, `--reviews-only`, `--verbose`
- Stdin input
- Non-numeric PR rejection
- Cache hit within TTL and `--no-cache` bypass

The tests live under `tests/backend/` so `scripts/check-backend.sh` runs them alongside the rest of the backend suite.

## Test plan

- [x] `scripts/check-backend.sh` — lint, format, mypy, pytest (118 passed)
- [x] Manual smoke with a stubbed gh: default / `--summary` / `--json` outputs match the format in #232
- [ ] Reviewer spot-check against a live PR once merged (requires `gh` auth)
