### PR TITLE
feat: offline journal queue — JournalClient + UI + integration tests (#215, #216, #218)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -42,10 +42,21 @@ struct ContentView: View {
     self.journalRepository = journalRepository
     self.catalogRepository = repository
     let syncSettings = SyncSettings()
+    let journalQueue: JournalQueueProtocol?
+    do {
+      journalQueue = try JournalQueue()
+    } catch {
+      // Offline queue is best-effort. If SQLite setup fails (e.g. in previews
+      // or on read-only storage) fall back to no-queue behaviour so journal
+      // submissions still succeed locally.
+      print("⚠️ Failed to initialize journal queue: \(error). Offline retry disabled.")
+      journalQueue = nil
+    }
     let journalClient = JournalClient(
       apiClient: apiClient,
       repository: journalRepository,
-      syncSettings: syncSettings
+      syncSettings: syncSettings,
+      queue: journalQueue
     )
     self.journalClient = journalClient
     let initialLayer = UserDefaults.standard.integer(forKey: "selectedLayerIndex")
@@ -175,6 +186,12 @@ struct ContentView: View {
             message: Text("Thanks for checking in."),
             dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
           )
+        case let .queued(message):
+          Alert(
+            title: Text("Saved Offline"),
+            message: Text(message),
+            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
+          )
         case let .failure(message):
           Alert(
             title: Text("Something went wrong"),
@@ -195,6 +212,11 @@ struct ContentView: View {
             do {
               try await flowCoordinator.submit()
               // Success - reset flow state (quick log doesn't use review sheet)
+              flowCoordinator.reset()
+            } catch JournalError.queuedForRetry {
+              viewModel.journalFeedback = .init(
+                kind: .queued("Saved offline. Will sync automatically.")
+              )
               flowCoordinator.reset()
             } catch {
               viewModel.journalFeedback = .init(kind: .failure("Failed to log emotion: \(error.localizedDescription)"))
@@ -218,6 +240,11 @@ struct ContentView: View {
             do {
               try await flowCoordinator.submit()
               // Success - reset flow state (quick log doesn't use review sheet)
+              flowCoordinator.reset()
+            } catch JournalError.queuedForRetry {
+              viewModel.journalFeedback = .init(
+                kind: .queued("Saved offline. Will sync automatically.")
+              )
               flowCoordinator.reset()
             } catch {
               viewModel.journalFeedback = .init(kind: .failure("Failed to log emotions: \(error.localizedDescription)"))

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -6,6 +6,9 @@ struct ContentView: View {
   @StateObject private var viewModel: ContentViewModel
   @StateObject private var flowCoordinator: FlowCoordinator
   @StateObject private var syncSettingsViewModel: SyncSettingsViewModel
+  @StateObject private var networkMonitor: NetworkMonitor
+  @StateObject private var journalQueue: JournalQueue
+  @StateObject private var syncService: JournalSyncService
   @EnvironmentObject private var notificationDelegate: NotificationDelegate
   let journalClient: JournalClientProtocol
   let journalRepository: JournalRepositoryProtocol
@@ -42,16 +45,22 @@ struct ContentView: View {
     self.journalRepository = journalRepository
     self.catalogRepository = repository
     let syncSettings = SyncSettings()
-    let journalQueue: JournalQueueProtocol?
+    let journalQueue: JournalQueue
     do {
       journalQueue = try JournalQueue()
     } catch {
-      // Offline queue is best-effort. If SQLite setup fails (e.g. in previews
-      // or on read-only storage) fall back to no-queue behaviour so journal
-      // submissions still succeed locally.
-      print("⚠️ Failed to initialize journal queue: \(error). Offline retry disabled.")
-      journalQueue = nil
+      // The documents directory is unavailable in SwiftUI previews and on a
+      // few read-only storage configurations. Fall back to a temp-dir queue
+      // so the UI can still render even though entries won't persist across
+      // launches.
+      print("⚠️ Failed to initialize journal queue: \(error). Falling back to temp storage.")
+      let fallbackPath = NSTemporaryDirectory() + "journal_queue_fallback.sqlite"
+      // swiftlint:disable:next force_try  -- temp dir is always writable.
+      journalQueue = try! JournalQueue(databasePath: fallbackPath)
     }
+    _journalQueue = StateObject(wrappedValue: journalQueue)
+    let monitor = NetworkMonitor()
+    _networkMonitor = StateObject(wrappedValue: monitor)
     let journalClient = JournalClient(
       apiClient: apiClient,
       repository: journalRepository,
@@ -59,6 +68,12 @@ struct ContentView: View {
       queue: journalQueue
     )
     self.journalClient = journalClient
+    let sync = JournalSyncService(
+      queue: journalQueue,
+      apiClient: apiClient,
+      networkMonitor: monitor
+    )
+    _syncService = StateObject(wrappedValue: sync)
     let initialLayer = UserDefaults.standard.integer(forKey: "selectedLayerIndex")
     let initialPhase = UserDefaults.standard.integer(forKey: "selectedPhaseIndex")
     let model = ContentViewModel(
@@ -117,6 +132,15 @@ struct ContentView: View {
       }
       .ignoresSafeArea(edges: .bottom)
       .task { await viewModel.loadCatalog() }
+      .task {
+        // Kick off auto-sync once when the view appears. The service
+        // subscribes to NetworkMonitor and triggers a sync whenever
+        // connectivity is restored.
+        syncService.startAutoSync()
+      }
+      .onChange(of: syncService.syncStatus) { _, newValue in
+        viewModel.handleSyncStatusChange(newValue, totalPending: journalQueue.pendingCount)
+      }
       .onChange(of: viewModel.phaseOrder) {
         adjustPhaseSelection()
       }
@@ -190,6 +214,18 @@ struct ContentView: View {
           Alert(
             title: Text("Saved Offline"),
             message: Text(message),
+            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
+          )
+        case let .syncing(current, total):
+          Alert(
+            title: Text("Syncing"),
+            message: Text("Syncing \(current) of \(total) entr\(total == 1 ? "y" : "ies")…"),
+            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
+          )
+        case let .syncSuccess(count):
+          Alert(
+            title: Text("Synced"),
+            message: Text("\(count) entr\(count == 1 ? "y" : "ies") synced successfully."),
             dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
           )
         case let .failure(message):
@@ -304,6 +340,9 @@ struct ContentView: View {
           MenuView(
             journalClient: journalClient,
             syncSettingsViewModel: syncSettingsViewModel,
+            journalQueue: journalQueue,
+            syncService: syncService,
+            networkMonitor: networkMonitor,
             isPresented: $showingMenu
           )
           .toolbar {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -45,19 +45,7 @@ struct ContentView: View {
     self.journalRepository = journalRepository
     self.catalogRepository = repository
     let syncSettings = SyncSettings()
-    let journalQueue: JournalQueue
-    do {
-      journalQueue = try JournalQueue()
-    } catch {
-      // The documents directory is unavailable in SwiftUI previews and on a
-      // few read-only storage configurations. Fall back to a temp-dir queue
-      // so the UI can still render even though entries won't persist across
-      // launches.
-      print("⚠️ Failed to initialize journal queue: \(error). Falling back to temp storage.")
-      let fallbackPath = NSTemporaryDirectory() + "journal_queue_fallback.sqlite"
-      // swiftlint:disable:next force_try  -- temp dir is always writable.
-      journalQueue = try! JournalQueue(databasePath: fallbackPath)
-    }
+    let journalQueue = Self.makeJournalQueue()
     _journalQueue = StateObject(wrappedValue: journalQueue)
     let monitor = NetworkMonitor()
     _networkMonitor = StateObject(wrappedValue: monitor)
@@ -89,6 +77,52 @@ struct ContentView: View {
     _flowCoordinator = StateObject(wrappedValue: coordinator)
     _layerSelection = State(initialValue: initialLayer)
     _phaseSelection = State(initialValue: initialPhase + 1)
+  }
+
+  /// Builds a JournalQueue with progressive fallback: documents directory →
+  /// NSTemporaryDirectory → in-memory SQLite. The in-memory leg has no
+  /// filesystem dependency, so it cannot fail in normal operation; if even
+  /// that throws, the device is in a state where no offline persistence is
+  /// possible and crashing surfaces the problem rather than silently
+  /// dropping entries.
+  private static func makeJournalQueue() -> JournalQueue {
+    do {
+      return try JournalQueue()
+    } catch {
+      print("⚠️ Documents-dir journal queue init failed: \(error). Trying temp dir.")
+    }
+    let fallbackPath = NSTemporaryDirectory() + "journal_queue_fallback.sqlite"
+    do {
+      return try JournalQueue(databasePath: fallbackPath)
+    } catch {
+      print("⚠️ Temp-dir journal queue init failed: \(error). Falling back to in-memory.")
+    }
+    do {
+      return try JournalQueue(databasePath: ":memory:")
+    } catch {
+      fatalError("In-memory journal queue init failed unexpectedly: \(error)")
+    }
+  }
+
+  /// Submits the current FlowCoordinator entry and renders the appropriate
+  /// feedback. Centralised so the two confirmation alerts (primary and
+  /// secondary) share identical queued/failure handling — the only thing
+  /// that varies is the failure copy.
+  @MainActor
+  private func submitFlowEntry(failurePrefix: String) async {
+    do {
+      try await flowCoordinator.submit()
+      flowCoordinator.reset()
+    } catch JournalError.queuedForRetry {
+      viewModel.journalFeedback = .init(
+        kind: .queued("Saved offline. Will sync automatically.")
+      )
+      flowCoordinator.reset()
+    } catch {
+      viewModel.journalFeedback = .init(
+        kind: .failure("\(failurePrefix): \(error.localizedDescription)")
+      )
+    }
   }
 
   /// Clamped layer selection that's always valid for the current filteredLayers
@@ -244,20 +278,7 @@ struct ContentView: View {
           flowCoordinator.promptForStrategy()
         }
         Button("Done") {
-          Task {
-            do {
-              try await flowCoordinator.submit()
-              // Success - reset flow state (quick log doesn't use review sheet)
-              flowCoordinator.reset()
-            } catch JournalError.queuedForRetry {
-              viewModel.journalFeedback = .init(
-                kind: .queued("Saved offline. Will sync automatically.")
-              )
-              flowCoordinator.reset()
-            } catch {
-              viewModel.journalFeedback = .init(kind: .failure("Failed to log emotion: \(error.localizedDescription)"))
-            }
-          }
+          Task { await submitFlowEntry(failurePrefix: "Failed to log emotion") }
         }
         Button("Cancel", role: .cancel) {
           flowCoordinator.cancel()
@@ -272,20 +293,7 @@ struct ContentView: View {
           flowCoordinator.promptForStrategy()
         }
         Button("Done") {
-          Task {
-            do {
-              try await flowCoordinator.submit()
-              // Success - reset flow state (quick log doesn't use review sheet)
-              flowCoordinator.reset()
-            } catch JournalError.queuedForRetry {
-              viewModel.journalFeedback = .init(
-                kind: .queued("Saved offline. Will sync automatically.")
-              )
-              flowCoordinator.reset()
-            } catch {
-              viewModel.journalFeedback = .init(kind: .failure("Failed to log emotions: \(error.localizedDescription)"))
-            }
-          }
+          Task { await submitFlowEntry(failurePrefix: "Failed to log emotions") }
         }
         Button("Cancel", role: .cancel) {
           flowCoordinator.cancel()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/APIClient.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/APIClient.swift
@@ -13,12 +13,57 @@ enum APIPath {
 protocol APIClientProtocol {
   func get<T: Decodable>(_ path: String) async throws -> T
   func post<Response: Decodable>(_ path: String, body: some Encodable) async throws -> Response
+  func post<Response: Decodable>(
+    _ path: String,
+    body: some Encodable,
+    headers: [String: String]?
+  ) async throws -> Response
+}
+
+extension APIClientProtocol {
+  /// Default implementation that ignores headers and delegates to the 2-parameter post.
+  ///
+  /// Allows existing mocks/implementations that only define the 2-parameter post
+  /// to satisfy the 3-parameter requirement without explicit header handling.
+  func post<Response: Decodable>(
+    _ path: String,
+    body: some Encodable,
+    headers _: [String: String]?
+  ) async throws -> Response {
+    try await post(path, body: body)
+  }
 }
 
 enum APIClientError: Error {
   case invalidURL(String)
   case transport(Error)
   case badResponse(Int)
+}
+
+extension APIClientError {
+  /// Whether this error indicates a transient failure that may succeed on retry.
+  ///
+  /// Retryable errors include:
+  /// - Transport errors (network connectivity, timeouts)
+  /// - 5xx server errors (server overloaded or transient failure)
+  /// - 408 Request Timeout
+  /// - 429 Too Many Requests
+  ///
+  /// Non-retryable errors include:
+  /// - Invalid URL construction (permanent)
+  /// - 4xx client errors other than 408/429 (validation, auth, not found)
+  var isRetryable: Bool {
+    switch self {
+    case .invalidURL:
+      return false
+    case .transport:
+      return true
+    case let .badResponse(status):
+      if status >= 500 { return true }
+      if status == 408 || status == 429 { return true }
+      return false
+    }
+  }
 }
 
 final class APIClient: APIClientProtocol {
@@ -74,10 +119,23 @@ final class APIClient: APIClientProtocol {
   }
 
   func post<Response: Decodable>(_ path: String, body: some Encodable) async throws -> Response {
+    try await post(path, body: body, headers: nil)
+  }
+
+  func post<Response: Decodable>(
+    _ path: String,
+    body: some Encodable,
+    headers: [String: String]?
+  ) async throws -> Response {
     var request = try URLRequest(url: url(for: path))
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json", forHTTPHeaderField: "Accept")
+    if let headers {
+      for (field, value) in headers {
+        request.setValue(value, forHTTPHeaderField: field)
+      }
+    }
     request.httpBody = try encoder.encode(body)
 
     do {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalClient.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalClient.swift
@@ -48,6 +48,24 @@ struct JournalPayload: Codable {
   }
 }
 
+/// Header name used to send idempotency keys with journal POST requests.
+///
+/// Matches the backend journal router which reads the `X-Idempotency-Key`
+/// header to deduplicate replayed submissions.
+enum JournalRequestHeader {
+  static let idempotencyKey = "X-Idempotency-Key"
+}
+
+/// Errors surfaced by the journal submission flow.
+///
+/// Distinguishes between transient network failures that have been queued for
+/// background retry and permanent failures that the user should be informed of.
+enum JournalError: Error, Equatable {
+  /// The submission was saved locally and queued for retry once connectivity
+  /// returns. The associated UUID identifies the enqueued local entry.
+  case queuedForRetry(entryID: UUID)
+}
+
 protocol JournalClientProtocol {
   @discardableResult
   func submit(
@@ -63,24 +81,35 @@ protocol JournalClientProtocol {
   ) async throws -> LocalJournalEntry
 }
 
-/// Journal client with local-first architecture.
+/// Journal client with local-first architecture and offline queueing.
 ///
 /// This client saves all journal entries to local SQLite storage first,
 /// then optionally syncs to the backend server if cloud sync is enabled.
+/// When a sync attempt fails with a retryable error (network, 5xx) and a
+/// queue is supplied, the entry is enqueued for background retry and the
+/// caller receives `JournalError.queuedForRetry` so the UI can present a
+/// distinct "saved locally" message.
 ///
 /// ## Local-First Behavior
 /// 1. Creates LocalJournalEntry and saves to repository (always)
-/// 2. If cloudSyncEnabled, attempts backend sync
+/// 2. If cloudSyncEnabled, attempts backend sync with an idempotency key
 /// 3. Updates local entry with sync status and server ID
 /// 4. Returns the local entry (with or without successful sync)
 ///
 /// ## Offline Support
 /// Entries are always saved locally, even when offline or sync fails.
-/// Background sync can retry pending/failed entries later.
+/// Retryable failures are enqueued in `JournalQueue` and retried by
+/// `JournalSyncService`. Non-retryable failures mark the entry as failed.
+///
+/// ## Actor Isolation
+/// Isolated to `@MainActor` so it can interoperate safely with the
+/// `@MainActor`-isolated `JournalQueue` without cross-actor bridging.
+@MainActor
 final class JournalClient: JournalClientProtocol {
   private let apiClient: APIClientProtocol
   private let repository: JournalRepositoryProtocol
   private let syncSettings: SyncSettings
+  private let queue: JournalQueueProtocol?
   private let dateProvider: () -> Date
   private let userDefaults: UserDefaults
   private let userDefaultsKey = "com.wavelengthwatch.userIdentifier"
@@ -89,12 +118,14 @@ final class JournalClient: JournalClientProtocol {
     apiClient: APIClientProtocol,
     repository: JournalRepositoryProtocol,
     syncSettings: SyncSettings,
+    queue: JournalQueueProtocol? = nil,
     dateProvider: @escaping () -> Date = Date.init,
     userDefaults: UserDefaults = .standard
   ) {
     self.apiClient = apiClient
     self.repository = repository
     self.syncSettings = syncSettings
+    self.queue = queue
     self.dateProvider = dateProvider
     self.userDefaults = userDefaults
   }
@@ -121,8 +152,7 @@ final class JournalClient: JournalClientProtocol {
     strategyID: Int?,
     initiatedBy: InitiatedBy = .self_initiated
   ) async throws -> LocalJournalEntry {
-    // 1. Create local entry with pending sync status
-    var entry = LocalJournalEntry(
+    let entry = LocalJournalEntry(
       createdAt: dateProvider(),
       userID: numericUserIdentifier(),
       curriculumID: curriculumID,
@@ -132,48 +162,24 @@ final class JournalClient: JournalClientProtocol {
       entryType: .emotion
     )
 
-    // 2. Save to local repository first (always)
-    try repository.save(entry)
+    let payload = JournalPayload(
+      createdAt: entry.createdAt,
+      userID: entry.userID,
+      curriculumID: entry.curriculumID,
+      secondaryCurriculumID: entry.secondaryCurriculumID,
+      strategyID: entry.strategyID,
+      initiatedBy: entry.initiatedBy,
+      entryType: .emotion
+    )
 
-    // 3. Attempt backend sync if enabled
-    if syncSettings.cloudSyncEnabled {
-      do {
-        let payload = JournalPayload(
-          createdAt: entry.createdAt,
-          userID: entry.userID,
-          curriculumID: entry.curriculumID,
-          secondaryCurriculumID: entry.secondaryCurriculumID,
-          strategyID: entry.strategyID,
-          initiatedBy: entry.initiatedBy,
-          entryType: .emotion
-        )
-
-        let response: JournalResponseModel = try await apiClient.post(APIPath.journal, body: payload)
-
-        // Update entry with server ID and synced status
-        entry = LocalJournalEntry.synced(from: response, localEntry: entry)
-        try repository.update(entry)
-      } catch {
-        // Sync failed - mark as failed for retry
-        print("⚠️ Journal sync failed for entry \(entry.id): \(error). Entry saved locally with failed sync status.")
-        entry.syncStatus = .failed
-        entry.lastSyncAttempt = dateProvider()
-        try repository.update(entry)
-
-        // Don't throw - entry is still saved locally
-        // TODO: Consider adding user-visible feedback (notification badge or status indicator)
-      }
-    }
-
-    return entry
+    return try await persistAndSync(entry: entry, payload: payload)
   }
 
   @discardableResult
   func submitRestPeriod(
     initiatedBy: InitiatedBy = .self_initiated
   ) async throws -> LocalJournalEntry {
-    // 1. Create local REST entry with pending sync status
-    var entry = LocalJournalEntry(
+    let entry = LocalJournalEntry(
       createdAt: dateProvider(),
       userID: numericUserIdentifier(),
       curriculumID: nil,
@@ -183,38 +189,73 @@ final class JournalClient: JournalClientProtocol {
       entryType: .rest
     )
 
-    // 2. Save to local repository first (always)
+    let payload = JournalPayload(
+      createdAt: entry.createdAt,
+      userID: entry.userID,
+      curriculumID: nil,
+      secondaryCurriculumID: nil,
+      strategyID: nil,
+      initiatedBy: entry.initiatedBy,
+      entryType: .rest
+    )
+
+    return try await persistAndSync(entry: entry, payload: payload)
+  }
+
+  /// Saves the entry locally and, if cloud sync is enabled, attempts to POST
+  /// it to the backend. Handles queueing and error classification.
+  private func persistAndSync(
+    entry: LocalJournalEntry,
+    payload: JournalPayload
+  ) async throws -> LocalJournalEntry {
+    var entry = entry
     try repository.save(entry)
 
-    // 3. Attempt backend sync if enabled
-    if syncSettings.cloudSyncEnabled {
-      do {
-        let payload = JournalPayload(
-          createdAt: entry.createdAt,
-          userID: entry.userID,
-          curriculumID: nil,
-          secondaryCurriculumID: nil,
-          strategyID: nil,
-          initiatedBy: entry.initiatedBy,
-          entryType: .rest
-        )
-
-        let response: JournalResponseModel = try await apiClient.post(APIPath.journal, body: payload)
-
-        // Update entry with server ID and synced status
-        entry = LocalJournalEntry.synced(from: response, localEntry: entry)
-        try repository.update(entry)
-      } catch {
-        // Sync failed - mark as failed for retry
-        print("⚠️ Journal sync failed for REST entry \(entry.id): \(error). Entry saved locally with failed sync status.")
-        entry.syncStatus = .failed
-        entry.lastSyncAttempt = dateProvider()
-        try repository.update(entry)
-
-        // Don't throw - entry is still saved locally
-      }
+    guard syncSettings.cloudSyncEnabled else {
+      return entry
     }
 
-    return entry
+    let idempotencyKey = entry.id.uuidString
+    do {
+      let response: JournalResponseModel = try await apiClient.post(
+        APIPath.journal,
+        body: payload,
+        headers: [JournalRequestHeader.idempotencyKey: idempotencyKey]
+      )
+      entry = LocalJournalEntry.synced(from: response, localEntry: entry)
+      try repository.update(entry)
+      return entry
+    } catch {
+      let retryable = isRetryable(error)
+      if retryable, let queue {
+        entry.lastSyncAttempt = dateProvider()
+        try repository.update(entry)
+        try queue.enqueue(entry)
+        throw JournalError.queuedForRetry(entryID: entry.id)
+      }
+
+      print("⚠️ Journal sync failed for entry \(entry.id): \(error). Marking entry as failed.")
+      entry.syncStatus = .failed
+      entry.lastSyncAttempt = dateProvider()
+      try repository.update(entry)
+
+      if retryable {
+        // No queue configured — preserve legacy behaviour: keep entry locally
+        // without throwing so the user still sees a success-ish experience.
+        return entry
+      }
+      throw error
+    }
+  }
+
+  /// Classifies an error as retryable (network/server) vs permanent (validation).
+  private func isRetryable(_ error: Error) -> Bool {
+    if let apiError = error as? APIClientError {
+      return apiError.isRetryable
+    }
+    if error is URLError {
+      return true
+    }
+    return false
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalQueue.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalQueue.swift
@@ -56,6 +56,15 @@ protocol JournalQueueProtocol {
 /// ```
 @MainActor
 final class JournalQueue: ObservableObject, JournalQueueProtocol {
+  // MARK: - Published Properties
+
+  /// Count of entries currently in the queue with `pending` status.
+  ///
+  /// Published so SwiftUI views can reactively render an offline indicator
+  /// when entries are waiting to sync. Recomputed after every mutating
+  /// operation (`enqueue`, `markSyncing`, `markSynced`, `markFailed`).
+  @Published private(set) var pendingCount: Int = 0
+
   // MARK: - Private Properties
 
   /// SQLite database pointer.
@@ -102,10 +111,25 @@ final class JournalQueue: ObservableObject, JournalQueueProtocol {
 
     try openDatabase()
     try createTables()
+    refreshPendingCount()
   }
 
   deinit {
     closeDatabase()
+  }
+
+  /// Recomputes `pendingCount` from the database and publishes the new value.
+  ///
+  /// Called internally after every mutating operation. Failures are logged
+  /// but swallowed so observers never see a stale/invalid count propagate
+  /// as a thrown error on the caller.
+  private func refreshPendingCount() {
+    do {
+      let stats = try statistics()
+      pendingCount = stats.pending
+    } catch {
+      print("⚠️ Failed to refresh journal queue pending count: \(error)")
+    }
   }
 
   // MARK: - Public Methods
@@ -160,6 +184,8 @@ final class JournalQueue: ObservableObject, JournalQueueProtocol {
       let message = String(cString: sqlite3_errmsg(db))
       throw JournalQueueError.insertFailed(message)
     }
+
+    refreshPendingCount()
   }
 
   /// Retrieves all pending entries from the queue.
@@ -212,6 +238,7 @@ final class JournalQueue: ObservableObject, JournalQueueProtocol {
   /// - Throws: `JournalQueueError` if entry not found or update fails.
   func markSyncing(id: UUID) throws {
     try updateStatus(id: id, status: .syncing, incrementRetry: false)
+    refreshPendingCount()
   }
 
   /// Marks an entry as successfully synced.
@@ -222,6 +249,7 @@ final class JournalQueue: ObservableObject, JournalQueueProtocol {
   /// - Throws: `JournalQueueError` if entry not found or update fails.
   func markSynced(id: UUID) throws {
     try updateStatus(id: id, status: .synced, incrementRetry: false)
+    refreshPendingCount()
   }
 
   /// Marks an entry as failed to sync.
@@ -233,8 +261,9 @@ final class JournalQueue: ObservableObject, JournalQueueProtocol {
   ///   - id: The entry ID to update.
   ///   - error: The error that caused the failure (for logging).
   /// - Throws: `JournalQueueError` if entry not found or update fails.
-  func markFailed(id: UUID, error: Error) throws {
+  func markFailed(id: UUID, error _: Error) throws {
     try updateStatus(id: id, status: .failed, incrementRetry: true)
+    refreshPendingCount()
   }
 
   /// Removes synced entries older than the specified number of days.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalSyncService.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalSyncService.swift
@@ -170,10 +170,13 @@ final class JournalSyncService: ObservableObject {
             entryType: item.localEntry.entryType
           )
 
-          // Post to backend
+          // Post to backend with idempotency key derived from the entry's
+          // local UUID. Reusing the key across retry attempts lets the
+          // backend deduplicate replayed submissions.
           let _: JournalResponseModel = try await apiClient.post(
             APIPath.journal,
-            body: payload
+            body: payload,
+            headers: [JournalRequestHeader.idempotencyKey: item.localEntry.id.uuidString]
           )
 
           // Mark as synced in queue

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalSyncService.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalSyncService.swift
@@ -138,8 +138,12 @@ final class JournalSyncService: ObservableObject {
       // Fetch pending entries from queue
       let pending = try queue.pendingEntries()
 
-      // Filter out entries that have exceeded max retries
-      let syncableEntries = pending.filter { $0.localEntry.retryCount < maxRetries }
+      // Filter out entries that have exceeded max retries. Use the queue
+      // item's persisted `retryCount`, not `localEntry.retryCount` — the
+      // latter is the JSON snapshot from when the entry was first enqueued
+      // and stays at zero forever, so reading it would silently bypass the
+      // retry cap.
+      let syncableEntries = pending.filter { $0.retryCount < maxRetries }
 
       guard !syncableEntries.isEmpty else {
         syncStatus = .success(syncedCount: 0)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
@@ -62,6 +62,8 @@ final class ContentViewModel: ObservableObject {
     enum Kind: Equatable {
       case success
       case queued(String)
+      case syncing(current: Int, total: Int)
+      case syncSuccess(count: Int)
       case failure(String)
     }
 
@@ -159,6 +161,27 @@ final class ContentViewModel: ObservableObject {
   @MainActor
   func setInitiatedBy(_ value: InitiatedBy) {
     currentInitiatedBy = value
+  }
+
+  /// Updates `journalFeedback` in response to a sync status change.
+  ///
+  /// Translates the service-level `JournalSyncStatus` into a user-facing
+  /// `JournalFeedback` value. Single-entry syncs are skipped because they
+  /// complete faster than an alert can meaningfully render; calling code
+  /// should supply `totalPending` (current queue depth) so the progress
+  /// message maps to "current of total" counts rather than raw percentages.
+  @MainActor
+  func handleSyncStatusChange(_ status: JournalSyncStatus, totalPending: Int) {
+    switch status {
+    case let .syncing(progress):
+      guard totalPending > 1 else { return }
+      let current = min(totalPending, Int((progress * Double(totalPending)).rounded()) + 1)
+      journalFeedback = JournalFeedback(kind: .syncing(current: current, total: totalPending))
+    case let .success(count) where count > 0:
+      journalFeedback = JournalFeedback(kind: .syncSuccess(count: count))
+    case .idle, .success, .error:
+      break
+    }
   }
 
   /// Converts a layer ID to its index in the full layers array.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
@@ -61,6 +61,7 @@ final class ContentViewModel: ObservableObject {
   struct JournalFeedback: Identifiable, Equatable {
     enum Kind: Equatable {
       case success
+      case queued(String)
       case failure(String)
     }
 
@@ -124,6 +125,10 @@ final class ContentViewModel: ObservableObject {
         initiatedBy: initiatedBy
       )
       journalFeedback = JournalFeedback(kind: .success)
+    } catch JournalError.queuedForRetry {
+      journalFeedback = JournalFeedback(
+        kind: .queued("Saved offline. Will sync automatically.")
+      )
     } catch {
       journalFeedback = JournalFeedback(kind: .failure("We couldn't log your entry. Please try again."))
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -160,6 +160,11 @@ struct FlowReviewSheet: View {
         try await flowCoordinator.submit()
         isSubmitting = false
         showingSuccess = true
+      } catch JournalError.queuedForRetry {
+        // Entry is saved locally and will sync automatically once connectivity
+        // is restored. Treat this as a successful submission for UX purposes.
+        isSubmitting = false
+        showingSuccess = true
       } catch {
         isSubmitting = false
         errorMessage = "Failed to submit: \(error.localizedDescription)"

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Menu/MenuView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Menu/MenuView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct MenuView: View {
   let journalClient: JournalClientProtocol
   @ObservedObject var syncSettingsViewModel: SyncSettingsViewModel
+  @ObservedObject var journalQueue: JournalQueue
+  @ObservedObject var syncService: JournalSyncService
+  @ObservedObject var networkMonitor: NetworkMonitor
   @Binding var isPresented: Bool
   @EnvironmentObject private var viewModel: ContentViewModel
   @EnvironmentObject private var flowCoordinator: FlowCoordinator
@@ -37,6 +40,28 @@ struct MenuView: View {
 
       NavigationLink(destination: SyncSettingsView(viewModel: syncSettingsViewModel)) {
         Label("Sync Settings", systemImage: "arrow.triangle.2.circlepath")
+      }
+
+      NavigationLink(destination: SyncStatusView(
+        queue: journalQueue,
+        syncService: syncService,
+        networkMonitor: networkMonitor
+      )) {
+        HStack {
+          Label("Sync Status", systemImage: "icloud.and.arrow.up")
+          Spacer()
+          if journalQueue.pendingCount > 0 {
+            Text("\(journalQueue.pendingCount)")
+              .font(.caption2.monospacedDigit())
+              .foregroundColor(.yellow)
+              .padding(.horizontal, 6)
+              .padding(.vertical, 2)
+              .background(
+                Capsule().fill(Color.yellow.opacity(0.2))
+              )
+              .accessibilityLabel("\(journalQueue.pendingCount) entries waiting to sync")
+          }
+        }
       }
 
       NavigationLink(destination: ConceptExplainerView()) {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/SyncStatusView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/SyncStatusView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+/// Displays queue status, network connectivity, and manual sync controls.
+///
+/// Shown from the main menu whenever users want to inspect or force a
+/// retry of the offline journal queue. Observes `JournalQueue`,
+/// `JournalSyncService`, and `NetworkMonitor` so all rendered state stays
+/// in sync with the underlying services.
+struct SyncStatusView: View {
+  @ObservedObject var queue: JournalQueue
+  @ObservedObject var syncService: JournalSyncService
+  @ObservedObject var networkMonitor: NetworkMonitor
+  @State private var manualSyncError: String?
+
+  var body: some View {
+    List {
+      Section("Network") {
+        HStack {
+          Image(systemName: networkMonitor.isConnected ? "wifi" : "wifi.slash")
+            .foregroundColor(networkMonitor.isConnected ? .green : .red)
+          Text(networkMonitor.isConnected ? "Online" : "Offline")
+          Spacer()
+          Circle()
+            .fill(networkMonitor.isConnected ? Color.green : Color.red)
+            .frame(width: 8, height: 8)
+        }
+      }
+
+      Section("Queue") {
+        HStack {
+          Text("Pending Entries")
+          Spacer()
+          Text("\(queue.pendingCount)")
+            .foregroundColor(.secondary)
+            .monospacedDigit()
+        }
+
+        if case let .syncing(progress) = syncService.syncStatus {
+          HStack(spacing: 8) {
+            ProgressView(value: progress)
+              .progressViewStyle(.linear)
+            Text("\(Int(progress * 100))%")
+              .font(.caption2)
+              .foregroundColor(.secondary)
+              .monospacedDigit()
+          }
+        } else if syncService.isSyncing {
+          HStack {
+            ProgressView()
+            Text("Syncing…")
+          }
+        }
+
+        if queue.pendingCount > 0 {
+          Button("Sync Now") {
+            manualSyncError = nil
+            Task {
+              do {
+                try await syncService.sync()
+              } catch {
+                manualSyncError = error.localizedDescription
+              }
+            }
+          }
+          .disabled(!networkMonitor.isConnected || syncService.isSyncing)
+        }
+      }
+
+      if let manualSyncError {
+        Section("Last Error") {
+          Text(manualSyncError)
+            .font(.caption)
+            .foregroundColor(.red)
+        }
+      } else if case let .success(count) = syncService.syncStatus, count > 0 {
+        Section("Last Sync") {
+          HStack {
+            Image(systemName: "checkmark.circle.fill")
+              .foregroundColor(.green)
+            Text("Synced \(count) entr\(count == 1 ? "y" : "ies")")
+              .font(.caption)
+          }
+        }
+      }
+    }
+    .navigationTitle("Sync Status")
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewModelTests.swift
@@ -161,6 +161,93 @@ struct ContentViewModelTests {
     #expect(emotionsCount > strategiesCount)
   }
 
+  // MARK: - Queue Integration Feedback Tests (#216)
+
+  @Test @MainActor func journalQueuedEntryShowsQueuedFeedback() async {
+    let repository = CatalogRepositoryMock(cached: SampleData.catalog, result: .success(SampleData.catalog))
+    let journal = JournalClientMock()
+    journal.shouldQueue = true
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journal)
+
+    await viewModel.journal(curriculumID: 1)
+
+    switch viewModel.journalFeedback?.kind {
+    case let .queued(message)?:
+      #expect(message.contains("offline"))
+    default:
+      Issue.record("Expected queued feedback, got \(String(describing: viewModel.journalFeedback?.kind))")
+    }
+  }
+
+  @Test @MainActor func syncingStatusUpdatesFeedbackWhenMultiplePending() {
+    let repository = CatalogRepositoryMock(cached: SampleData.catalog, result: .success(SampleData.catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journal)
+
+    viewModel.handleSyncStatusChange(.syncing(progress: 0.25), totalPending: 4)
+
+    switch viewModel.journalFeedback?.kind {
+    case let .syncing(current, total)?:
+      #expect(total == 4)
+      #expect(current == 2) // floor(0.25 * 4) + 1 = 2
+    default:
+      Issue.record("Expected syncing feedback, got \(String(describing: viewModel.journalFeedback?.kind))")
+    }
+  }
+
+  @Test @MainActor func syncingStatusSkippedForSingleEntry() {
+    let repository = CatalogRepositoryMock(cached: SampleData.catalog, result: .success(SampleData.catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journal)
+
+    viewModel.handleSyncStatusChange(.syncing(progress: 0.5), totalPending: 1)
+
+    #expect(viewModel.journalFeedback == nil)
+  }
+
+  @Test @MainActor func syncSuccessUpdatesFeedback() {
+    let repository = CatalogRepositoryMock(cached: SampleData.catalog, result: .success(SampleData.catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journal)
+
+    viewModel.handleSyncStatusChange(.success(syncedCount: 3), totalPending: 0)
+
+    switch viewModel.journalFeedback?.kind {
+    case let .syncSuccess(count)?:
+      #expect(count == 3)
+    default:
+      Issue.record("Expected syncSuccess feedback, got \(String(describing: viewModel.journalFeedback?.kind))")
+    }
+  }
+
+  @Test @MainActor func syncSuccessWithZeroCountDoesNotOverrideFeedback() {
+    let repository = CatalogRepositoryMock(cached: SampleData.catalog, result: .success(SampleData.catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journal)
+
+    // Pre-set a different feedback
+    viewModel.journalFeedback = .init(kind: .success)
+    viewModel.handleSyncStatusChange(.success(syncedCount: 0), totalPending: 0)
+
+    // Existing feedback should remain unchanged (no-op for zero-count success)
+    #expect(viewModel.journalFeedback?.kind == .success)
+  }
+
+  @Test @MainActor func idleAndErrorStatusDoNotUpdateFeedback() {
+    let repository = CatalogRepositoryMock(cached: SampleData.catalog, result: .success(SampleData.catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journal)
+
+    viewModel.journalFeedback = .init(kind: .success)
+
+    viewModel.handleSyncStatusChange(.idle, totalPending: 0)
+    #expect(viewModel.journalFeedback?.kind == .success)
+
+    enum DummyError: Error { case whatever }
+    viewModel.handleSyncStatusChange(.error(DummyError.whatever), totalPending: 0)
+    #expect(viewModel.journalFeedback?.kind == .success)
+  }
+
   @Test func filteredLayersWhenLayersEmptyReturnsEmpty() {
     let repository = CatalogRepositoryMock(result: .success(SampleData.catalog))
     let journal = JournalClientMock()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalClientTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalClientTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import WavelengthWatch_Watch_App
 
 /// Comprehensive tests for JournalClient local-first behavior and sync scenarios.
+@MainActor
 struct JournalClientLocalFirstTests {
   // MARK: - Local Save Tests
 
@@ -251,6 +252,335 @@ struct JournalClientLocalFirstTests {
     #expect(entry.entryType == .rest)
     #expect(entry.syncStatus == .failed)
     #expect(try repository.count() == 1)
+  }
+}
+
+/// Tests that verify JournalClient's integration with the offline journal
+/// queue when a queue is provided — the #215 integration point.
+@MainActor
+struct JournalClientQueueIntegrationTests {
+  // MARK: - Retryable Errors Queue
+
+  @Test func submit_retryableTransportError_enqueuesEntry() async throws {
+    let repository = InMemoryJournalRepository()
+    let queue = InMemoryJournalQueueSpy()
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let apiClient = StubAPIClientSpy(postResult: .failure(APIClientError.transport(URLError(.notConnectedToInternet))))
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings,
+      queue: queue
+    )
+
+    var queuedID: UUID?
+    do {
+      _ = try await client.submit(
+        curriculumID: 42,
+        secondaryCurriculumID: nil,
+        strategyID: nil,
+        initiatedBy: .self_initiated
+      )
+      Issue.record("Expected queuedForRetry error to be thrown")
+    } catch let JournalError.queuedForRetry(entryID) {
+      queuedID = entryID
+    }
+
+    #expect(queuedID != nil)
+    #expect(queue.enqueuedEntries.count == 1)
+    #expect(queue.enqueuedEntries.first?.id == queuedID)
+    // Entry is still saved locally.
+    #expect(try repository.count() == 1)
+    // Repository entry remains pending so sync service can retry.
+    #expect(try repository.fetch(id: queuedID!)?.syncStatus == .pending)
+  }
+
+  @Test func submit_retryableServerError_enqueuesEntry() async throws {
+    let repository = InMemoryJournalRepository()
+    let queue = InMemoryJournalQueueSpy()
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let apiClient = StubAPIClientSpy(postResult: .failure(APIClientError.badResponse(503)))
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings,
+      queue: queue
+    )
+
+    await #expect(throws: JournalError.self) {
+      _ = try await client.submit(
+        curriculumID: 42,
+        secondaryCurriculumID: nil,
+        strategyID: nil,
+        initiatedBy: .self_initiated
+      )
+    }
+    #expect(queue.enqueuedEntries.count == 1)
+  }
+
+  // MARK: - Non-Retryable Errors
+
+  @Test func submit_nonRetryableValidationError_doesNotQueue() async throws {
+    let repository = InMemoryJournalRepository()
+    let queue = InMemoryJournalQueueSpy()
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let apiClient = StubAPIClientSpy(postResult: .failure(APIClientError.badResponse(422)))
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings,
+      queue: queue
+    )
+
+    await #expect(throws: APIClientError.self) {
+      _ = try await client.submit(
+        curriculumID: 42,
+        secondaryCurriculumID: nil,
+        strategyID: nil,
+        initiatedBy: .self_initiated
+      )
+    }
+
+    #expect(queue.enqueuedEntries.isEmpty)
+    // Entry was saved locally but marked failed.
+    #expect(try repository.count() == 1)
+    let entries = try repository.fetchAll()
+    #expect(entries.first?.syncStatus == .failed)
+  }
+
+  // MARK: - Successful Sync Path
+
+  @Test func submit_successfulSync_doesNotQueue() async throws {
+    let repository = InMemoryJournalRepository()
+    let queue = InMemoryJournalQueueSpy()
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let apiClient = SuccessfulAPIClientSpy()
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings,
+      queue: queue
+    )
+
+    let entry = try await client.submit(
+      curriculumID: 42,
+      secondaryCurriculumID: nil,
+      strategyID: nil,
+      initiatedBy: .self_initiated
+    )
+
+    #expect(entry.syncStatus == .synced)
+    #expect(queue.enqueuedEntries.isEmpty)
+  }
+
+  // MARK: - Idempotency Key
+
+  @Test func submit_sendsIdempotencyKeyHeader() async throws {
+    let repository = InMemoryJournalRepository()
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let apiClient = HeaderCapturingAPIClientSpy()
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings
+    )
+
+    let entry = try await client.submit(
+      curriculumID: 42,
+      secondaryCurriculumID: nil,
+      strategyID: nil,
+      initiatedBy: .self_initiated
+    )
+
+    let headers = try #require(apiClient.capturedHeaders)
+    let key = try #require(headers[JournalRequestHeader.idempotencyKey])
+    #expect(key == entry.id.uuidString)
+    // Key must be a valid UUID per backend validation rules.
+    #expect(UUID(uuidString: key) != nil)
+  }
+
+  @Test func submit_idempotencyKey_matchesLocalEntryID() async throws {
+    let repository = InMemoryJournalRepository()
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let apiClient = HeaderCapturingAPIClientSpy()
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings
+    )
+
+    let entry = try await client.submit(
+      curriculumID: 42,
+      secondaryCurriculumID: nil,
+      strategyID: nil,
+      initiatedBy: .self_initiated
+    )
+
+    // The key is derived deterministically from the local entry ID, so retry
+    // attempts from the sync service can reuse it and trigger backend dedup.
+    #expect(apiClient.capturedHeaders?[JournalRequestHeader.idempotencyKey] == entry.id.uuidString)
+  }
+
+  // MARK: - REST Entries
+
+  @Test func submitRestPeriod_retryableError_enqueuesRestEntry() async throws {
+    let repository = InMemoryJournalRepository()
+    let queue = InMemoryJournalQueueSpy()
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let apiClient = StubAPIClientSpy(postResult: .failure(APIClientError.badResponse(502)))
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings,
+      queue: queue
+    )
+
+    await #expect(throws: JournalError.self) {
+      _ = try await client.submitRestPeriod(initiatedBy: .self_initiated)
+    }
+
+    #expect(queue.enqueuedEntries.count == 1)
+    #expect(queue.enqueuedEntries.first?.entryType == .rest)
+  }
+}
+
+/// Tests for `APIClientError.isRetryable` classification.
+struct APIClientErrorRetryableTests {
+  @Test func transportErrorIsRetryable() {
+    let error = APIClientError.transport(URLError(.timedOut))
+    #expect(error.isRetryable)
+  }
+
+  @Test func invalidURLIsNotRetryable() {
+    let error = APIClientError.invalidURL("bad")
+    #expect(!error.isRetryable)
+  }
+
+  @Test func serverError5xxIsRetryable() {
+    #expect(APIClientError.badResponse(500).isRetryable)
+    #expect(APIClientError.badResponse(502).isRetryable)
+    #expect(APIClientError.badResponse(503).isRetryable)
+  }
+
+  @Test func timeoutAndThrottleAreRetryable() {
+    #expect(APIClientError.badResponse(408).isRetryable)
+    #expect(APIClientError.badResponse(429).isRetryable)
+  }
+
+  @Test func clientError4xxIsNotRetryable() {
+    #expect(!APIClientError.badResponse(400).isRetryable)
+    #expect(!APIClientError.badResponse(401).isRetryable)
+    #expect(!APIClientError.badResponse(404).isRetryable)
+    #expect(!APIClientError.badResponse(422).isRetryable)
+  }
+}
+
+// MARK: - Queue Integration Test Doubles
+
+/// In-memory spy that records enqueued entries without using SQLite.
+/// Conforms to `JournalQueueProtocol` so it can be injected into JournalClient.
+final class InMemoryJournalQueueSpy: JournalQueueProtocol {
+  var enqueuedEntries: [LocalJournalEntry] = []
+  var shouldThrowOnEnqueue = false
+
+  func enqueue(_ entry: LocalJournalEntry) throws {
+    if shouldThrowOnEnqueue {
+      throw JournalQueueError.insertFailed("spy forced failure")
+    }
+    enqueuedEntries.append(entry)
+  }
+
+  func pendingEntries() throws -> [JournalQueueItem] {
+    enqueuedEntries.map { JournalQueueItem(entry: $0) }
+  }
+
+  func fetch(id: UUID) throws -> JournalQueueItem? {
+    enqueuedEntries.first(where: { $0.id == id }).map { JournalQueueItem(entry: $0) }
+  }
+
+  func markSyncing(id _: UUID) throws {}
+  func markSynced(id _: UUID) throws {}
+  func markFailed(id _: UUID, error _: Error) throws {}
+  func cleanupSynced(olderThan _: Int) throws {}
+
+  func statistics() throws -> QueueStatistics {
+    QueueStatistics(
+      pending: enqueuedEntries.count,
+      syncing: 0,
+      synced: 0,
+      failed: 0
+    )
+  }
+}
+
+/// API client that returns a fixed result (success or specific error) for
+/// post calls. Used to exercise retryable vs. non-retryable classification.
+final class StubAPIClientSpy: APIClientProtocol {
+  private let postResult: Result<JournalResponseModel, Error>
+
+  init(postResult: Result<JournalResponseModel, Error>) {
+    self.postResult = postResult
+  }
+
+  func get<T: Decodable>(_: String) async throws -> T {
+    throw URLError(.badURL)
+  }
+
+  func post<Response: Decodable>(_: String, body _: some Encodable) async throws -> Response {
+    switch postResult {
+    case let .success(response):
+      return response as! Response
+    case let .failure(error):
+      throw error
+    }
+  }
+}
+
+/// API client that captures the headers passed to post so tests can assert
+/// that the idempotency key header is sent with journal submissions.
+final class HeaderCapturingAPIClientSpy: APIClientProtocol {
+  var capturedHeaders: [String: String]?
+
+  func get<T: Decodable>(_: String) async throws -> T {
+    throw URLError(.badURL)
+  }
+
+  func post<Response: Decodable>(_: String, body _: some Encodable) async throws -> Response {
+    // Should not be called — the 3-argument overload below handles requests
+    // coming from JournalClient. Keep this here to satisfy the protocol.
+    let response = JournalResponseModel(
+      id: 999,
+      curriculumID: 42,
+      secondaryCurriculumID: nil,
+      strategyID: nil,
+      initiatedBy: .self_initiated,
+      entryType: .emotion
+    )
+    return response as! Response
+  }
+
+  func post<Response: Decodable>(
+    _: String,
+    body _: some Encodable,
+    headers: [String: String]?
+  ) async throws -> Response {
+    capturedHeaders = headers
+    let response = JournalResponseModel(
+      id: 999,
+      curriculumID: 42,
+      secondaryCurriculumID: nil,
+      strategyID: nil,
+      initiatedBy: .self_initiated,
+      entryType: .emotion
+    )
+    return response as! Response
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalClientTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalClientTests.swift
@@ -536,7 +536,10 @@ final class StubAPIClientSpy: APIClientProtocol {
   func post<Response: Decodable>(_: String, body _: some Encodable) async throws -> Response {
     switch postResult {
     case let .success(response):
-      return response as! Response
+      guard let typed = response as? Response else {
+        throw URLError(.badServerResponse)
+      }
+      return typed
     case let .failure(error):
       throw error
     }
@@ -563,7 +566,10 @@ final class HeaderCapturingAPIClientSpy: APIClientProtocol {
       initiatedBy: .self_initiated,
       entryType: .emotion
     )
-    return response as! Response
+    guard let typed = response as? Response else {
+      throw URLError(.badServerResponse)
+    }
+    return typed
   }
 
   func post<Response: Decodable>(
@@ -580,7 +586,10 @@ final class HeaderCapturingAPIClientSpy: APIClientProtocol {
       initiatedBy: .self_initiated,
       entryType: .emotion
     )
-    return response as! Response
+    guard let typed = response as? Response else {
+      throw URLError(.badServerResponse)
+    }
+    return typed
   }
 }
 
@@ -601,7 +610,10 @@ final class SuccessfulAPIClientSpy: APIClientProtocol {
       initiatedBy: .self_initiated,
       entryType: .emotion
     )
-    return response as! T
+    guard let typed = response as? T else {
+      throw URLError(.badServerResponse)
+    }
+    return typed
   }
 }
 
@@ -634,7 +646,10 @@ final class TrackingAPIClientSpy: APIClientProtocol {
       initiatedBy: .self_initiated,
       entryType: .emotion
     )
-    return response as! T
+    guard let typed = response as? T else {
+      throw URLError(.badServerResponse)
+    }
+    return typed
   }
 }
 
@@ -656,7 +671,10 @@ final class RestAPIClientSpy: APIClientProtocol {
       initiatedBy: .self_initiated,
       entryType: .rest
     )
-    return response as! T
+    guard let typed = response as? T else {
+      throw URLError(.badServerResponse)
+    }
+    return typed
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalClientTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalClientTests.swift
@@ -287,13 +287,13 @@ struct JournalClientQueueIntegrationTests {
       queuedID = entryID
     }
 
-    #expect(queuedID != nil)
+    let unwrappedID = try #require(queuedID)
     #expect(queue.enqueuedEntries.count == 1)
-    #expect(queue.enqueuedEntries.first?.id == queuedID)
+    #expect(queue.enqueuedEntries.first?.id == unwrappedID)
     // Entry is still saved locally.
-    #expect(try repository.count() == 1)
+    try #expect(repository.count() == 1)
     // Repository entry remains pending so sync service can retry.
-    #expect(try repository.fetch(id: queuedID!)?.syncStatus == .pending)
+    try #expect(repository.fetch(id: unwrappedID)?.syncStatus == .pending)
   }
 
   @Test func submit_retryableServerError_enqueuesEntry() async throws {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalQueueTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalQueueTests.swift
@@ -491,4 +491,90 @@ struct JournalQueueTests {
       try queue.markFailed(id: nonExistentID, error: TestError())
     }
   }
+
+  // MARK: - Published pendingCount Tests (#216)
+
+  @Test @MainActor func pendingCountStartsAtZeroForEmptyQueue() throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+
+    #expect(queue.pendingCount == 0)
+  }
+
+  @Test @MainActor func pendingCountIncrementsOnEnqueue() throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+
+    try queue.enqueue(sampleEntry(curriculumID: 1))
+    #expect(queue.pendingCount == 1)
+
+    try queue.enqueue(sampleEntry(curriculumID: 2))
+    #expect(queue.pendingCount == 2)
+
+    try queue.enqueue(sampleEntry(curriculumID: 3))
+    #expect(queue.pendingCount == 3)
+  }
+
+  @Test @MainActor func pendingCountDecrementsWhenMarkedSyncing() throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let entry = sampleEntry()
+    try queue.enqueue(entry)
+    #expect(queue.pendingCount == 1)
+
+    try queue.markSyncing(id: entry.id)
+    #expect(queue.pendingCount == 0)
+  }
+
+  @Test @MainActor func pendingCountRemainsZeroAfterMarkSynced() throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let entry = sampleEntry()
+    try queue.enqueue(entry)
+    try queue.markSyncing(id: entry.id)
+    try queue.markSynced(id: entry.id)
+
+    #expect(queue.pendingCount == 0)
+  }
+
+  @Test @MainActor func pendingCountReflectsFailedEntriesAsNonPending() throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let entry = sampleEntry()
+    try queue.enqueue(entry)
+    try queue.markSyncing(id: entry.id)
+
+    struct TestError: Error {}
+    try queue.markFailed(id: entry.id, error: TestError())
+
+    // Failed entries are tracked separately; pendingCount only counts `.pending` rows.
+    #expect(queue.pendingCount == 0)
+  }
+
+  @Test @MainActor func pendingCountHydratedFromDiskOnInit() throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    // First instance: enqueue two entries, close
+    do {
+      let queue = try JournalQueue(databasePath: dbPath)
+      try queue.enqueue(sampleEntry(curriculumID: 1))
+      try queue.enqueue(sampleEntry(curriculumID: 2))
+      #expect(queue.pendingCount == 2)
+    }
+
+    // Second instance: pendingCount should be hydrated from disk
+    let queue = try JournalQueue(databasePath: dbPath)
+    #expect(queue.pendingCount == 2)
+  }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalSyncServiceTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalSyncServiceTests.swift
@@ -361,12 +361,32 @@ final class MockJournalQueue: JournalQueueProtocol {
 
   func pendingEntries() throws -> [JournalQueueItem] {
     pendingItems.map { entry in
-      JournalQueueItem(entry: entry)
+      // Mirror the entry's retryCount onto the queue item so tests can
+      // exercise JournalSyncService's maxRetries filter, which reads
+      // `JournalQueueItem.retryCount` (the SQLite-persisted counter), not
+      // the JSON-snapshot copy on `localEntry`.
+      JournalQueueItem(
+        id: entry.id,
+        localEntry: entry,
+        status: .pending,
+        retryCount: entry.retryCount,
+        lastAttempt: nil,
+        createdAt: Date()
+      )
     }
   }
 
   func fetch(id: UUID) throws -> JournalQueueItem? {
-    pendingItems.first(where: { $0.id == id }).map { JournalQueueItem(entry: $0) }
+    pendingItems.first(where: { $0.id == id }).map { entry in
+      JournalQueueItem(
+        id: entry.id,
+        localEntry: entry,
+        status: .pending,
+        retryCount: entry.retryCount,
+        lastAttempt: nil,
+        createdAt: Date()
+      )
+    }
   }
 
   func markSyncing(id: UUID) throws {
@@ -426,7 +446,10 @@ final class MockAPIClient: APIClientProtocol {
       initiatedBy: .self_initiated,
       entryType: .emotion
     )
-    return response as! Response
+    guard let typed = response as? Response else {
+      throw URLError(.badServerResponse)
+    }
+    return typed
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/OfflineQueueIntegrationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/OfflineQueueIntegrationTests.swift
@@ -1,0 +1,608 @@
+import Combine
+import Foundation
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// End-to-end integration tests for the offline journal queue (#218).
+///
+/// These tests wire together `JournalClient`, the SQLite-backed
+/// `JournalQueue`, `JournalSyncService`, and a controllable
+/// `NetworkMonitor` / `APIClient` so we can exercise realistic offline
+/// scenarios: queueing while disconnected, auto-sync on reconnect,
+/// idempotency key reuse across retries, FIFO ordering, validation-error
+/// disposition, persistence across app termination, and concurrent-sync
+/// serialization.
+///
+/// All SQLite work happens in a per-test temporary database so the suite
+/// runs in parallel without interference.
+@MainActor
+struct OfflineQueueIntegrationTests {
+  // MARK: - Test Helpers
+
+  private func temporaryDatabasePath() -> String {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("offline_queue_\(UUID().uuidString).sqlite")
+      .path
+  }
+
+  /// Convenience builder that wires a JournalClient with the injected
+  /// queue and api client, using an in-memory repository + mock sync
+  /// settings so tests focus on queue behaviour rather than repo state.
+  private func makeClient(
+    queue: JournalQueueProtocol,
+    apiClient: APIClientProtocol,
+    repository: JournalRepositoryProtocol = InMemoryJournalRepository()
+  ) -> (JournalClient, SyncSettings) {
+    let syncSettings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    syncSettings.cloudSyncEnabled = true
+    let client = JournalClient(
+      apiClient: apiClient,
+      repository: repository,
+      syncSettings: syncSettings,
+      queue: queue
+    )
+    return (client, syncSettings)
+  }
+
+  // MARK: - Basic Flow
+
+  @Test func offlineSubmissionQueuesEntry() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient()
+    api.shouldFail = true
+    api.failWith = APIClientError.transport(URLError(.notConnectedToInternet))
+    let (client, _) = makeClient(queue: queue, apiClient: api)
+
+    var queuedID: UUID?
+    do {
+      _ = try await client.submit(
+        curriculumID: 42,
+        secondaryCurriculumID: nil,
+        strategyID: nil,
+        initiatedBy: .self_initiated
+      )
+      Issue.record("Expected queuedForRetry error")
+    } catch let JournalError.queuedForRetry(entryID) {
+      queuedID = entryID
+    }
+
+    #expect(queuedID != nil)
+    #expect(queue.pendingCount == 1)
+    let pending = try queue.pendingEntries()
+    #expect(pending.count == 1)
+    #expect(pending.first?.localEntry.id == queuedID)
+  }
+
+  @Test func onlineSubmissionDoesNotQueue() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient() // defaults to success
+    let (client, _) = makeClient(queue: queue, apiClient: api)
+
+    let entry = try await client.submit(
+      curriculumID: 42,
+      secondaryCurriculumID: nil,
+      strategyID: nil,
+      initiatedBy: .self_initiated
+    )
+
+    #expect(entry.syncStatus == .synced)
+    #expect(queue.pendingCount == 0)
+    #expect(api.postCallCount == 1)
+  }
+
+  @Test func networkReconnectTriggersDrain() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient()
+    let monitor = MockNetworkMonitor(isConnected: false)
+    let (client, _) = makeClient(queue: queue, apiClient: api)
+
+    // Offline: submission throws queuedForRetry and entry lands in queue.
+    api.shouldFail = true
+    api.failWith = APIClientError.transport(URLError(.notConnectedToInternet))
+
+    do {
+      _ = try await client.submit(
+        curriculumID: 7,
+        secondaryCurriculumID: nil,
+        strategyID: nil,
+        initiatedBy: .self_initiated
+      )
+    } catch JournalError.queuedForRetry {
+      // Expected
+    }
+
+    #expect(queue.pendingCount == 1)
+
+    // Network reconnects and API now succeeds; sync drains the queue.
+    api.shouldFail = false
+    monitor.simulateConnection()
+
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+    try await sync.sync()
+
+    #expect(queue.pendingCount == 0)
+    let stats = try queue.statistics()
+    #expect(stats.synced == 1)
+  }
+
+  // MARK: - Idempotency
+
+  @Test func multipleOfflineEntriesUseDistinctIdempotencyKeys() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient()
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let (client, _) = makeClient(queue: queue, apiClient: api)
+
+    // Queue three entries while offline.
+    api.shouldFail = true
+    api.failWith = APIClientError.transport(URLError(.notConnectedToInternet))
+    for curriculum in 1 ... 3 {
+      do {
+        _ = try await client.submit(
+          curriculumID: curriculum,
+          secondaryCurriculumID: nil,
+          strategyID: nil,
+          initiatedBy: .self_initiated
+        )
+      } catch JournalError.queuedForRetry {
+        // Expected
+      }
+    }
+
+    #expect(queue.pendingCount == 3)
+
+    // Reconnect and drain; capture idempotency keys observed by the API.
+    api.shouldFail = false
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+    try await sync.sync()
+
+    let keys = api.capturedIdempotencyKeys
+    #expect(keys.count == 3)
+    #expect(Set(keys).count == 3) // All unique
+    for key in keys {
+      #expect(UUID(uuidString: key) != nil)
+    }
+  }
+
+  @Test func retryReusesSameIdempotencyKeyAsInitialSubmit() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient()
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let (client, _) = makeClient(queue: queue, apiClient: api)
+
+    // Offline submission fails, key captured from the initial attempt.
+    api.shouldFail = true
+    api.failWith = APIClientError.badResponse(503)
+    var queuedID: UUID?
+    do {
+      _ = try await client.submit(
+        curriculumID: 42,
+        secondaryCurriculumID: nil,
+        strategyID: nil,
+        initiatedBy: .self_initiated
+      )
+    } catch let JournalError.queuedForRetry(entryID) {
+      queuedID = entryID
+    }
+
+    let initialKey = try #require(api.capturedIdempotencyKeys.first)
+    #expect(initialKey == queuedID?.uuidString)
+
+    // Now retry via sync service — reusing the SAME idempotency key lets
+    // the backend deduplicate a replayed successful submission.
+    api.shouldFail = false
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+    try await sync.sync()
+
+    #expect(api.capturedIdempotencyKeys.count == 2)
+    #expect(api.capturedIdempotencyKeys.last == initialKey)
+  }
+
+  // MARK: - Ordering
+
+  @Test func queueSyncPreservesFIFOOrder() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient()
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let (client, _) = makeClient(queue: queue, apiClient: api)
+
+    // Enqueue 5 entries offline with distinct curriculum IDs.
+    api.shouldFail = true
+    api.failWith = APIClientError.transport(URLError(.timedOut))
+    for curriculum in 1 ... 5 {
+      do {
+        _ = try await client.submit(
+          curriculumID: curriculum,
+          secondaryCurriculumID: nil,
+          strategyID: nil,
+          initiatedBy: .self_initiated
+        )
+      } catch JournalError.queuedForRetry {
+        // Expected
+      }
+    }
+
+    // Drain and assert curriculum IDs landed at the backend in order 1..5.
+    api.shouldFail = false
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+    try await sync.sync()
+
+    #expect(api.receivedCurriculumIDs == [1, 2, 3, 4, 5])
+  }
+
+  // MARK: - Error Handling
+
+  @Test func validationError400DoesNotEnqueue() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient()
+    api.shouldFail = true
+    api.failWith = APIClientError.badResponse(422)
+    let (client, _) = makeClient(queue: queue, apiClient: api)
+
+    await #expect(throws: APIClientError.self) {
+      _ = try await client.submit(
+        curriculumID: -1,
+        secondaryCurriculumID: nil,
+        strategyID: nil,
+        initiatedBy: .self_initiated
+      )
+    }
+
+    #expect(queue.pendingCount == 0)
+    let stats = try queue.statistics()
+    #expect(stats.total == 0)
+  }
+
+  @Test func syncServerError500KeepsEntryInQueueAndIncrementsRetryCount() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let entry = LocalJournalEntry(
+      createdAt: Date(),
+      userID: 123,
+      curriculumID: 1,
+      initiatedBy: .self_initiated,
+      entryType: .emotion
+    )
+    try queue.enqueue(entry)
+    #expect(queue.pendingCount == 1)
+
+    let api = ToggleableAPIClient()
+    api.shouldFail = true
+    api.failWith = APIClientError.badResponse(500)
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+
+    // First retry: record failure + retry count increments to 1.
+    await #expect(throws: APIClientError.self) {
+      try await sync.sync()
+    }
+    var stats = try queue.statistics()
+    #expect(stats.failed == 1)
+    #expect(try queue.fetch(id: entry.id)?.retryCount == 1)
+
+    // pendingCount is zero because the entry is now `failed` (not `pending`).
+    #expect(queue.pendingCount == 0)
+
+    // Entry is intact, not dropped.
+    #expect(try queue.fetch(id: entry.id) != nil)
+    stats = try queue.statistics()
+    #expect(stats.total == 1)
+  }
+
+  @Test func failedEntriesAreNotAutoRetriedOnNextSync() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let entry = LocalJournalEntry(
+      createdAt: Date(),
+      userID: 123,
+      curriculumID: 1,
+      initiatedBy: .self_initiated,
+      entryType: .emotion
+    )
+    try queue.enqueue(entry)
+
+    let api = ToggleableAPIClient()
+    api.shouldFail = true
+    api.failWith = APIClientError.badResponse(500)
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+
+    // First sync fails: entry transitions pending → failed, retryCount=1.
+    await #expect(throws: APIClientError.self) {
+      try await sync.sync()
+    }
+    #expect(try queue.fetch(id: entry.id)?.retryCount == 1)
+    #expect(try queue.fetch(id: entry.id)?.status == .failed)
+
+    // Second sync with working API: failed entries are NOT reprocessed
+    // because pendingEntries() only returns entries with status=.pending.
+    // The sync completes without touching the network.
+    api.shouldFail = false
+    try await sync.sync()
+
+    #expect(api.postCallCount == 1) // First POST only; no re-attempt.
+    #expect(try queue.fetch(id: entry.id)?.retryCount == 1) // Unchanged.
+    let stats = try queue.statistics()
+    #expect(stats.failed == 1)
+    #expect(stats.synced == 0)
+  }
+
+  // MARK: - App Lifecycle
+
+  @Test func queuePersistsAcrossClientRestart() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    // First "app run": queue two entries offline, then drop everything.
+    do {
+      let queue = try JournalQueue(databasePath: dbPath)
+      let api = ToggleableAPIClient()
+      api.shouldFail = true
+      api.failWith = APIClientError.transport(URLError(.notConnectedToInternet))
+      let (client, _) = makeClient(queue: queue, apiClient: api)
+
+      for curriculum in [10, 20] {
+        do {
+          _ = try await client.submit(
+            curriculumID: curriculum,
+            secondaryCurriculumID: nil,
+            strategyID: nil,
+            initiatedBy: .self_initiated
+          )
+        } catch JournalError.queuedForRetry {
+          // Expected
+        }
+      }
+      #expect(queue.pendingCount == 2)
+    }
+
+    // Second "app run": re-open the same SQLite file.
+    let restartedQueue = try JournalQueue(databasePath: dbPath)
+    #expect(restartedQueue.pendingCount == 2)
+    let pending = try restartedQueue.pendingEntries()
+    let curriculumIDs = pending.compactMap { $0.localEntry.curriculumID }.sorted()
+    #expect(curriculumIDs == [10, 20])
+  }
+
+  @Test func partialSyncResumesAfterRestart() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    // First app run: queue 3 entries, sync only the first (simulated
+    // by manually walking the queue), then drop state.
+    let firstID: UUID
+    let remainingIDs: [UUID]
+    do {
+      let queue = try JournalQueue(databasePath: dbPath)
+      var ids: [UUID] = []
+      for curriculum in 1 ... 3 {
+        let entry = LocalJournalEntry(
+          createdAt: Date(),
+          userID: 123,
+          curriculumID: curriculum,
+          initiatedBy: .self_initiated,
+          entryType: .emotion
+        )
+        try queue.enqueue(entry)
+        ids.append(entry.id)
+      }
+      firstID = ids[0]
+      remainingIDs = Array(ids.dropFirst())
+
+      // Sync first entry only (simulate interruption after one success).
+      try queue.markSyncing(id: firstID)
+      try queue.markSynced(id: firstID)
+      #expect(queue.pendingCount == 2)
+    }
+
+    // Second app run: the two unsynced entries should still be pending.
+    let restartedQueue = try JournalQueue(databasePath: dbPath)
+    #expect(restartedQueue.pendingCount == 2)
+    let pending = try restartedQueue.pendingEntries()
+    let pendingIDs = Set(pending.map { $0.localEntry.id })
+    #expect(pendingIDs == Set(remainingIDs))
+
+    // Sync drains the remaining entries.
+    let api = ToggleableAPIClient()
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let sync = JournalSyncService(
+      queue: restartedQueue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+    try await sync.sync()
+
+    #expect(restartedQueue.pendingCount == 0)
+    #expect(api.postCallCount == 2)
+  }
+
+  // MARK: - Edge Cases
+
+  @Test func emptyQueueSyncIsANoOp() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let api = ToggleableAPIClient()
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+
+    try await sync.sync()
+
+    #expect(api.postCallCount == 0)
+    #expect(sync.syncStatus == .success(syncedCount: 0))
+  }
+
+  @Test func offlineSyncCallIsANoOp() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    let entry = LocalJournalEntry(
+      createdAt: Date(),
+      userID: 123,
+      curriculumID: 1,
+      initiatedBy: .self_initiated,
+      entryType: .emotion
+    )
+    try queue.enqueue(entry)
+
+    let api = ToggleableAPIClient()
+    let monitor = MockNetworkMonitor(isConnected: false)
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+
+    try await sync.sync()
+
+    // Network is offline: the service bails before touching the API and
+    // leaves the entry untouched for the next attempt.
+    #expect(api.postCallCount == 0)
+    #expect(queue.pendingCount == 1)
+  }
+
+  @Test func concurrentSyncCallsAreSerialized() async throws {
+    let dbPath = temporaryDatabasePath()
+    defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+    let queue = try JournalQueue(databasePath: dbPath)
+    for curriculum in 1 ... 3 {
+      let entry = LocalJournalEntry(
+        createdAt: Date(),
+        userID: 123,
+        curriculumID: curriculum,
+        initiatedBy: .self_initiated,
+        entryType: .emotion
+      )
+      try queue.enqueue(entry)
+    }
+
+    let api = ToggleableAPIClient()
+    api.artificialDelayNanos = 50_000_000 // 50ms per call
+    let monitor = MockNetworkMonitor(isConnected: true)
+    let sync = JournalSyncService(
+      queue: queue,
+      apiClient: api,
+      networkMonitor: monitor
+    )
+
+    // Start two concurrent syncs; the second should short-circuit because
+    // `isSyncing` is already true on the first.
+    async let first: Void = sync.sync()
+    async let second: Void = sync.sync()
+    _ = try await (first, second)
+
+    // Only one sync run actually processed entries. Exactly 3 POSTs are
+    // expected (not 6) — the second call returned early.
+    #expect(api.postCallCount == 3)
+    #expect(queue.pendingCount == 0)
+  }
+}
+
+// MARK: - Integration Test Doubles
+
+/// Flexible API client for integration tests: toggle success/failure, swap
+/// which error is raised, capture idempotency keys and curriculum IDs from
+/// each POST, and optionally sleep to simulate latency.
+@MainActor
+final class ToggleableAPIClient: APIClientProtocol {
+  var shouldFail: Bool = false
+  var failWith: Error = URLError(.notConnectedToInternet)
+  var artificialDelayNanos: UInt64 = 0
+
+  private(set) var postCallCount: Int = 0
+  private(set) var capturedIdempotencyKeys: [String] = []
+  private(set) var receivedCurriculumIDs: [Int] = []
+
+  func get<T: Decodable>(_: String) async throws -> T {
+    throw URLError(.badURL)
+  }
+
+  func post<Response: Decodable>(_: String, body _: some Encodable) async throws -> Response {
+    throw URLError(.badURL) // Tests always hit the 3-arg overload below.
+  }
+
+  func post<Response: Decodable>(
+    _: String,
+    body: some Encodable,
+    headers: [String: String]?
+  ) async throws -> Response {
+    if artificialDelayNanos > 0 {
+      try await Task.sleep(nanoseconds: artificialDelayNanos)
+    }
+    postCallCount += 1
+    if let key = headers?[JournalRequestHeader.idempotencyKey] {
+      capturedIdempotencyKeys.append(key)
+    }
+    if let payload = body as? JournalPayload, let curriculumID = payload.curriculumID {
+      receivedCurriculumIDs.append(curriculumID)
+    }
+    if shouldFail {
+      throw failWith
+    }
+    let response = JournalResponseModel(
+      id: 999,
+      curriculumID: (body as? JournalPayload)?.curriculumID,
+      secondaryCurriculumID: (body as? JournalPayload)?.secondaryCurriculumID,
+      strategyID: (body as? JournalPayload)?.strategyID,
+      initiatedBy: .self_initiated,
+      entryType: .emotion
+    )
+    return response as! Response
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/OfflineQueueIntegrationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/OfflineQueueIntegrationTests.swift
@@ -603,6 +603,9 @@ final class ToggleableAPIClient: APIClientProtocol {
       initiatedBy: .self_initiated,
       entryType: .emotion
     )
-    return response as! Response
+    guard let typed = response as? Response else {
+      throw URLError(.badServerResponse)
+    }
+    return typed
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/OfflineQueueIntegrationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/OfflineQueueIntegrationTests.swift
@@ -409,7 +409,7 @@ struct OfflineQueueIntegrationTests {
     let restartedQueue = try JournalQueue(databasePath: dbPath)
     #expect(restartedQueue.pendingCount == 2)
     let pending = try restartedQueue.pendingEntries()
-    let curriculumIDs = pending.compactMap { $0.localEntry.curriculumID }.sorted()
+    let curriculumIDs = pending.compactMap(\.localEntry.curriculumID).sorted()
     #expect(curriculumIDs == [10, 20])
   }
 
@@ -448,7 +448,7 @@ struct OfflineQueueIntegrationTests {
     let restartedQueue = try JournalQueue(databasePath: dbPath)
     #expect(restartedQueue.pendingCount == 2)
     let pending = try restartedQueue.pendingEntries()
-    let pendingIDs = Set(pending.map { $0.localEntry.id })
+    let pendingIDs = Set(pending.map(\.localEntry.id))
     #expect(pendingIDs == Set(remainingIDs))
 
     // Sync drains the remaining entries.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/TestUtilities.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/TestUtilities.swift
@@ -154,6 +154,9 @@ final class JournalClientMock: JournalClientProtocol {
   var restSubmissions: [InitiatedBy] = []
   var submittedInitiatedBy: InitiatedBy?
   var shouldFail = false
+  /// When true, submit() throws `JournalError.queuedForRetry` to simulate
+  /// the offline-queue path introduced in #215.
+  var shouldQueue = false
 
   func submit(
     curriculumID: Int,
@@ -163,6 +166,9 @@ final class JournalClientMock: JournalClientProtocol {
   ) async throws -> LocalJournalEntry {
     submissions.append((curriculumID, secondaryCurriculumID, strategyID))
     submittedInitiatedBy = initiatedBy
+    if shouldQueue {
+      throw JournalError.queuedForRetry(entryID: UUID())
+    }
     if shouldFail {
       throw ErrorStub()
     }
@@ -182,6 +188,9 @@ final class JournalClientMock: JournalClientProtocol {
   ) async throws -> LocalJournalEntry {
     restSubmissions.append(initiatedBy)
     submittedInitiatedBy = initiatedBy
+    if shouldQueue {
+      throw JournalError.queuedForRetry(entryID: UUID())
+    }
     if shouldFail {
       throw ErrorStub()
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
@@ -85,6 +85,7 @@ struct CatalogRepositoryTests {
   }
 }
 
+@MainActor
 struct JournalClientTests {
   @Test func encodesPayloadWithStableUserIdentifier() async throws {
     let spy = APIClientSpy()


### PR DESCRIPTION
Closes #215
Closes #216
Closes #218

The designated execution branch carries all three phases of the offline-queue rollout, so this PR covers them together.

## #215 — JournalClient ↔ queue integration

- Wires the SQLite-backed `JournalQueue` into `JournalClient` so retryable sync failures (network, 5xx, 408, 429) automatically persist entries for background retry instead of failing outright.
- Classifies errors via a new `APIClientError.isRetryable` helper. Non-retryable errors (4xx validation) still mark the entry as failed and bubble up.
- Introduces `JournalError.queuedForRetry(entryID:)` as a distinct signal so the UI can render a "Saved Offline" confirmation instead of an error alert.
- Threads an idempotency key through both the initial submit and `JournalSyncService` retries, using the local entry UUID so the backend can deduplicate replays.
- Makes `JournalClient` `@MainActor` to call the `@MainActor`-isolated `JournalQueue` directly (all existing callers are already MainActor).
- Adds a 3-argument `post(_:body:headers:)` requirement on `APIClientProtocol` with a default extension delegating to the 2-arg variant, so existing mocks/spies continue to work.

## #216 — UI queue status + sync feedback

- `JournalQueue` publishes `pendingCount`; recomputed after every mutating op so views react to enqueue / markSyncing / markSynced / markFailed without polling.
- New `SyncStatusView` (reachable from the Menu) shows network state, pending entry count, live sync progress, and a manual "Sync Now" button.
- `MenuView` shows a pending-count badge next to the new "Sync Status" row.
- `ContentView` kicks off auto-sync on appear and delegates `syncStatus` changes to a new testable `ContentViewModel.handleSyncStatusChange` helper.
- `JournalFeedback.Kind` gains `.syncing(current:total:)` and `.syncSuccess(count:)` cases with matching alert presentation.

## #218 — End-to-end offline integration tests

- New `OfflineQueueIntegrationTests` suite wires real `JournalClient`, `JournalQueue`, and `JournalSyncService` against a controllable `ToggleableAPIClient` mock + `MockNetworkMonitor` and exercises 14 realistic scenarios:
  - **Basic flow**: offline submission queues; online happy path skips the queue; reconnect drains queued entries.
  - **Idempotency**: distinct keys across distinct entries; same key reused across initial submit and retry so the backend can deduplicate.
  - **Ordering**: 5 queued entries drain FIFO.
  - **Error handling**: 4xx validation bypasses the queue; 5xx keeps the entry in place and increments `retryCount`; failed entries are not auto-retried on subsequent `sync()` calls.
  - **App lifecycle**: queue persists across `JournalQueue` restarts; partial sync state resumes cleanly.
  - **Edge cases**: empty queue sync is a no-op; offline sync is a no-op; concurrent `sync()` calls are serialized via the `isSyncing` guard.

## Test plan

- [x] New `JournalClientQueueIntegrationTests` — retryable transport, 5xx, 4xx, success-doesn't-queue, idempotency header, REST entries.
- [x] New `APIClientErrorRetryableTests` — 4xx / 5xx / 408 / 429 / transport / invalidURL classification.
- [x] New `JournalQueueTests` cases — `pendingCount` starts at zero, increments on enqueue, decrements across status transitions, survives restart.
- [x] New `ContentViewModelTests` cases — `.queued` feedback on offline journal, `.syncing` mapped for multi-entry batches, `.syncing` suppressed for single entries, `.syncSuccess` for non-zero counts, `.success(0)` / `.idle` / `.error` no-ops.
- [x] New `OfflineQueueIntegrationTests` — 14 end-to-end scenarios listed above.
- [x] `@MainActor` applied to pre-existing `JournalClientLocalFirstTests` and `JournalClientTests` so they remain compatible with the now-MainActor `JournalClient`.
- [ ] CI runs the full watchOS test suite (`frontend/WavelengthWatch/run-tests-individually.sh`) to confirm no regressions.

https://claude.ai/code/session_01HLm5zpRyawxQ75fac1aK6d