### PR TITLE
Analytics reframes batch 1

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsViewSections.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsViewSections.swift
@@ -41,12 +41,9 @@ extension AnalyticsView {
           .fill(Color.secondary.opacity(0.15))
       )
 
-      // Recent Activity Display
-      if overview.currentStreak > 0 || overview.totalEntries >= 2 {
-        StreakDisplayView(
-          currentStreak: overview.currentStreak,
-          longestStreak: overview.longestStreak
-        )
+      // Recent Activity Display — neutral monthly count (Issue #280)
+      if overview.totalEntries > 0 {
+        StreakDisplayView(monthlyCheckIns: overview.totalEntries)
       }
 
       // Last Check-In
@@ -83,14 +80,14 @@ extension AnalyticsView {
           .font(.caption)
           .foregroundColor(.secondary)
 
-        // Trend Indicator
+        // Neutral trend context — no evaluative colors (Issue #281)
         if overview.medicinalTrend != 0 {
           HStack(spacing: 4) {
-            Image(systemName: overview.medicinalTrend > 0 ? "arrow.up" : "arrow.down")
+            Image(systemName: "waveform.path")
               .font(.caption2)
-              .foregroundColor(overview.medicinalTrend > 0 ? .green : .orange)
+              .foregroundColor(.secondary)
 
-            Text(String(format: "%.1f%% this period", abs(overview.medicinalTrend * 100)))
+            Text(String(format: "%.1f%% shift this period", abs(overview.medicinalTrend * 100)))
               .font(.caption2)
               .foregroundColor(.secondary)
           }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsViewSections.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsViewSections.swift
@@ -41,7 +41,6 @@ extension AnalyticsView {
           .fill(Color.secondary.opacity(0.15))
       )
 
-      // Recent Activity Display — neutral monthly count (Issue #280)
       if overview.totalEntries > 0 {
         StreakDisplayView(monthlyCheckIns: overview.totalEntries)
       }
@@ -80,7 +79,6 @@ extension AnalyticsView {
           .font(.caption)
           .foregroundColor(.secondary)
 
-        // Neutral trend context — no evaluative colors (Issue #281)
         if overview.medicinalTrend != 0 {
           HStack(spacing: 4) {
             Image(systemName: "waveform.path")

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/GrowthIndicatorsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/GrowthIndicatorsView.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
 /// Displays activity pattern indicators — medicinal trend, layer diversity, and phase coverage.
-///
-/// Reframed in Issue #282 to honor the wavelength's natural ebbs and flows:
-/// no red/green evaluative colors, no "declining/increasing" performance language,
-/// and supportive context explaining that quieter phases are part of the rhythm.
 struct GrowthIndicatorsView: View {
   let indicators: GrowthIndicators
 
@@ -42,8 +38,6 @@ struct GrowthIndicatorsView: View {
 
   // MARK: - Trend Direction
 
-  /// Neutral descriptors for medicinal ratio movement over time.
-  /// No "positive/negative" framing — every phase of the wavelength is valid.
   enum TrendDirection {
     case more // More medicinal expressions this period
     case quieter // Fewer medicinal expressions — a natural contraction
@@ -76,12 +70,10 @@ struct GrowthIndicatorsView: View {
     }
   }
 
-  /// Single neutral color for all trend directions — no evaluative palette (Issue #282).
   var trendColor: Color {
     .secondary
   }
 
-  /// Descriptive, judgment-free label for the trend direction.
   var trendDescription: String {
     switch trendDirection {
     case .more:
@@ -109,7 +101,6 @@ struct GrowthIndicatorsView: View {
     "\(indicators.phaseCoverage) of 6 phases"
   }
 
-  /// Supportive affirmation anchored in APTITUDE's wavelength teachings.
   var rhythmContext: String {
     "Your engagement naturally ebbs and flows. Quieter phases can be times of integration and rest."
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/GrowthIndicatorsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/GrowthIndicatorsView.swift
@@ -1,12 +1,16 @@
 import SwiftUI
 
-/// Displays growth indicators showing medicinal trend, layer diversity, and phase coverage
+/// Displays activity pattern indicators — medicinal trend, layer diversity, and phase coverage.
+///
+/// Reframed in Issue #282 to honor the wavelength's natural ebbs and flows:
+/// no red/green evaluative colors, no "declining/increasing" performance language,
+/// and supportive context explaining that quieter phases are part of the rhythm.
 struct GrowthIndicatorsView: View {
   let indicators: GrowthIndicators
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("Growth Indicators")
+      Text("Your Activity Pattern")
         .font(.headline)
         .foregroundColor(.secondary)
 
@@ -15,8 +19,7 @@ struct GrowthIndicatorsView: View {
       } else {
         VStack(alignment: .leading, spacing: 8) {
           MedicinalTrendView(
-            trend: indicators.medicinalTrend,
-            direction: trendDirection,
+            description: trendDescription,
             arrow: trendArrow,
             color: trendColor,
             formattedText: formattedTrend
@@ -26,6 +29,12 @@ struct GrowthIndicatorsView: View {
             layerText: layerDiversityText,
             phaseText: phaseCoverageText
           )
+
+          Text(rhythmContext)
+            .font(.caption2)
+            .foregroundColor(.secondary)
+            .multilineTextAlignment(.leading)
+            .padding(.top, 4)
         }
       }
     }
@@ -33,25 +42,24 @@ struct GrowthIndicatorsView: View {
 
   // MARK: - Trend Direction
 
-  /// Represents medicinal trend direction using neutral, supportive language.
-  /// Avoids evaluative terminology like "negative" that implies failure.
+  /// Neutral descriptors for medicinal ratio movement over time.
+  /// No "positive/negative" framing — every phase of the wavelength is valid.
   enum TrendDirection {
-    case positive
-    case varying // Natural fluctuation (replaces "negative")
-    case neutral
+    case more // More medicinal expressions this period
+    case quieter // Fewer medicinal expressions — a natural contraction
+    case steady // Within a small threshold of the previous period
   }
 
   var trendDirection: TrendDirection {
-    // Threshold for meaningful trend: ±5% (0.05 in decimal)
-    // medicinalTrend is a decimal fraction (0.0-1.0 range)
+    // Threshold for meaningful change: ±5% (0.05 in decimal)
     let threshold = 0.05
 
     if indicators.medicinalTrend > threshold {
-      return .positive
+      return .more
     } else if indicators.medicinalTrend < -threshold {
-      return .varying // Natural fluctuation - not "negative"
+      return .quieter
     } else {
-      return .neutral
+      return .steady
     }
   }
 
@@ -59,25 +67,29 @@ struct GrowthIndicatorsView: View {
 
   var trendArrow: String {
     switch trendDirection {
-    case .positive:
+    case .more:
       "arrow.up"
-    case .varying:
+    case .quieter:
       "arrow.down"
-    case .neutral:
+    case .steady:
       "arrow.forward"
     }
   }
 
-  /// Color for trend indicator using neutral, supportive palette.
-  /// Avoids red/orange evaluative colors that imply judgment or failure.
+  /// Single neutral color for all trend directions — no evaluative palette (Issue #282).
   var trendColor: Color {
+    .secondary
+  }
+
+  /// Descriptive, judgment-free label for the trend direction.
+  var trendDescription: String {
     switch trendDirection {
-    case .positive:
-      .green
-    case .varying:
-      .secondary // Neutral - honoring natural rhythm
-    case .neutral:
-      .secondary // Neutral - honoring natural rhythm
+    case .more:
+      "More medicinal this period"
+    case .quieter:
+      "A quieter phase right now"
+    case .steady:
+      "A steady rhythm"
     }
   }
 
@@ -97,6 +109,11 @@ struct GrowthIndicatorsView: View {
     "\(indicators.phaseCoverage) of 6 phases"
   }
 
+  /// Supportive affirmation anchored in APTITUDE's wavelength teachings.
+  var rhythmContext: String {
+    "Your engagement naturally ebbs and flows. Quieter phases can be times of integration and rest."
+  }
+
   var isEmpty: Bool {
     indicators.layerDiversity == 0
       && indicators.phaseCoverage == 0
@@ -107,15 +124,14 @@ struct GrowthIndicatorsView: View {
 // MARK: - Subviews
 
 private struct MedicinalTrendView: View {
-  let trend: Double
-  let direction: GrowthIndicatorsView.TrendDirection
+  let description: String
   let arrow: String
   let color: Color
   let formattedText: String
 
   var body: some View {
     VStack(alignment: .leading, spacing: 4) {
-      Text("Medicinal Trend")
+      Text("Medicinal Rhythm")
         .font(.caption2)
         .foregroundColor(.secondary)
 
@@ -129,6 +145,10 @@ private struct MedicinalTrendView: View {
           .foregroundColor(color)
           .font(.caption)
       }
+
+      Text(description)
+        .font(.caption2)
+        .foregroundColor(.secondary)
     }
   }
 }
@@ -164,10 +184,10 @@ private struct DiversityCoverageView: View {
 private struct EmptyStateView: View {
   var body: some View {
     VStack(spacing: 8) {
-      Image(systemName: "chart.line.uptrend.xyaxis")
+      Image(systemName: "waveform.path")
         .font(.title)
         .foregroundColor(.secondary)
-      Text("No growth data")
+      Text("No activity data yet")
         .font(.caption)
         .foregroundColor(.secondary)
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/TemporalPatternsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/TemporalPatternsView.swift
@@ -1,14 +1,25 @@
 import SwiftUI
 
-/// Displays temporal patterns showing dominant phase and dosage per hour
+/// Displays when a user naturally tends to check in — framed as their
+/// natural rhythm rather than a performance metric (Issue #285).
+///
+/// Uses a single neutral color, descriptive (not prescriptive) language,
+/// and an affirmation that every rhythm is valid.
 struct TemporalPatternsView: View {
   let patterns: TemporalPatterns
   let phases: [CatalogPhaseModel]
 
+  /// Single neutral color shared across rows — no evaluative palette.
+  static let neutralColor: Color = .purple
+
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("Temporal Patterns")
+      Text(Self.title)
         .font(.headline)
+        .foregroundColor(.secondary)
+
+      Text(Self.subtitle)
+        .font(.caption2)
         .foregroundColor(.secondary)
 
       if patterns.hourlyDistribution.isEmpty {
@@ -19,9 +30,22 @@ struct TemporalPatternsView: View {
             HourlyRow(summary: summary)
           }
         }
+
+        Text(Self.affirmation)
+          .font(.caption2)
+          .foregroundColor(.secondary)
+          .italic()
+          .multilineTextAlignment(.leading)
+          .padding(.top, 8)
       }
     }
   }
+
+  // MARK: - Copy
+
+  static let title = "Your Natural Rhythm"
+  static let subtitle = "When you naturally tend to check in"
+  static let affirmation = "Everyone's rhythm is unique. This is your pattern, and it's valid."
 
   // MARK: - Data Transformation
 
@@ -61,16 +85,9 @@ struct TemporalPatternsView: View {
     return "\(adjustedHour) \(period)"
   }
 
-  /// Maps dosage to a color — Medicinal gets green, Toxic gets neutral
-  static func dosageColor(for dosage: String?) -> Color {
-    switch dosage {
-    case "Medicinal":
-      .green
-    case "Toxic":
-      .secondary
-    default:
-      .purple
-    }
+  /// Single neutral color for all rows — no medicinal/toxic evaluative coding (Issue #285).
+  static func dosageColor(for _: String?) -> Color {
+    neutralColor
   }
 }
 
@@ -86,13 +103,13 @@ private struct HourlyRow: View {
         .font(.caption2)
         .frame(width: 40, alignment: .leading)
 
-      // Phase + dosage indicator
+      // Phase + dosage indicator (neutral color)
       VStack(alignment: .leading, spacing: 1) {
         if let phaseName = summary.phaseName {
           Text(phaseName)
             .font(.caption2)
             .fontWeight(.medium)
-            .foregroundColor(TemporalPatternsView.dosageColor(for: summary.dosage))
+            .foregroundColor(TemporalPatternsView.neutralColor)
         }
 
         if let dosage = summary.dosage {
@@ -103,10 +120,10 @@ private struct HourlyRow: View {
       }
       .frame(width: 55, alignment: .leading)
 
-      // Bar
+      // Bar (neutral color)
       GeometryReader { geometry in
         RoundedRectangle(cornerRadius: 3)
-          .fill(TemporalPatternsView.dosageColor(for: summary.dosage))
+          .fill(TemporalPatternsView.neutralColor)
           .frame(
             width: geometry.size.width * min(max(summary.percentage, 0) / 100.0, 1.0),
             height: 12
@@ -129,7 +146,7 @@ private struct EmptyStateView: View {
       Image(systemName: "clock")
         .font(.title)
         .foregroundColor(.secondary)
-      Text("No temporal data")
+      Text("No rhythm data yet")
         .font(.caption)
         .foregroundColor(.secondary)
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/TemporalPatternsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/TemporalPatternsView.swift
@@ -1,15 +1,10 @@
 import SwiftUI
 
-/// Displays when a user naturally tends to check in — framed as their
-/// natural rhythm rather than a performance metric (Issue #285).
-///
-/// Uses a single neutral color, descriptive (not prescriptive) language,
-/// and an affirmation that every rhythm is valid.
+/// Displays when a user naturally tends to check in — framed as their natural rhythm.
 struct TemporalPatternsView: View {
   let patterns: TemporalPatterns
   let phases: [CatalogPhaseModel]
 
-  /// Single neutral color shared across rows — no evaluative palette.
   static let neutralColor: Color = .purple
 
   var body: some View {
@@ -49,7 +44,6 @@ struct TemporalPatternsView: View {
 
   // MARK: - Data Transformation
 
-  /// Summary of a single hour's dominant phase and dosage
   struct HourlySummary: Equatable {
     let hourLabel: String
     let count: Int
@@ -85,7 +79,6 @@ struct TemporalPatternsView: View {
     return "\(adjustedHour) \(period)"
   }
 
-  /// Single neutral color for all rows — no medicinal/toxic evaluative coding (Issue #285).
   static func dosageColor(for _: String?) -> Color {
     neutralColor
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StreakDisplayView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StreakDisplayView.swift
@@ -1,26 +1,9 @@
 import SwiftUI
 
 /// A neutral activity summary that replaces streak-style gamification.
-///
-/// Displays the number of check-ins over the past ~30 days as a plain
-/// descriptive observation, with no streak counting, fire emoji, or
-/// "longest/previous high" framing that implies daily goals.
-///
-/// ## Usage
-/// ```swift
-/// StreakDisplayView(monthlyCheckIns: 7)
-/// ```
-///
-/// ## Analytics Context
-/// Part of the analytics reframes batch 1 (Issues #280, #281, #282, #285)
-/// to align with APTITUDE values — presence over engagement metrics.
-/// Replaces the previous streak counter (Issue #280).
 struct StreakDisplayView: View {
   let monthlyCheckIns: Int
 
-  /// Creates a recent activity display.
-  ///
-  /// - Parameter monthlyCheckIns: Total check-ins in the trailing ~30 days.
   init(monthlyCheckIns: Int) {
     precondition(monthlyCheckIns >= 0, "Monthly check-ins cannot be negative")
     self.monthlyCheckIns = monthlyCheckIns
@@ -52,15 +35,11 @@ struct StreakDisplayView: View {
     )
   }
 
-  // MARK: - Computed Properties
-
-  /// Neutral, descriptive activity line — no streak / goal framing.
   var activityText: String {
     let word = monthlyCheckIns == 1 ? "check-in" : "check-ins"
-    return "\(monthlyCheckIns) \(word) this month"
+    return "\(monthlyCheckIns) \(word) in the last 30 days"
   }
 
-  /// Supportive context that affirms natural rhythms.
   var contextText: String {
     "Your check-in rhythm naturally varies"
   }
@@ -78,12 +57,6 @@ struct StreakDisplayView: View {
   StreakDisplayView(monthlyCheckIns: 1)
     .padding()
     .previewDisplayName("Single Check-In")
-}
-
-#Preview("Quieter Period") {
-  StreakDisplayView(monthlyCheckIns: 0)
-    .padding()
-    .previewDisplayName("Quieter Period")
 }
 
 #Preview("Very Active") {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StreakDisplayView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StreakDisplayView.swift
@@ -1,72 +1,48 @@
 import SwiftUI
 
-/// A reusable component for displaying journal entry activity statistics.
+/// A neutral activity summary that replaces streak-style gamification.
 ///
-/// Shows recent activity with neutral calendar icon, historical context,
-/// and trend indicators to reflect natural engagement patterns.
+/// Displays the number of check-ins over the past ~30 days as a plain
+/// descriptive observation, with no streak counting, fire emoji, or
+/// "longest/previous high" framing that implies daily goals.
 ///
 /// ## Usage
 /// ```swift
-/// // Basic activity display
-/// StreakDisplayView(
-///   currentStreak: 5,
-///   longestStreak: 12
-/// )
+/// StreakDisplayView(monthlyCheckIns: 7)
 /// ```
 ///
 /// ## Analytics Context
-/// Part of the analytics feature (Issue #195) for displaying temporal patterns
-/// and consistency metrics to users. Supports validation of natural rhythms without
-/// gamification pressure. Updated in Issue #280 to remove streak language.
+/// Part of the analytics reframes batch 1 (Issues #280, #281, #282, #285)
+/// to align with APTITUDE values — presence over engagement metrics.
+/// Replaces the previous streak counter (Issue #280).
 struct StreakDisplayView: View {
-  let currentStreak: Int
-  let longestStreak: Int
+  let monthlyCheckIns: Int
 
-  /// Creates a streak display view.
+  /// Creates a recent activity display.
   ///
-  /// - Parameters:
-  ///   - currentStreak: Current consecutive days with at least 1 entry
-  ///   - longestStreak: Historical best streak
-  init(
-    currentStreak: Int,
-    longestStreak: Int
-  ) {
-    precondition(currentStreak >= 0, "Current streak cannot be negative")
-    precondition(longestStreak >= 0, "Longest streak cannot be negative")
-    precondition(
-      currentStreak <= longestStreak,
-      "Current streak (\(currentStreak)) cannot exceed longest streak (\(longestStreak)). Caller must update longestStreak when record is broken."
-    )
-
-    self.currentStreak = currentStreak
-    self.longestStreak = longestStreak
+  /// - Parameter monthlyCheckIns: Total check-ins in the trailing ~30 days.
+  init(monthlyCheckIns: Int) {
+    precondition(monthlyCheckIns >= 0, "Monthly check-ins cannot be negative")
+    self.monthlyCheckIns = monthlyCheckIns
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      // Recent activity with neutral calendar icon
-      HStack(spacing: 6) {
-        Image(systemName: "calendar")
-          .font(.title2)
-          .foregroundColor(.purple)
+    HStack(spacing: 8) {
+      Image(systemName: "calendar")
+        .font(.title2)
+        .foregroundColor(.purple)
 
-        VStack(alignment: .leading, spacing: 2) {
-          Text(currentStreakText)
-            .font(.headline)
-            .fontWeight(.semibold)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(activityText)
+          .font(.headline)
+          .fontWeight(.semibold)
 
-          Text(longestStreakText)
-            .font(.caption)
-            .foregroundColor(.secondary)
-        }
-
-        Spacer()
-
-        // Trend indicator
-        Text(trendArrow)
-          .font(.title3)
-          .foregroundColor(trendColor)
+        Text(contextText)
+          .font(.caption)
+          .foregroundColor(.secondary)
       }
+
+      Spacer()
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(12)
@@ -78,110 +54,40 @@ struct StreakDisplayView: View {
 
   // MARK: - Computed Properties
 
-  /// Formatted text for recent activity without gamification language
-  var currentStreakText: String {
-    "Recent Activity"
+  /// Neutral, descriptive activity line — no streak / goal framing.
+  var activityText: String {
+    let word = monthlyCheckIns == 1 ? "check-in" : "check-ins"
+    return "\(monthlyCheckIns) \(word) this month"
   }
 
-  /// Formatted text for historical context without competitive framing
-  var longestStreakText: String {
-    let dayWord = longestStreak == 1 ? "day" : "days"
-    return "Previous high: \(longestStreak) \(dayWord)"
+  /// Supportive context that affirms natural rhythms.
+  var contextText: String {
+    "Your check-in rhythm naturally varies"
   }
-
-  /// Trend indicator based on current vs longest streak comparison
-  ///
-  /// Note: `.improving` case removed after adding validation that currentStreak <= longestStreak.
-  /// When a new record is achieved, the caller must update longestStreak to match currentStreak.
-  var trendIndicator: TrendIndicator {
-    if currentStreak == longestStreak {
-      .stable // At personal record
-    } else {
-      .resting // Honoring natural rhythm
-    }
-  }
-
-  /// Arrow symbol for trend direction
-  var trendArrow: String {
-    switch trendIndicator {
-    case .stable:
-      "→"
-    case .resting:
-      "↓"
-    }
-  }
-
-  /// Color for trend indicator
-  ///
-  /// Uses neutral, supportive colors to honor natural rhythms.
-  /// Avoids red/orange evaluative colors that imply judgment.
-  var trendColor: Color {
-    switch trendIndicator {
-    case .stable:
-      .green // At personal best - positive!
-    case .resting:
-      .secondary // Neutral - honoring natural rhythm
-    }
-  }
-}
-
-// MARK: - Supporting Types
-
-/// Represents the trend of current streak relative to longest streak
-///
-/// Note: `.improving` case removed because currentStreak cannot exceed longestStreak
-/// (enforced by precondition in init). When a new record is achieved, the caller
-/// must update longestStreak to match currentStreak, resulting in `.stable` status.
-///
-/// Uses neutral, supportive language to honor natural rhythms rather than judge engagement.
-enum TrendIndicator: Equatable {
-  case stable // Current == Longest (at personal record)
-  case resting // Current < Longest (honoring natural rhythm)
 }
 
 // MARK: - Previews
 
 #Preview("Recent Activity") {
-  StreakDisplayView(
-    currentStreak: 5,
-    longestStreak: 12
-  )
-  .padding()
-  .previewDisplayName("Recent Activity")
+  StreakDisplayView(monthlyCheckIns: 7)
+    .padding()
+    .previewDisplayName("Recent Activity")
 }
 
-#Preview("At Previous High") {
-  StreakDisplayView(
-    currentStreak: 15,
-    longestStreak: 15
-  )
-  .padding()
-  .previewDisplayName("At Previous High")
+#Preview("Single Check-In") {
+  StreakDisplayView(monthlyCheckIns: 1)
+    .padding()
+    .previewDisplayName("Single Check-In")
 }
 
-#Preview("Resting Period") {
-  StreakDisplayView(
-    currentStreak: 0,
-    longestStreak: 12
-  )
-  .padding()
-  .previewDisplayName("Resting Period")
+#Preview("Quieter Period") {
+  StreakDisplayView(monthlyCheckIns: 0)
+    .padding()
+    .previewDisplayName("Quieter Period")
 }
 
-#Preview("Starting Out") {
-  StreakDisplayView(
-    currentStreak: 1,
-    longestStreak: 1
-  )
-  .padding()
-  .previewDisplayName("Starting Out")
-}
-
-#Preview("Long-term Practice") {
-  StreakDisplayView(
-    currentStreak: 365,
-    longestStreak: 400
-  )
-  .padding()
-  .previewDisplayName("Long-term Practice")
+#Preview("Very Active") {
+  StreakDisplayView(monthlyCheckIns: 42)
+    .padding()
+    .previewDisplayName("Very Active")
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/GrowthIndicatorsViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/GrowthIndicatorsViewTests.swift
@@ -111,7 +111,7 @@ struct GrowthIndicatorsViewTests {
     #expect(view.trendArrow == "arrow.forward")
   }
 
-  // MARK: - Trend Color (neutral in all cases, Issue #282)
+  // MARK: - Trend Color (neutral in all cases)
 
   @Test("trendColor is neutral for more trend (no evaluative green)")
   func trendColor_isNeutralForMoreTrend() {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/GrowthIndicatorsViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/GrowthIndicatorsViewTests.swift
@@ -30,54 +30,58 @@ struct GrowthIndicatorsViewTests {
     #expect(view.indicators.phaseCoverage == 5)
   }
 
-  @Test("trendDirection returns positive for trend above threshold")
-  func trendDirection_returnsPositiveForTrendAboveThreshold() {
+  // MARK: - Trend Direction (neutral descriptors)
+
+  @Test("trendDirection returns more for trend above threshold")
+  func trendDirection_returnsMoreForTrendAboveThreshold() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
       medicinalTrend: 0.055, // 5.5%, above 5% threshold
       layerDiversity: 3,
       phaseCoverage: 4
     ))
 
-    #expect(view.trendDirection == .positive)
+    #expect(view.trendDirection == .more)
   }
 
-  @Test("trendDirection returns varying for trend below negative threshold")
-  func trendDirection_returnsVaryingForTrendBelowThreshold() {
+  @Test("trendDirection returns quieter for trend below negative threshold")
+  func trendDirection_returnsQuieterForTrendBelowThreshold() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: -0.06, // -6%, below -5% threshold
+      medicinalTrend: -0.06,
       layerDiversity: 2,
       phaseCoverage: 3
     ))
 
-    #expect(view.trendDirection == .varying)
+    #expect(view.trendDirection == .quieter)
   }
 
-  @Test("trendDirection returns neutral for trend within thresholds")
-  func trendDirection_returnsNeutralForTrendWithinThresholds() {
+  @Test("trendDirection returns steady within threshold")
+  func trendDirection_returnsSteadyWithinThreshold() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.02, // 2%, within ±5% threshold
+      medicinalTrend: 0.02,
       layerDiversity: 3,
       phaseCoverage: 4
     ))
 
-    #expect(view.trendDirection == .neutral)
+    #expect(view.trendDirection == .steady)
   }
 
-  @Test("trendDirection handles zero trend as neutral")
-  func trendDirection_handlesZeroTrendAsNeutral() {
+  @Test("trendDirection returns steady for zero trend")
+  func trendDirection_returnsSteadyForZeroTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
       medicinalTrend: 0.0,
       layerDiversity: 1,
       phaseCoverage: 2
     ))
 
-    #expect(view.trendDirection == .neutral)
+    #expect(view.trendDirection == .steady)
   }
 
-  @Test("trendArrow returns up arrow for positive trend")
-  func trendArrow_returnsUpArrowForPositiveTrend() {
+  // MARK: - Trend Arrow (neutral direction indicator only)
+
+  @Test("trendArrow returns up arrow for more trend")
+  func trendArrow_returnsUpArrowForMoreTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.10, // 10%
+      medicinalTrend: 0.10,
       layerDiversity: 3,
       phaseCoverage: 4
     ))
@@ -85,10 +89,10 @@ struct GrowthIndicatorsViewTests {
     #expect(view.trendArrow == "arrow.up")
   }
 
-  @Test("trendArrow returns down arrow for varying trend")
-  func trendArrow_returnsDownArrowForVaryingTrend() {
+  @Test("trendArrow returns down arrow for quieter trend")
+  func trendArrow_returnsDownArrowForQuieterTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: -0.08, // -8%
+      medicinalTrend: -0.08,
       layerDiversity: 2,
       phaseCoverage: 3
     ))
@@ -96,10 +100,10 @@ struct GrowthIndicatorsViewTests {
     #expect(view.trendArrow == "arrow.down")
   }
 
-  @Test("trendArrow returns forward arrow for neutral trend")
-  func trendArrow_returnsForwardArrowForNeutralTrend() {
+  @Test("trendArrow returns forward arrow for steady trend")
+  func trendArrow_returnsForwardArrowForSteadyTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.015, // 1.5%
+      medicinalTrend: 0.015,
       layerDiversity: 3,
       phaseCoverage: 4
     ))
@@ -107,47 +111,114 @@ struct GrowthIndicatorsViewTests {
     #expect(view.trendArrow == "arrow.forward")
   }
 
-  @Test("trendColor returns green for positive trend")
-  func trendColor_returnsGreenForPositiveTrend() {
+  // MARK: - Trend Color (neutral in all cases, Issue #282)
+
+  @Test("trendColor is neutral for more trend (no evaluative green)")
+  func trendColor_isNeutralForMoreTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.15, // 15%
+      medicinalTrend: 0.15,
       layerDiversity: 4,
       phaseCoverage: 5
     ))
 
-    #expect(view.trendColor == .green)
+    #expect(view.trendColor != .green)
+    #expect(view.trendColor != .red)
+    #expect(view.trendColor != .orange)
+    #expect(view.trendColor != .yellow)
   }
 
-  @Test("trendColor returns neutral color for varying trend")
-  func trendColor_returnsNeutralColorForVaryingTrend() {
+  @Test("trendColor is neutral for quieter trend")
+  func trendColor_isNeutralForQuieterTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: -0.12, // -12%
+      medicinalTrend: -0.12,
       layerDiversity: 2,
       phaseCoverage: 3
     ))
 
-    // Should use a neutral, supportive color (not red/orange)
     #expect(view.trendColor != .red)
     #expect(view.trendColor != .orange)
+    #expect(view.trendColor != .green)
+    #expect(view.trendColor != .yellow)
   }
 
-  @Test("trendColor returns neutral color for neutral trend")
-  func trendColor_returnsNeutralColorForNeutralTrend() {
+  @Test("trendColor is neutral for steady trend")
+  func trendColor_isNeutralForSteadyTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.03, // 3%
+      medicinalTrend: 0.03,
       layerDiversity: 3,
       phaseCoverage: 4
     ))
 
-    // Should use a neutral color (not red/orange)
     #expect(view.trendColor != .red)
     #expect(view.trendColor != .orange)
+    #expect(view.trendColor != .green)
+    #expect(view.trendColor != .yellow)
   }
 
-  @Test("formattedTrend includes percentage and sign for positive trend")
-  func formattedTrend_includesPercentageAndSignForPositiveTrend() {
+  @Test("trendColor is identical across directions")
+  func trendColor_identicalAcrossDirections() {
+    let more = GrowthIndicatorsView(indicators: GrowthIndicators(
+      medicinalTrend: 0.20,
+      layerDiversity: 3,
+      phaseCoverage: 4
+    ))
+    let quieter = GrowthIndicatorsView(indicators: GrowthIndicators(
+      medicinalTrend: -0.20,
+      layerDiversity: 3,
+      phaseCoverage: 4
+    ))
+    let steady = GrowthIndicatorsView(indicators: GrowthIndicators(
+      medicinalTrend: 0.01,
+      layerDiversity: 3,
+      phaseCoverage: 4
+    ))
+
+    #expect(more.trendColor == quieter.trendColor)
+    #expect(quieter.trendColor == steady.trendColor)
+  }
+
+  // MARK: - Trend Description (no prescriptive language)
+
+  @Test("trendDescription avoids prescriptive language")
+  func trendDescription_avoidsPrescriptiveLanguage() {
+    let cases: [Double] = [0.15, -0.15, 0.0]
+    for trend in cases {
+      let view = GrowthIndicatorsView(indicators: GrowthIndicators(
+        medicinalTrend: trend,
+        layerDiversity: 3,
+        phaseCoverage: 4
+      ))
+      let text = view.trendDescription.lowercased()
+      #expect(!text.contains("declining"))
+      #expect(!text.contains("failure"))
+      #expect(!text.contains("should"))
+      #expect(!text.contains("need to"))
+      #expect(!text.contains("better"))
+      #expect(!text.contains("worse"))
+    }
+  }
+
+  // MARK: - Rhythm Context (supportive affirmation)
+
+  @Test("rhythmContext affirms natural ebbs and flows")
+  func rhythmContext_affirmsNaturalEbbAndFlow() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.1234, // 12.34%
+      medicinalTrend: -0.05,
+      layerDiversity: 2,
+      phaseCoverage: 3
+    ))
+    let text = view.rhythmContext.lowercased()
+    #expect(text.contains("natural"))
+    #expect(!text.contains("should"))
+    #expect(!text.contains("goal"))
+  }
+
+  // MARK: - Formatted Trend (factual, unchanged)
+
+  @Test("formattedTrend includes percentage and sign for increase")
+  func formattedTrend_includesPercentageAndSignForIncrease() {
+    let view = GrowthIndicatorsView(indicators: GrowthIndicators(
+      medicinalTrend: 0.1234,
       layerDiversity: 3,
       phaseCoverage: 4
     ))
@@ -155,10 +226,10 @@ struct GrowthIndicatorsViewTests {
     #expect(view.formattedTrend == "+12.3%")
   }
 
-  @Test("formattedTrend includes percentage and sign for decreasing trend")
-  func formattedTrend_includesPercentageAndSignForDecreasingTrend() {
+  @Test("formattedTrend includes percentage and sign for decrease")
+  func formattedTrend_includesPercentageAndSignForDecrease() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: -0.0876, // -8.76%
+      medicinalTrend: -0.0876,
       layerDiversity: 2,
       phaseCoverage: 3
     ))
@@ -176,6 +247,8 @@ struct GrowthIndicatorsViewTests {
 
     #expect(view.formattedTrend == "0.0%")
   }
+
+  // MARK: - Diversity / Coverage Text
 
   @Test("layerDiversityText formats singular layer correctly")
   func layerDiversityText_formatsSingularLayerCorrectly() {
@@ -243,6 +316,8 @@ struct GrowthIndicatorsViewTests {
     #expect(view.phaseCoverageText == "0 of 6 phases")
   }
 
+  // MARK: - isEmpty
+
   @Test("isEmpty returns true when no data")
   func isEmpty_returnsTrueWhenNoData() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
@@ -276,8 +351,8 @@ struct GrowthIndicatorsViewTests {
     #expect(view.isEmpty == false)
   }
 
-  @Test("isEmpty returns false when has positive trend")
-  func isEmpty_returnsFalseWhenHasPositiveTrend() {
+  @Test("isEmpty returns false when has more trend")
+  func isEmpty_returnsFalseWhenHasMoreTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
       medicinalTrend: 0.05,
       layerDiversity: 0,
@@ -287,8 +362,8 @@ struct GrowthIndicatorsViewTests {
     #expect(view.isEmpty == false)
   }
 
-  @Test("isEmpty returns false when has varying trend")
-  func isEmpty_returnsFalseWhenHasVaryingTrend() {
+  @Test("isEmpty returns false when has quieter trend")
+  func isEmpty_returnsFalseWhenHasQuieterTrend() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
       medicinalTrend: -0.05,
       layerDiversity: 0,
@@ -298,34 +373,36 @@ struct GrowthIndicatorsViewTests {
     #expect(view.isEmpty == false)
   }
 
-  @Test("integration test with realistic positive growth data")
-  func integrationTest_withRealisticPositiveGrowthData() {
+  // MARK: - Integration
+
+  @Test("integration test with realistic more-medicinal data")
+  func integrationTest_withRealisticMoreMedicinalData() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.185, // 18.5%
+      medicinalTrend: 0.185,
       layerDiversity: 5,
       phaseCoverage: 6
     ))
 
-    #expect(view.trendDirection == .positive)
+    #expect(view.trendDirection == .more)
     #expect(view.trendArrow == "arrow.up")
-    #expect(view.trendColor == .green)
+    #expect(view.trendColor != .green)
+    #expect(view.trendColor != .red)
     #expect(view.formattedTrend == "+18.5%")
     #expect(view.layerDiversityText == "5 modes")
     #expect(view.phaseCoverageText == "6 of 6 phases")
     #expect(view.isEmpty == false)
   }
 
-  @Test("integration test with realistic varying growth data")
-  func integrationTest_withRealisticVaryingGrowthData() {
+  @Test("integration test with realistic quieter-phase data")
+  func integrationTest_withRealisticQuieterPhaseData() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: -0.152, // -15.2%
+      medicinalTrend: -0.152,
       layerDiversity: 2,
       phaseCoverage: 3
     ))
 
-    #expect(view.trendDirection == .varying)
+    #expect(view.trendDirection == .quieter)
     #expect(view.trendArrow == "arrow.down")
-    // Should use neutral, supportive color
     #expect(view.trendColor != .red)
     #expect(view.trendColor != .orange)
     #expect(view.formattedTrend == "-15.2%")
@@ -334,17 +411,16 @@ struct GrowthIndicatorsViewTests {
     #expect(view.isEmpty == false)
   }
 
-  @Test("integration test with realistic neutral growth data")
-  func integrationTest_withRealisticNeutralGrowthData() {
+  @Test("integration test with realistic steady data")
+  func integrationTest_withRealisticSteadyData() {
     let view = GrowthIndicatorsView(indicators: GrowthIndicators(
-      medicinalTrend: 0.025, // 2.5%
+      medicinalTrend: 0.025,
       layerDiversity: 3,
       phaseCoverage: 4
     ))
 
-    #expect(view.trendDirection == .neutral)
+    #expect(view.trendDirection == .steady)
     #expect(view.trendArrow == "arrow.forward")
-    // Should use neutral, supportive color
     #expect(view.trendColor != .red)
     #expect(view.trendColor != .orange)
     #expect(view.formattedTrend == "+2.5%")

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/StreakDisplayViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/StreakDisplayViewTests.swift
@@ -28,19 +28,19 @@ struct StreakDisplayViewTests {
   @Test("activity text uses plural for zero check-ins")
   func activityText_usesPluralForZero() {
     let view = StreakDisplayView(monthlyCheckIns: 0)
-    #expect(view.activityText == "0 check-ins this month")
+    #expect(view.activityText == "0 check-ins in the last 30 days")
   }
 
   @Test("activity text uses singular for one check-in")
   func activityText_usesSingularForOne() {
     let view = StreakDisplayView(monthlyCheckIns: 1)
-    #expect(view.activityText == "1 check-in this month")
+    #expect(view.activityText == "1 check-in in the last 30 days")
   }
 
   @Test("activity text uses plural for multiple check-ins")
   func activityText_usesPluralForMany() {
     let view = StreakDisplayView(monthlyCheckIns: 12)
-    #expect(view.activityText == "12 check-ins this month")
+    #expect(view.activityText == "12 check-ins in the last 30 days")
   }
 
   // MARK: - Neutral, non-gamified language

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/StreakDisplayViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/StreakDisplayViewTests.swift
@@ -3,220 +3,66 @@ import Testing
 @testable import WavelengthWatch_Watch_App
 
 struct StreakDisplayViewTests {
-  // MARK: - Basic Display Tests
+  // MARK: - Initialization
 
-  @Test("view displays current streak")
-  func view_displaysCurrentStreak() {
-    let view = StreakDisplayView(
-      currentStreak: 5,
-      longestStreak: 12
-    )
-
-    #expect(view.currentStreak == 5)
+  @Test("view stores monthly check-in count")
+  func view_storesMonthlyCheckInCount() {
+    let view = StreakDisplayView(monthlyCheckIns: 7)
+    #expect(view.monthlyCheckIns == 7)
   }
 
-  @Test("view displays longest streak")
-  func view_displaysLongestStreak() {
-    let view = StreakDisplayView(
-      currentStreak: 5,
-      longestStreak: 12
-    )
-
-    #expect(view.longestStreak == 12)
+  @Test("view accepts zero check-ins")
+  func view_acceptsZeroCheckIns() {
+    let view = StreakDisplayView(monthlyCheckIns: 0)
+    #expect(view.monthlyCheckIns == 0)
   }
 
-  // MARK: - Trend Indicator Tests
-
-  // NOTE: Test for currentStreak > longestStreak removed because this now triggers
-  // a precondition failure (cannot be tested). The component enforces that
-  // currentStreak <= longestStreak. When a record is broken, the caller must
-  // update longestStreak to match currentStreak before creating the view.
-
-  @Test("trend indicators use neutral, supportive language")
-  func trendIndicators_useNeutralSupportiveLanguage() {
-    let restingView = StreakDisplayView(
-      currentStreak: 5,
-      longestStreak: 12
-    )
-
-    // Verify resting state uses neutral color (not red/orange evaluative colors)
-    let color = restingView.trendColor
-    #expect(color != .red)
-    #expect(color != .orange)
+  @Test("view accepts large check-in counts")
+  func view_acceptsLargeCheckInCounts() {
+    let view = StreakDisplayView(monthlyCheckIns: 365)
+    #expect(view.monthlyCheckIns == 365)
   }
 
-  @Test("view shows stable trend when current equals longest")
-  func view_showsStableTrendWhenCurrentEqualsLongest() {
-    let view = StreakDisplayView(
-      currentStreak: 12,
-      longestStreak: 12
-    )
+  // MARK: - Activity Text
 
-    #expect(view.trendIndicator == .stable)
+  @Test("activity text uses plural for zero check-ins")
+  func activityText_usesPluralForZero() {
+    let view = StreakDisplayView(monthlyCheckIns: 0)
+    #expect(view.activityText == "0 check-ins this month")
   }
 
-  @Test("view shows resting trend when current is less than longest")
-  func view_showsRestingTrendWhenCurrentIsLessThanLongest() {
-    let view = StreakDisplayView(
-      currentStreak: 5,
-      longestStreak: 12
-    )
-
-    #expect(view.trendIndicator == .resting)
+  @Test("activity text uses singular for one check-in")
+  func activityText_usesSingularForOne() {
+    let view = StreakDisplayView(monthlyCheckIns: 1)
+    #expect(view.activityText == "1 check-in this month")
   }
 
-  @Test("view shows stable trend when both streaks are zero")
-  func view_showsStableTrendWhenBothStreaksAreZero() {
-    let view = StreakDisplayView(
-      currentStreak: 0,
-      longestStreak: 0
-    )
-
-    #expect(view.trendIndicator == .stable)
+  @Test("activity text uses plural for multiple check-ins")
+  func activityText_usesPluralForMany() {
+    let view = StreakDisplayView(monthlyCheckIns: 12)
+    #expect(view.activityText == "12 check-ins this month")
   }
 
-  // MARK: - Edge Cases
+  // MARK: - Neutral, non-gamified language
 
-  @Test("view handles zero current streak")
-  func view_handlesZeroCurrentStreak() {
-    let view = StreakDisplayView(
-      currentStreak: 0,
-      longestStreak: 12
-    )
-
-    #expect(view.currentStreak == 0)
-    #expect(view.longestStreak == 12)
-  }
-
-  /// NOTE: Test for currentStreak > longestStreak removed because this violates
-  /// the precondition that currentStreak <= longestStreak. This edge case is now
-  /// semantically invalid and properly caught by the precondition.
-  @Test("view handles zero longest streak")
-  func view_handlesZeroLongestStreak() {
-    let view = StreakDisplayView(
-      currentStreak: 0,
-      longestStreak: 0
-    )
-
-    #expect(view.currentStreak == 0)
-    #expect(view.longestStreak == 0)
-  }
-
-  @Test("view handles single day streak")
-  func view_handlesSingleDayStreak() {
-    let view = StreakDisplayView(
-      currentStreak: 1,
-      longestStreak: 1
-    )
-
-    #expect(view.currentStreak == 1)
-    #expect(view.longestStreak == 1)
-    #expect(view.trendIndicator == .stable)
-  }
-
-  @Test("view handles large streak numbers")
-  func view_handlesLargeStreakNumbers() {
-    let view = StreakDisplayView(
-      currentStreak: 365,
-      longestStreak: 400
-    )
-
-    #expect(view.currentStreak == 365)
-    #expect(view.longestStreak == 400)
-  }
-
-  // MARK: - Text Formatting Tests
-
-  @Test("view uses neutral activity language without gamification")
-  func view_usesNeutralActivityLanguage() {
-    let view = StreakDisplayView(
-      currentStreak: 1,
-      longestStreak: 5
-    )
-
-    let text = view.currentStreakText
-    // Should use neutral "Recent Activity" language, not "Streak"
+  @Test("activity text removes all streak terminology")
+  func activityText_removesStreakTerminology() {
+    let view = StreakDisplayView(monthlyCheckIns: 5)
+    let text = view.activityText
     #expect(!text.contains("Streak"))
-    #expect(text.contains("Recent Activity"))
-  }
-
-  @Test("view shows activity count without pressure language")
-  func view_showsActivityCountWithoutPressure() {
-    let view = StreakDisplayView(
-      currentStreak: 5,
-      longestStreak: 12
-    )
-
-    let text = view.currentStreakText
-    // Should show count without gamification
-    #expect(!text.contains("Streak"))
-    #expect(text.contains("Recent Activity"))
-  }
-
-  @Test("view formats historical context without longest language")
-  func view_formatsHistoricalContextWithoutLongest() {
-    let view = StreakDisplayView(
-      currentStreak: 5,
-      longestStreak: 12
-    )
-
-    let text = view.longestStreakText
-    // Should avoid "Longest" competitive framing
+    #expect(!text.contains("streak"))
+    #expect(!text.contains("🔥"))
     #expect(!text.contains("Longest"))
-    // Can show historical note without pressure (e.g., "Previous high")
-    #expect(text.contains("12"))
-    #expect(text.contains("Previous high"))
+    #expect(!text.contains("Previous high"))
   }
 
-  // MARK: - Trend Arrow Tests
-
-  // NOTE: Test for up arrow (↑) removed because .improving trend no longer exists.
-  // Component now only supports .stable (→) and .resting (↓) trends.
-
-  @Test("view returns right arrow for stable trend")
-  func view_returnsRightArrowForStableTrend() {
-    let view = StreakDisplayView(
-      currentStreak: 12,
-      longestStreak: 12
-    )
-
-    #expect(view.trendArrow == "→")
-  }
-
-  @Test("view returns down arrow for resting trend")
-  func view_returnsDownArrowForRestingTrend() {
-    let view = StreakDisplayView(
-      currentStreak: 5,
-      longestStreak: 12
-    )
-
-    #expect(view.trendArrow == "↓")
-  }
-
-  // MARK: - Integration Tests
-
-  @Test("view shows all components together")
-  func view_showsAllComponentsTogether() {
-    let view = StreakDisplayView(
-      currentStreak: 25,
-      longestStreak: 30
-    )
-
-    #expect(view.currentStreak == 25)
-    #expect(view.longestStreak == 30)
-    #expect(view.trendIndicator == .resting)
-    #expect(view.trendArrow == "↓")
-  }
-
-  @Test("view works with minimal data")
-  func view_worksWithMinimalData() {
-    let view = StreakDisplayView(
-      currentStreak: 0,
-      longestStreak: 0
-    )
-
-    #expect(view.currentStreak == 0)
-    #expect(view.longestStreak == 0)
-    #expect(view.trendIndicator == .stable)
+  @Test("context text affirms natural rhythms without pressure")
+  func contextText_affirmsNaturalRhythms() {
+    let view = StreakDisplayView(monthlyCheckIns: 5)
+    let text = view.contextText
+    #expect(!text.contains("should"))
+    #expect(!text.contains("goal"))
+    #expect(!text.contains("streak"))
+    #expect(text.lowercased().contains("natural"))
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/TemporalPatternsViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/TemporalPatternsViewTests.swift
@@ -13,7 +13,7 @@ struct TemporalPatternsViewTests {
     CatalogPhaseModel(id: 4, name: "Resting", medicinal: [], toxic: [], strategies: []),
   ]
 
-  // MARK: - Basic Initialization Tests
+  // MARK: - Basic Initialization
 
   @Test("view initializes with empty data")
   func view_initializesWithEmptyData() {
@@ -41,7 +41,33 @@ struct TemporalPatternsViewTests {
     #expect(view.patterns.hourlyDistribution.count == 3)
   }
 
-  // MARK: - Hour Label Tests
+  // MARK: - Copy (Issue #285)
+
+  @Test("title uses Your Natural Rhythm framing")
+  func title_usesNaturalRhythmFraming() {
+    #expect(TemporalPatternsView.title == "Your Natural Rhythm")
+  }
+
+  @Test("subtitle uses descriptive tend-to language")
+  func subtitle_usesDescriptiveLanguage() {
+    let text = TemporalPatternsView.subtitle.lowercased()
+    #expect(text.contains("naturally"))
+    #expect(text.contains("tend"))
+    #expect(!text.contains("should"))
+    #expect(!text.contains("need to"))
+  }
+
+  @Test("affirmation honors unique rhythms")
+  func affirmation_honorsUniqueRhythms() {
+    let text = TemporalPatternsView.affirmation.lowercased()
+    #expect(text.contains("unique"))
+    #expect(!text.contains("should"))
+    #expect(!text.contains("need to"))
+    #expect(!text.contains("better"))
+    #expect(!text.contains("worse"))
+  }
+
+  // MARK: - Hour Label
 
   @Test("hourLabel formats hours correctly")
   func hourLabel_formatsHoursCorrectly() {
@@ -54,7 +80,7 @@ struct TemporalPatternsViewTests {
     #expect(TemporalPatternsView.hourLabel(23) == "11 PM")
   }
 
-  // MARK: - Hourly Summary Tests
+  // MARK: - Hourly Summary
 
   @Test("hourlySummaries includes phase name when available")
   func hourlySummaries_includesPhaseNameWhenAvailable() {
@@ -139,24 +165,35 @@ struct TemporalPatternsViewTests {
     #expect(view.hourlySummaries.isEmpty)
   }
 
-  // MARK: - Dosage Color Tests
+  // MARK: - Neutral Dosage Color (Issue #285)
 
-  @Test("dosageColor returns green for Medicinal")
-  func dosageColor_returnsGreenForMedicinal() {
-    #expect(TemporalPatternsView.dosageColor(for: "Medicinal") == .green)
+  @Test("dosageColor returns neutral purple for Medicinal")
+  func dosageColor_returnsNeutralPurpleForMedicinal() {
+    #expect(TemporalPatternsView.dosageColor(for: "Medicinal") == .purple)
   }
 
-  @Test("dosageColor returns secondary for Toxic")
-  func dosageColor_returnsSecondaryForToxic() {
-    #expect(TemporalPatternsView.dosageColor(for: "Toxic") == .secondary)
+  @Test("dosageColor returns neutral purple for Toxic")
+  func dosageColor_returnsNeutralPurpleForToxic() {
+    #expect(TemporalPatternsView.dosageColor(for: "Toxic") == .purple)
   }
 
-  @Test("dosageColor returns purple as default")
-  func dosageColor_returnsPurpleAsDefault() {
+  @Test("dosageColor returns neutral purple for nil")
+  func dosageColor_returnsNeutralPurpleForNil() {
     #expect(TemporalPatternsView.dosageColor(for: nil) == .purple)
   }
 
-  // MARK: - Integration Tests
+  @Test("dosageColor never returns evaluative colors")
+  func dosageColor_neverReturnsEvaluativeColors() {
+    for dosage in ["Medicinal", "Toxic", nil] {
+      let color = TemporalPatternsView.dosageColor(for: dosage)
+      #expect(color != .red)
+      #expect(color != .green)
+      #expect(color != .orange)
+      #expect(color != .yellow)
+    }
+  }
+
+  // MARK: - Integration
 
   @Test("integration test with mixed phase and dosage data")
   func integrationTest_withMixedPhaseAndDosageData() {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/TemporalPatternsViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/TemporalPatternsViewTests.swift
@@ -41,7 +41,7 @@ struct TemporalPatternsViewTests {
     #expect(view.patterns.hourlyDistribution.count == 3)
   }
 
-  // MARK: - Copy (Issue #285)
+  // MARK: - Copy
 
   @Test("title uses Your Natural Rhythm framing")
   func title_usesNaturalRhythmFraming() {
@@ -165,7 +165,7 @@ struct TemporalPatternsViewTests {
     #expect(view.hourlySummaries.isEmpty)
   }
 
-  // MARK: - Neutral Dosage Color (Issue #285)
+  // MARK: - Neutral Dosage Color
 
   @Test("dosageColor returns neutral purple for Medicinal")
   func dosageColor_returnsNeutralPurpleForMedicinal() {


### PR DESCRIPTION
## Summary

Reframes four analytics surfaces to align with APTITUDE's wavelength teachings — replacing evaluative/gamified framings with descriptive, supportive language and a single neutral color palette.

Closes #280, #281, #282, #285.

### #280 — Remove streak gamification
`StreakDisplayView` now shows "N check-ins this month" with proper pluralization. Removed streak counting, fire emoji, trend arrows, and evaluative color logic. Call site in `AnalyticsViewSections` passes `overview.totalEntries` and gates on `> 0`.

### #281 — Remove evaluative color coding on medicinal trend
Emotional Health section's medicinal trend row drops the red/green directional arrow for a neutral `waveform.path` icon with "X.X% shift this period" phrasing, both rendered in `.secondary`.

### #282 — Reframe growth indicator trend language
`GrowthIndicatorsView` renames to "Your Activity Pattern". `TrendDirection` cases replaced with `.more` / `.quieter` / `.steady`. A single `.secondary` color is used for all directions. Added descriptive labels ("More medicinal this period", "A quieter phase right now", "A steady rhythm") and a supportive `rhythmContext`: "Your engagement naturally ebbs and flows. Quieter phases can be times of integration and rest."

### #285 — Reframe Temporal Patterns
Renamed to "Your Natural Rhythm" with descriptive subtitle "When you naturally tend to check in" and validating affirmation "Everyone's rhythm is unique. This is your pattern, and it's valid." Introduced a single `neutralColor` (`.purple`) for all rows; `dosageColor(for:)` no longer switches on Medicinal/Toxic.

## Test plan

Tests adjusted in stay-green style before implementation — covering new copy, pluralization, neutral colors across all inputs, and absence of prescriptive/evaluative language.

- [ ] CI runs `frontend/WavelengthWatch/run-tests-individually.sh` (StreakDisplayViewTests, GrowthIndicatorsViewTests, TemporalPatternsViewTests)
- [ ] CI runs SwiftFormat lint
- [ ] Manual smoke test of Analytics tab on watch simulator post-merge

**Note:** Local Xcode validation was not possible in this Linux environment (no `xcodebuild`); CI will validate the test suite.

https://claude.ai/code/session_01KohSWjdxbmNgKZ3CVvTMUM