### PR TITLE
Add skills and workflows from well-worn-tools

### DIFF
--- a/.claude/skills/address-feedback/SKILL.md
+++ b/.claude/skills/address-feedback/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: address-feedback
+description: >-
+  Iterate on Claude PR review feedback intelligently and merge when ready.
+  Use when the user asks to "address feedback", "respond to Claude's review",
+  "iterate on the PR", "fix review comments", or "merge if Claude said LGTM".
+  The Claude reviewer publishes a top-level PR comment via GitHub Action
+  ending in a `Verdict:` line (LGTM / CHANGES_REQUESTED / COMMENTS) — it is
+  NOT a formal GitHub approval. This skill locates the most recent such
+  comment via GitHub MCP, parses the verdict, triages blockers/problems/nits
+  into a TDD-driven local fix loop, replies and resolves threads, and merges
+  only when the latest verdict is `LGTM`, the comment was posted after the
+  current HEAD's push, and all required checks are green.
+  Do NOT use for giving a review (use comprehensive-pr-review), debugging CI
+  failures themselves (use ci-debugging), general TDD work outside review
+  context (use stay-green), bug RCA (use bug-squashing-methodology), or
+  issue/branch/PR creation (use git-workflow).
+metadata:
+  author: Geoff
+  version: 1.1.0
+---
+
+# Address Feedback
+
+Close the loop on a Claude PR review: find the latest verdict comment, iterate locally with TDD, push once, and merge only when the verdict is `LGTM` for the current HEAD and CI is green.
+
+## How the Claude Review Surfaces
+
+The Claude reviewer runs as a GitHub Action on each push. It posts its findings as a **top-level PR comment** authored by a bot account (e.g. `claude[bot]`, `github-actions[bot]`). The comment follows the `comprehensive-pr-review` format and ends with a line like:
+
+```
+## Verdict: LGTM
+```
+
+Possible verdicts: `LGTM`, `CHANGES_REQUESTED`, `COMMENTS`. There is **no formal GitHub approval** to read — `state == "APPROVED"` will not be set. Treat the comment body as the source of truth.
+
+## Prompt-Engineering Tactics (Brief)
+
+Before touching code, restate each review item as a 6-component micro-prompt so the fix is precise instead of sprawling:
+
+- **Role** — "Engineer addressing a single review comment."
+- **Goal** — the exact change requested (one sentence).
+- **Context** — `file:line`, the surrounding 5-10 lines, the reviewer's quote.
+- **Format** — minimal diff; no drive-by refactors.
+- **Examples** — if the reviewer suggested code, paste it verbatim.
+- **Constraints** — keep blast radius small; preserve public API; add a regression test.
+
+If a comment is ambiguous on any component, reply asking for clarification rather than guessing. See `prompt-engineering` for the full framework.
+
+## Instructions
+
+### Step 1: Locate the Latest Claude Verdict Comment
+
+Use the GitHub MCP tools — never `gh` CLI. The goal is to determine whether a Claude review comment exists for the current HEAD push, and what its verdict is.
+
+1. Get HEAD SHA and the push timestamp:
+   - `mcp__github__pull_request_read` with `method: "get"` → record `head.sha`.
+   - `mcp__github__get_commit` with `sha: head.sha` → record `commit.committer.date` (proxy for the latest push time).
+2. List **top-level PR comments** (not line-level review comments):
+   - `mcp__github__pull_request_read` with `method: "get_comments"` (paginate if the PR is long-running).
+3. Filter the comments:
+   - **Author** is a bot matching the Claude reviewer (`claude[bot]`, `github-actions[bot]`, or whichever account posts the review on this repo). When in doubt, also require the body to contain a `Verdict:` line.
+   - **`created_at >= head commit's committer.date`** — the currency check. Comments posted before the latest push describe an earlier state and are stale.
+4. Sort matching comments by `created_at` desc; the first is the **current** Claude review.
+5. Parse the verdict from that comment's body. Look for a line matching (case-insensitive):
+
+   ```
+   ^\s*(?:##\s+|\*\*)?Verdict[:\*\s]+(LGTM|CHANGES_REQUESTED|COMMENTS)
+   ```
+
+6. Classify and route:
+   - `LGTM` → skip to Step 6 (merge gate).
+   - `CHANGES_REQUESTED` → required fixes; continue to Step 2 with the **Security Concerns**, **Problems**, and any blocking items from the comment body.
+   - `COMMENTS` → optional improvements; user decides whether to address; if skipping, jump to Step 6.
+   - **No qualifying comment** (none after the latest push) → wait for the next review run; do not merge. Optionally post `@claude please review` via `mcp__github__add_issue_comment` if the action did not run.
+   - **Comment exists but no parseable Verdict line** → treat as malformed; ask the user before merging. Do not infer a verdict from prose.
+
+### Step 2: Triage the Comment Body into a Fix Plan
+
+The Claude review is a single comment with sections (Strengths / Security Concerns / Problems / Code Quality / Requests / Verdict). Extract each actionable item into a row:
+
+| id | section | file:line (if cited) | quote | requested change | test idea | severity |
+
+Also pull any **line-level** review threads via `mcp__github__pull_request_read` with `method: "get_review_comments"` and merge them into the same table — these come back with `isResolved` metadata so you can ignore already-resolved threads.
+
+Apply the prompt-engineering framing above. Drop or push back on items that are out of scope, factually wrong, or already addressed — reply with a short justification instead of changing code.
+
+### Step 3: Fix Locally with TDD — Never Push to Probe CI
+
+For each row, smallest unit first:
+
+1. **Red** — write a test that fails because of the bug the reviewer flagged.
+2. **Green** — make the minimal change; the test passes.
+3. **Refactor** — only within the same file, only if it stays green.
+
+Then run the full local gate before any push:
+
+```bash
+# Whatever the project uses; pick the equivalents:
+pre-commit run --all-files
+./scripts/test.sh --all      # or pytest / npm test / go test ./... / cargo test
+./scripts/typecheck.sh       # or mypy / tsc --noEmit / etc.
+```
+
+If a check fails, fix it locally and re-run. **Do not push to use CI as your test runner.** See `stay-green` for the gates and `ci-debugging` only if a local-green change later fails in CI.
+
+### Step 4: Reply, Resolve, Re-Request
+
+For each item, after the fix lands locally:
+
+1. **Line-level threads** — `mcp__github__add_reply_to_pull_request_comment` with a short reply (what changed, where: `src/x.py:42`, and the commit SHA once pushed), then `mcp__github__resolve_review_thread`.
+2. **Top-level Claude review comment** — there is no thread to resolve. Post a single summary reply via `mcp__github__add_issue_comment` listing each addressed item and the SHA(s) that fixed it.
+3. After pushing, request a fresh review by posting `@claude please re-review` via `mcp__github__add_issue_comment`. The GitHub Action runs again and writes a new verdict comment — that becomes the comment you parse on the next pass.
+
+### Step 5: Push Once and Await the Next Verdict
+
+Push the branch (single push, not one per fix). Then delegate the wait to `await-claude-review` — it pins the new HEAD, calls `mcp__github__subscribe_pr_activity`, and ends the turn so the session wakes on the bot's verdict comment via `<github-webhook-activity>`. **Do not poll** with `sleep` or repeated `get_comments` calls, and do not wait on CI passes — the webhook does not deliver them; only the comment event is the wake signal.
+
+When the helper wakes the session:
+
+- Verdict `LGTM` for the current HEAD → continue to Step 6.
+- Verdict `CHANGES_REQUESTED` → loop back to Step 2 with the new comment body.
+- Verdict `COMMENTS` → user decides; if skipping, Step 6.
+- CI failure event for the current HEAD → if the failing job is the reviewer action, the helper retriggers it and stays subscribed; if it's other CI, hand off to `ci-debugging` and keep the subscription open. Either way, do not advance to merge.
+
+### Step 6: Merge Gate — All Must Hold
+
+Merge only when **every** condition is true. If any fails, stop and explain which one.
+
+- Latest qualifying Claude review comment has `Verdict: LGTM`.
+- That comment's `created_at >= head commit's committer.date` (verdict is for the current HEAD, not a pre-push state).
+- All required check runs are `success`:
+  - `mcp__github__pull_request_read` with `method: "get_status"` (combined commit status), and
+  - `mcp__github__pull_request_read` with `method: "get_check_runs"` (per-job detail).
+- No unresolved line-level review threads (`mcp__github__pull_request_read` with `method: "get_review_comments"` — each thread has `isResolved`).
+- The PR is `mergeable` and not `draft` (from the `get` response).
+
+Then:
+
+```
+mcp__github__merge_pull_request
+  pull_number: <N>
+  merge_method: "squash"   # or whatever the repo standard is
+```
+
+Confirm the merge succeeded; do not delete the remote branch unless the user asks.
+
+## Examples
+
+### Example 1: Current `Verdict: LGTM`, Green CI — Merge
+
+1. `pull_request_read get` → `head.sha = abc123`. `get_commit abc123` → `committer.date = 2026-05-01T10:00:00Z`.
+2. `pull_request_read get_comments` → latest bot comment by `claude[bot]` at `2026-05-01T10:04:33Z`, body ends with `## Verdict: LGTM`.
+3. `10:04:33Z >= 10:00:00Z` → comment is current.
+4. `get_status` and `get_check_runs` → all `success`. `get_review_comments` → no unresolved threads. PR `mergeable: true`, `draft: false`.
+5. `merge_pull_request` with `squash`. Report merge URL.
+
+### Example 2: Verdict Comment Predates the Latest Push (Stale)
+
+1. `head.sha = abc123`, `committer.date = 11:30:00Z`.
+2. Latest Claude comment is `Verdict: LGTM` but `created_at = 09:15:00Z` — before the push that produced `abc123`.
+3. The verdict reflects an earlier HEAD. State that the LGTM is stale, post `@claude please re-review` via `add_issue_comment`, and **do not merge**.
+
+### Example 3: `Verdict: CHANGES_REQUESTED` with Two Blockers and a Nit
+
+1. Parse the comment body: two **Problems** (file:line cited) and one **Code Quality** nit. Build the triage table.
+2. Decide the nit is out of scope for this PR — reply on the top-level Claude comment justifying the deferral.
+3. For the two blockers: Red-Green-Refactor locally, then `pre-commit run --all-files` + full test suite + typecheck. All green.
+4. Single `git push`. Post a summary reply via `add_issue_comment` listing the addressed items and the SHA. Then post `@claude please re-review`.
+5. New Claude comment arrives with `Verdict: LGTM` after the new push timestamp → re-enter Step 6.
+
+## Troubleshooting
+
+### Error: Cannot tell which comment is "Claude's"
+
+Match by author login first (`claude[bot]`, `github-actions[bot]`); fall back to `user.type == "Bot"` plus a body that contains a `Verdict:` line. If still ambiguous, ask the user which bot to treat as authoritative — do not guess.
+
+### Error: Verdict line not found or malformed
+
+The reviewer is supposed to end with `## Verdict: LGTM | CHANGES_REQUESTED | COMMENTS`. If the regex does not match, do not infer the verdict from prose ("looks good to me" is not a verdict). Surface the malformed comment to the user, optionally re-request the review, and **do not merge**.
+
+### Error: Verdict comment exists but predates the HEAD push
+
+The LGTM was for an earlier commit. Any push, even a docs-only one, supersedes it. Re-request a review (`add_issue_comment` with `@claude please re-review`), wait for the new comment, and re-enter Step 6 only after a current `Verdict: LGTM` arrives.
+
+### Error: Reviewer's suggestion would break tests or public API
+
+Do not silently ignore. Reply on the relevant thread (or the top-level comment) with the conflict (failing test name, API consumer, or constraint), propose an alternative, and pause until the user or reviewer agrees. Never bypass with `--no-verify` or skip checks; see `max-quality-no-shortcuts`.
+
+### Error: Tempted to push to "see what CI says"
+
+Stop. Reproduce the check locally first (`pre-commit run --all-files`, full test suite, typecheck). Pushing speculatively burns minutes per round trip and trains a sloppy loop. Only push when local gates are green.
+
+### Error: Merge gate passes but `mergeable` is `false`
+
+Conflicts with the base branch. Rebase or merge `main` locally, resolve, re-run local gates, push. The new commit supersedes the LGTM verdict — request a fresh review before re-entering the merge gate.

--- a/.claude/skills/await-claude-review/SKILL.md
+++ b/.claude/skills/await-claude-review/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: await-claude-review
+description: >-
+  Subscribe to GitHub PR activity and wait — without polling — for the
+  Claude reviewer's verdict comment on the current HEAD. Use when a PR
+  has just been pushed and you need to know the verdict
+  (LGTM / CHANGES_REQUESTED / COMMENTS) before merging, addressing
+  feedback, or declaring work done. Wraps
+  `mcp__github__subscribe_pr_activity`, which delivers comments and CI
+  failures (NOT CI passes) as `<github-webhook-activity>` events. The
+  verdict comment itself is a comment event, so the bot's post wakes
+  the session directly — no need to proxy through CI status. After
+  subscribing, end the turn; events resume the session.
+  Called by `address-feedback`, `stay-green`, and
+  `comprehensive-pr-review`.
+  Do NOT use for waiting on arbitrary CI success (not deliverable by
+  the webhook), general PR babysitting unrelated to the verdict gate,
+  debugging CI failures themselves (use `ci-debugging`), or one-off
+  status polling (use `pull_request_read` directly).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Await Claude Review
+
+Wait for the Claude reviewer's `Verdict:` comment on the current HEAD via PR webhook events. No polling, no `sleep`, no CI-pass proxy.
+
+## What the Subscription Actually Delivers
+
+`mcp__github__subscribe_pr_activity` says, verbatim:
+
+> Once subscribed comments and CI failures will be delivered into this conversation as `<github-webhook-activity>` messages.
+
+So the deliverable set is:
+
+| Event                                         | Delivered? | Notes                                                          |
+| --------------------------------------------- | ---------- | -------------------------------------------------------------- |
+| Top-level PR comment (incl. reviewer verdict) | Yes        | This is the wake signal you want.                              |
+| Line-level review comment / thread reply      | Yes        | Treated as a comment event.                                    |
+| CI **failure** (any required check failing)   | Yes        | Triage on receipt — may indicate the reviewer action failed.   |
+| CI **success / pass**                         | **No**     | Do not write logic that waits on this — it never arrives.      |
+| Successful workflow_run completion            | **No**     | Same as above.                                                 |
+| PR merge / close                              | Implicit   | You should `unsubscribe_pr_activity` on these from the caller. |
+
+**Implication.** Don't treat "CI green" as a proxy for "review posted." The verdict comment is itself a delivered event — wait for it directly.
+
+## Canonical Verdict Line
+
+The reviewer (see `comprehensive-pr-review`) ends its top-level comment with a line matching, case-insensitive:
+
+```
+^\s*(?:##\s+|\*\*)?Verdict[:\*\s]+(LGTM|CHANGES_REQUESTED|COMMENTS)
+```
+
+Examples that match:
+
+- `## Verdict: LGTM`
+- `**Verdict:** CHANGES_REQUESTED`
+- `Verdict: COMMENTS`
+
+If the regex does not match, treat the comment as malformed: do **not** infer a verdict from prose ("looks good to me" is not a verdict). Surface to the user.
+
+## Instructions
+
+### Step 1: Pin the HEAD You're Waiting For
+
+Before subscribing, record what "current" means so you can later distinguish a fresh verdict from a stale one.
+
+1. `mcp__github__pull_request_read` with `method: "get"` → record `head.sha`.
+2. `mcp__github__get_commit` with `sha: head.sha` → record `commit.committer.date` as `headPushedAt` (proxy for the latest push time).
+
+### Step 2: Subscribe and End the Turn
+
+```
+mcp__github__subscribe_pr_activity
+  owner: <owner>
+  repo:  <repo>
+  pullNumber: <N>
+```
+
+Then **stop**. Do not poll. Do not `sleep`. Do not call `pull_request_read get_comments` in a loop. Webhook events arrive as `<github-webhook-activity>` messages and resume the session on their own.
+
+### Step 3: On Wake — Classify the Event
+
+When a `<github-webhook-activity>` message arrives, decide what kind of event it is:
+
+- **Top-level PR comment from a reviewer bot** (`claude[bot]`, `github-actions[bot]`, or whichever account posts reviews on this repo) → go to Step 4.
+- **Line-level review comment** → not a verdict; if you're tracking thread resolutions for `address-feedback`, handle there. Otherwise stay subscribed and wait for the next event.
+- **CI failure event** → go to Step 5.
+- **Anything else** → stay subscribed; wait for the next event.
+
+### Step 4: Validate Currency and Parse Verdict
+
+Re-fetch the comments to read the full body (the webhook payload may be truncated):
+
+1. `mcp__github__pull_request_read` with `method: "get_comments"`.
+2. Filter to bot author + body containing the verdict regex.
+3. Sort by `created_at` desc; take the first.
+4. **Currency check**: require `created_at >= headPushedAt`. A verdict posted before the latest push describes an earlier state; ignore and keep waiting.
+5. Parse with the regex above. Return one of:
+   - `LGTM` → caller proceeds to merge gate.
+   - `CHANGES_REQUESTED` → caller enters fix loop.
+   - `COMMENTS` → caller decides (usually mergeable as-is).
+   - **Malformed** → surface to user; do not guess.
+
+### Step 5: On CI Failure for Current HEAD
+
+A CI failure event for `head.sha` may mean the reviewer action itself failed (timeout, rate limit, permissions) — in which case **the verdict comment will never arrive** and waiting is futile. Inspect the failed check:
+
+1. `mcp__github__pull_request_read` with `method: "get_check_runs"` for `head.sha`.
+2. If the failed run is the **review action** (look for the workflow that runs `@claude` review): post `@claude please review` via `mcp__github__add_issue_comment` to retrigger, then stay subscribed.
+3. If the failed run is **other CI** (lint, tests, build): surface the failure to the user and recommend handing off to `ci-debugging`. Stay subscribed — the reviewer action may still post.
+
+### Step 6: Cleanup
+
+The caller should call `mcp__github__unsubscribe_pr_activity` once the PR merges, closes, or the verdict gate is no longer needed. This helper does not unsubscribe on its own — leave the lifecycle to the caller.
+
+## Examples
+
+### Example 1: Push, Subscribe, Wake on LGTM
+
+1. Caller (`address-feedback` Step 5) finishes pushing fixes.
+2. Pin HEAD: `head.sha = abc123`, `headPushedAt = 2026-05-08T11:00:00Z`.
+3. `subscribe_pr_activity owner=acme repo=widgets pullNumber=42`. End turn.
+4. Wake: `<github-webhook-activity>` for a comment by `claude[bot]`.
+5. `get_comments` → latest matching at `2026-05-08T11:04:33Z`, body ends `## Verdict: LGTM`. `11:04:33Z >= 11:00:00Z` ✓.
+6. Return `LGTM` to caller. Caller proceeds to merge gate.
+
+### Example 2: Stale Verdict After Force-Push
+
+1. Pin HEAD: `head.sha = def456`, `headPushedAt = 2026-05-08T12:00:00Z`.
+2. Subscribe, end turn.
+3. Wake on a comment event. `get_comments` → latest verdict `LGTM` at `11:55:00Z` — that's *before* `headPushedAt`. The push superseded the verdict.
+4. Stay subscribed. Optionally post `@claude please re-review`. Return to waiting.
+
+### Example 3: Reviewer Action Failed in CI
+
+1. Subscribe after push, end turn.
+2. Wake: `<github-webhook-activity>` for a CI failure on `head.sha`.
+3. `get_check_runs` → the failing job is `claude-review` (timeout). No other failures.
+4. Post `@claude please review` to retrigger the action. Stay subscribed.
+5. Subsequent wake delivers the verdict comment normally.
+
+### Example 4: Other CI Failed; Verdict May Still Come
+
+1. Subscribe after push, end turn.
+2. Wake: CI failure on `head.sha`. `get_check_runs` → `pytest` failed; `claude-review` is still in progress.
+3. Surface the test failure to the user and recommend `ci-debugging` for that. Stay subscribed — the reviewer may still post a verdict (which the author will need to address regardless of test failures).
+
+## Troubleshooting
+
+### Error: Tempted to wait on "CI green" / `workflow_run.conclusion == success`
+
+Don't. The subscription does not deliver CI passes. Wait on the comment event directly — that *is* the delivered signal.
+
+### Error: Tempted to poll with `sleep` or `Bash run_in_background`
+
+Don't. The session is woken by `<github-webhook-activity>`. Polling burns time and conflicts with the harness's wake mechanism. Subscribe and end the turn.
+
+### Error: Webhook arrives but `get_comments` shows no matching verdict
+
+Possible causes, in order of likelihood:
+
+1. The event was a line-level review comment, not the top-level verdict. Stay subscribed.
+2. The reviewer posted a non-verdict comment (e.g., a status ping). Stay subscribed.
+3. The bot author login differs on this repo. Confirm the author and update the filter.
+
+### Error: Multiple bot accounts post comments
+
+Match by author login (`claude[bot]`, `github-actions[bot]`) AND require the body to contain the canonical Verdict regex. If still ambiguous, ask the user which account is authoritative — do not guess.
+
+### Error: PR merged or closed while waiting
+
+The caller should detect this and call `unsubscribe_pr_activity`. If you see no further events for a long time, ask the user before assuming the PR is still open.

--- a/.claude/skills/concurrency/SKILL.md
+++ b/.claude/skills/concurrency/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: concurrency
+description: >-
+  Safe and efficient concurrent code patterns across languages.
+  Use when implementing async operations, parallel processing,
+  thread pools, or managing shared state. Covers Python asyncio,
+  TypeScript Promises, Go goroutines, and Rust Tokio.
+  Do NOT use for general performance optimization without concurrency.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Concurrency
+
+Prefer immutability, minimize shared state, use structured concurrency, handle cancellation explicitly.
+
+## Instructions
+
+### Step 1: Choose the Right Concurrency Model
+
+- **I/O-bound** (network, file, database): Use async/await
+- **CPU-bound with I/O**: Use thread pools
+- **True parallelism (CPU-intensive)**: Use process pools or language-native parallelism
+
+### Step 2: Apply Language-Specific Patterns
+
+See `references/patterns-by-language.md` for detailed patterns.
+
+Key rules:
+- Always handle errors in concurrent tasks (never fire-and-forget)
+- Use context managers / structured concurrency for cleanup
+- Limit concurrency with semaphores (don't spawn unlimited tasks)
+- Use channels/queues for communication, not shared state
+
+### Step 3: Avoid Anti-Patterns
+
+- **Fire and forget**: Always await or handle task results
+- **Unhandled rejections**: Catch errors in every concurrent branch
+- **Race conditions**: Use locks for shared state, or eliminate shared state
+- **Blocking in async**: Never call blocking I/O in async code
+
+## Examples
+
+### Example 1: Python asyncio - Concurrent HTTP Fetches
+
+```python
+async def process_multiple_urls(urls: list[str]) -> list[dict]:
+    tasks = [fetch_data(url) for url in urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    valid_results = []
+    for result in results:
+        if isinstance(result, Exception):
+            logger.error(f"Failed to fetch: {result}")
+        else:
+            valid_results.append(result)
+    return valid_results
+```
+
+### Example 2: Go - Goroutines with WaitGroup
+
+```go
+func processItems(items []Item) []Result {
+    results := make([]Result, len(items))
+    var wg sync.WaitGroup
+    for i, item := range items {
+        wg.Add(1)
+        go func(index int, it Item) {
+            defer wg.Done()
+            results[index] = processItem(it)
+        }(i, item)
+    }
+    wg.Wait()
+    return results
+}
+```
+
+## Troubleshooting
+
+### Error: Tasks silently failing
+- Check if you're using `asyncio.gather(*tasks, return_exceptions=True)` and actually inspecting the results
+- In Go, ensure goroutine panics are recovered
+- In TypeScript, add `.catch()` to every Promise or use try/catch with await
+
+### Error: Deadlock or hang
+- Check for lock ordering issues (always acquire locks in the same order)
+- Look for await inside a lock that another task needs
+- Use timeouts on all blocking operations

--- a/.claude/skills/concurrency/references/patterns-by-language.md
+++ b/.claude/skills/concurrency/references/patterns-by-language.md
@@ -1,0 +1,164 @@
+# Concurrency Patterns by Language
+
+## Python
+
+### asyncio (I/O-bound)
+```python
+async def fetch_data(url: str) -> dict:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            return await response.json()
+
+async def process_multiple_urls(urls: list[str]) -> list[dict]:
+    tasks = [fetch_data(url) for url in urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    return [r for r in results if not isinstance(r, Exception)]
+```
+
+### ThreadPoolExecutor (CPU-bound with I/O)
+```python
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+def process_files_concurrently(file_paths: list[Path]) -> list[dict]:
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(process_file, p): p for p in file_paths}
+        results = []
+        for future in as_completed(futures):
+            try:
+                results.append(future.result())
+            except Exception as e:
+                logger.error(f"Failed {futures[future]}: {e}")
+        return results
+```
+
+### ProcessPoolExecutor (true parallelism)
+```python
+from concurrent.futures import ProcessPoolExecutor
+
+def parallel_processing(datasets: list[bytes]) -> list[int]:
+    with ProcessPoolExecutor() as executor:
+        return list(executor.map(cpu_intensive_task, datasets))
+```
+
+## TypeScript
+
+### Promise.all with error handling
+```typescript
+async function fetchMultipleResources(urls: string[]): Promise<Array<Resource | null>> {
+  return Promise.all(urls.map(async (url) => {
+    try {
+      const response = await fetch(url);
+      return await response.json();
+    } catch (error) {
+      console.error(`Failed to fetch ${url}:`, error);
+      return null;
+    }
+  }));
+}
+```
+
+### Worker threads (CPU-bound)
+```typescript
+import { Worker } from 'worker_threads';
+
+function runWorker(workerData: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker('./worker.js', { workerData });
+    worker.on('message', resolve);
+    worker.on('error', reject);
+    worker.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`Worker exit code ${code}`));
+    });
+  });
+}
+```
+
+## Go
+
+### Goroutines with sync.WaitGroup
+```go
+func processItems(items []Item) []Result {
+    results := make([]Result, len(items))
+    var wg sync.WaitGroup
+    for i, item := range items {
+        wg.Add(1)
+        go func(index int, it Item) {
+            defer wg.Done()
+            results[index] = processItem(it)
+        }(i, item)
+    }
+    wg.Wait()
+    return results
+}
+```
+
+### Context for cancellation
+```go
+func fetchWithTimeout(ctx context.Context, url string) (*Response, error) {
+    ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+    defer cancel()
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if err != nil { return nil, err }
+    return http.DefaultClient.Do(req)
+}
+```
+
+## Rust
+
+### Tokio JoinSet
+```rust
+async fn process_items(items: Vec<Item>) -> Vec<Result<Output, Error>> {
+    let mut set = JoinSet::new();
+    for item in items {
+        set.spawn(async move { process_item(item).await });
+    }
+    let mut results = Vec::new();
+    while let Some(result) = set.join_next().await {
+        results.push(result.unwrap());
+    }
+    results
+}
+```
+
+### Channels
+```rust
+use tokio::sync::mpsc;
+
+async fn producer_consumer() {
+    let (tx, mut rx) = mpsc::channel(100);
+    tokio::spawn(async move {
+        for i in 0..10 { tx.send(i).await.unwrap(); }
+    });
+    while let Some(value) = rx.recv().await {
+        println!("Received: {}", value);
+    }
+}
+```
+
+## Resource Management
+
+```python
+# Always clean up with context managers
+async with aiohttp.ClientSession() as session:
+    async with session.get(url) as response:
+        return await response.json()
+
+# Or ensure cleanup in finally
+task = None
+try:
+    task = asyncio.create_task(operation())
+    await task
+finally:
+    if task and not task.done():
+        task.cancel()
+        try: await task
+        except asyncio.CancelledError: pass
+```
+
+## Performance Considerations
+
+1. Don't create too many concurrent tasks (use semaphores)
+2. Batch operations when possible
+3. Use connection pooling
+4. Consider backpressure mechanisms
+5. Profile before optimizing

--- a/.claude/skills/cve-remediation/SKILL.md
+++ b/.claude/skills/cve-remediation/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: cve-remediation
+description: >-
+  Remediate dependency vulnerability scanner failures by verifying live
+  package registry data and upgrading instead of suppressing. Use when an
+  SCA / CVE tool fails or files an alert: npm audit, pnpm audit, yarn audit,
+  pip-audit, safety, Snyk, Dependabot, Trivy, Grype, OSV-Scanner, audit-ci,
+  cargo audit, govulncheck, bundler-audit, Renovate, or any CI step
+  reporting a CVE / GHSA / OSV advisory. The first action is ALWAYS to look
+  up the latest published version on the live registry — training data is
+  months stale and almost never knows the current version. Suppression,
+  ignore, or allowlist entries are the absolute last resort, only after
+  upgrade and override paths are proven unavailable; surrounding GitHub
+  issues and justification docs do not by themselves count as remediation.
+  Do NOT use for vulnerabilities in your own application code (use security
+  skill), general linter or type checker bypasses (use max-quality-no-shortcuts
+  skill), or unrelated CI failures (use ci-debugging skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# CVE Remediation
+
+A dependency vulnerability scanner just failed. The fix is almost always a version bump — but you must look up the current version on the live registry, because your training data is months out of date and the version you remember is probably not the latest.
+
+## The Anti-Pattern to Resist
+
+When a CVE alert fires, the path of least resistance feels like:
+
+1. Add a suppression / ignore / allowlist entry.
+2. File a GitHub issue.
+3. Write a justification doc.
+4. Move on.
+
+**Do not start here.** This sequence is correct only as a final fallback after upgrade paths are demonstrably exhausted. Treating it as the default leaves real, fixable vulnerabilities in production behind a paper trail of issues that nobody revisits. Polished documentation around a suppression is not a fix.
+
+## Instructions
+
+### Step 1: Parse the Alert
+
+Extract from the scanner output:
+
+- Package name and ecosystem (npm, PyPI, crates.io, Go module, Maven, RubyGems, NuGet, Composer)
+- Currently installed version
+- Advisory ID (`CVE-YYYY-NNNNN`, `GHSA-xxxx-xxxx-xxxx`, `OSV-YYYY-NNNN`)
+- Severity (critical, high, moderate, low)
+- "Patched versions" range (e.g., `>= 1.4.2`)
+- Whether it is a direct or transitive dependency
+
+If any field is missing, look it up before acting. Do not remediate from a half-read alert.
+
+### Step 2: Look Up the LATEST Published Version (Critical)
+
+**You do not know the current version.** Your training data trails reality by months and most ecosystems publish daily. Whatever version you "know" is the latest is probably wrong. Always query the live registry first.
+
+| Ecosystem | Quick command |
+|-----------|---------------|
+| npm / pnpm / yarn | `npm view <pkg> version` |
+| PyPI              | `pip index versions <pkg>` |
+| crates.io         | `cargo search <pkg> --limit 1` |
+| Go modules        | `go list -m -versions <module>` |
+| Maven Central     | see `references/registry-lookups.md` |
+| RubyGems          | `gem search -re <pkg>` |
+| NuGet             | see `references/registry-lookups.md` |
+| Packagist         | `composer show <pkg> --available --no-interaction` |
+
+See `references/registry-lookups.md` for HTTP fallbacks when the package manager CLI is not available, and for listing the full version history.
+
+### Step 3: Verify the Latest Version Actually Fixes the CVE
+
+A newer version is not automatically a patched version. Confirm the fix:
+
+1. Compare the latest registry version against the advisory's "patched versions" range. If `latest >= fixed-in`, upgrading fixes it.
+2. Read the changelog / release notes for the version that introduced the fix.
+3. For GHSA: `gh api /advisories/<GHSA-id> --jq '.vulnerabilities[].patched_versions'`
+4. For OSV: `curl -s https://api.osv.dev/v1/vulns/<id> | jq '.affected[].ranges'`
+
+If the latest version is still vulnerable, the CVE is genuinely unpatched. Skip to Step 6.
+
+### Step 4: Apply the Upgrade
+
+**Direct dependency** — bump the version constraint, regenerate the lockfile, test:
+
+```bash
+npm install <pkg>@<fixed-version>
+uv add "<pkg>>=<fixed-version>"
+poetry add "<pkg>@^<fixed-version>"
+cargo update -p <pkg> --precise <fixed-version>
+go get <module>@<fixed-version> && go mod tidy
+bundle update <pkg> --conservative
+```
+
+**Transitive dependency** — find the direct dependency that pulls it in, and either bump that direct dependency to a version whose tree includes the patched transitive, or override the transitive directly:
+
+| Ecosystem | Override mechanism |
+|-----------|--------------------|
+| npm       | `"overrides"` in `package.json` |
+| Yarn      | `"resolutions"` in `package.json` |
+| pnpm      | `"pnpm.overrides"` in `package.json` |
+| pip       | constraints file via `pip install -c constraints.txt` |
+| Poetry / uv | direct entry in `[tool.poetry.dependencies]` / `[project.dependencies]` |
+| Cargo     | `[patch.crates-io]` in `Cargo.toml` |
+| Go        | `replace` directive in `go.mod` |
+| Bundler   | explicit entry in `Gemfile` |
+
+Confirm the override took effect:
+
+```bash
+npm ls <pkg>
+pip show <pkg>
+cargo tree -i <pkg>
+go mod why <module>
+```
+
+### Step 5: Verify the Fix
+
+1. Re-run the scanner that failed. It must pass.
+2. Run the project's test suite, type checker, and linter. Upgrades can introduce breakage.
+3. For major version bumps, read the upstream changelog and adapt callers as needed.
+
+If tests break, fix the breakage. Do not roll back the upgrade unless the breakage is genuinely insurmountable — and if it is, treat the upgrade as blocked and escalate, do not silently suppress.
+
+### Step 6: Last Resort — Suppression (Only If Truly Unfixable)
+
+You may add a suppression / ignore / allowlist entry only if ALL of these hold:
+
+- [ ] Step 2 confirmed: no patched version exists on the live registry yet.
+- [ ] Step 3 confirmed: the latest published version is still vulnerable.
+- [ ] Upstream maintainers have a tracking issue or PR you can link to (or, if not, you have opened one).
+- [ ] You have considered and rejected: forking, applying a `patch-package` / `cargo patch` / equivalent local patch, swapping libraries.
+- [ ] You have explicitly assessed exposure: severity × reachability × runtime context.
+
+If all five hold, suppress using `references/suppression-template.md`. The suppression must include:
+
+1. Advisory ID and link
+2. Why no upgrade exists, with link to upstream tracking
+3. Reachability and exposure assessment
+4. Concrete review date, no more than 30 days out
+5. Linked GitHub issue tracking re-evaluation
+
+A bare `# noqa`, `audit-ci.json` allowlist, or `.snyk` entry without these is incomplete. Reject your own work if any of the five is missing.
+
+### Step 7: Commit and Document
+
+- Upgrade commit: `fix(deps): bump <pkg> to <version> for <CVE-id>`
+- Suppression commit: include the GitHub issue number, and the issue must encode the review date as a label or due date so it is rediscoverable.
+
+## Examples
+
+### Example 1: Direct npm Dependency, Patched Version Available
+
+**Alert**: `lodash 4.17.20` has CVE-2021-23337 (high). Fixed in `>= 4.17.21`.
+
+```bash
+$ npm view lodash version
+4.17.21
+$ npm install lodash@4.17.21
+$ npm audit                # passes
+$ npm test                 # passes
+```
+
+Commit: `fix(deps): bump lodash to 4.17.21 for CVE-2021-23337`.
+
+### Example 2: Transitive Python Dependency
+
+**Alert**: `urllib3 1.26.5` (transitive via `requests`) has GHSA-v845-jxx5-vc9f. Fixed in `>= 1.26.18`.
+
+```bash
+$ pip index versions urllib3
+Available versions: 2.2.3, 2.2.2, ..., 1.26.20, 1.26.18
+$ pip show requests | grep Requires      # confirms requests pins urllib3<2
+$ uv add "urllib3>=1.26.18,<2"
+$ uv lock && uv sync
+$ pip-audit                              # passes
+```
+
+### Example 3: No Patch Available — Genuine Last Resort
+
+**Alert**: `obscure-lib 0.3.1` has CVE-2025-XXXXX. No fixed version listed.
+
+```bash
+$ npm view obscure-lib version
+0.3.1                                    # latest is still vulnerable
+$ gh api /advisories/GHSA-xxxx-yyyy-zzzz --jq '.vulnerabilities[].patched_versions'
+""                                       # no patch exists
+$ gh search issues --repo upstream/obscure-lib "CVE-2025-XXXXX"
+# Found: upstream/obscure-lib#42 — fix in progress
+```
+
+Open project issue, link to upstream issue #42, set review date 30 days out, suppress using the template in `references/suppression-template.md`.
+
+## Troubleshooting
+
+### Error: "I'm sure version X.Y.Z is the latest"
+
+You are not. Run the registry lookup command from Step 2. Training data lag is the single most common reason this skill exists.
+
+### Error: "The override didn't change the resolved version"
+
+Override syntax wrong, or lockfile not regenerated. After editing the override:
+
+- npm: delete `node_modules` and `package-lock.json`, then `npm install`
+- pnpm: `pnpm install --force`
+- Cargo: `cargo update`
+- Verify with `<package-manager> ls <pkg>` or `cargo tree -i <pkg>`.
+
+### Error: "Tests break after the upgrade"
+
+Not a reason to suppress. Read the changelog, fix the breakage. If a major version jump is too disruptive right now, pin to the highest minor / patch within your current major that contains the fix.
+
+### Error: "The vulnerable code path is unreachable from our app"
+
+Reachability is supporting evidence for prioritization, never a substitute for upgrading when a fix exists. Reachability arguments belong only in Step 6, when no fix exists at all.
+
+### Error: "Just adding the suppression and an issue is faster"
+
+Yes, and the suppression has no expiry the tooling enforces. Every "temporary" suppression added without an enforced review date is a permanent unfixed CVE wearing a costume.

--- a/.claude/skills/cve-remediation/references/registry-lookups.md
+++ b/.claude/skills/cve-remediation/references/registry-lookups.md
@@ -1,0 +1,147 @@
+# Live Registry Lookups
+
+Your training data is stale. Always query the registry. CLI commands are preferred when available; HTTP fallbacks let you confirm versions when the package manager is not installed in the current environment.
+
+## npm / pnpm / yarn (npm registry)
+
+```bash
+# Latest version
+npm view <pkg> version
+
+# All versions, newest last
+npm view <pkg> versions --json
+
+# Latest version of a specific dist-tag
+npm view <pkg> dist-tags
+
+# HTTP fallback (no Node toolchain required)
+curl -s "https://registry.npmjs.org/<pkg>/latest" | jq -r '.version'
+curl -s "https://registry.npmjs.org/<pkg>" | jq -r '.["dist-tags"].latest'
+```
+
+## PyPI (Python)
+
+```bash
+# Latest version (modern pip)
+pip index versions <pkg>
+
+# Show installed and latest in one go
+pip install <pkg>==                      # error message lists all versions
+
+# HTTP fallback
+curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.version'
+curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.releases | keys[]' | sort -V | tail
+```
+
+## crates.io (Rust)
+
+```bash
+cargo search <pkg> --limit 1
+
+# HTTP fallback
+curl -s "https://crates.io/api/v1/crates/<pkg>" | jq -r '.crate.max_stable_version'
+```
+
+## Go modules
+
+```bash
+go list -m -versions <module>            # space-separated, oldest first
+
+# HTTP fallback (proxy)
+curl -s "https://proxy.golang.org/<module>/@latest" | jq -r '.Version'
+curl -s "https://proxy.golang.org/<module>/@v/list"   # all versions
+```
+
+Lowercase module path components that contain capitals: `proxy.golang.org` requires `!` escaping (e.g. `gitHub.com` -> `git!hub.com`). Easier path: use `go list`.
+
+## Maven Central (Java / Kotlin / Scala)
+
+```bash
+# Latest version of group:artifact
+curl -s "https://search.maven.org/solrsearch/select?q=g:<group>+AND+a:<artifact>&rows=1&wt=json" \
+  | jq -r '.response.docs[0].latestVersion'
+
+# All versions
+curl -s "https://search.maven.org/solrsearch/select?q=g:<group>+AND+a:<artifact>&core=gav&rows=50&wt=json" \
+  | jq -r '.response.docs[].v'
+```
+
+## RubyGems
+
+```bash
+gem search -re <pkg>                     # remote, exact match
+
+# HTTP fallback
+curl -s "https://rubygems.org/api/v1/gems/<pkg>.json" | jq -r '.version'
+curl -s "https://rubygems.org/api/v1/versions/<pkg>.json" | jq -r '.[].number'
+```
+
+## NuGet (.NET)
+
+```bash
+# HTTP — flat container index, last entry is the latest
+curl -s "https://api.nuget.org/v3-flatcontainer/<pkg-lowercase>/index.json" \
+  | jq -r '.versions[-1]'
+```
+
+## Packagist (PHP / Composer)
+
+```bash
+composer show <pkg> --available --no-interaction
+
+# HTTP fallback
+curl -s "https://repo.packagist.org/p2/<vendor>/<pkg>.json" \
+  | jq -r '.packages."<vendor>/<pkg>"[0].version'
+```
+
+## Hex (Elixir / Erlang)
+
+```bash
+mix hex.info <pkg>
+
+# HTTP fallback
+curl -s "https://hex.pm/api/packages/<pkg>" | jq -r '.releases[0].version'
+```
+
+## Pub (Dart / Flutter)
+
+```bash
+curl -s "https://pub.dev/api/packages/<pkg>" | jq -r '.latest.version'
+```
+
+## Container images (Trivy / Grype findings)
+
+When the alert is on a base image rather than a language package:
+
+```bash
+# Docker Hub tags
+curl -s "https://hub.docker.com/v2/repositories/<org>/<image>/tags/?page_size=50&ordering=last_updated" \
+  | jq -r '.results[].name'
+
+# GitHub Container Registry
+gh api "/orgs/<org>/packages/container/<image>/versions" --jq '.[].metadata.container.tags[]'
+```
+
+## Advisory Databases
+
+Confirm the *patched-in* version, not just the latest:
+
+```bash
+# GitHub Security Advisories
+gh api /advisories/<GHSA-id> --jq '{summary, severity, vulnerabilities: .vulnerabilities[] | {package, vulnerable_version_range, patched_versions, ecosystem: .package.ecosystem}}'
+
+# OSV.dev (cross-ecosystem)
+curl -s https://api.osv.dev/v1/vulns/<id> | jq '{summary, affected: .affected[] | {package: .package, ranges: .ranges, fixed: [.ranges[].events[] | select(.fixed) | .fixed]}}'
+
+# NVD (CVE-only)
+curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=<CVE-id>" | jq '.vulnerabilities[0].cve.descriptions[0].value'
+```
+
+## Verifying You Got the Live Answer
+
+Two sanity checks before acting:
+
+1. The version returned is greater than the version installed locally. If they match, you may be looking at a cached metadata file — retry without cache (`npm view --no-cache`, `pip cache purge`).
+2. The publish date on the latest version is recent. `npm view <pkg> time.modified` and `pip show <pkg>` (after install) confirm freshness.
+
+If a registry call fails or returns stale-looking data, prefer to escalate over guessing. A wrong version number causes either an unnecessary suppression or a broken upgrade.

--- a/.claude/skills/cve-remediation/references/suppression-template.md
+++ b/.claude/skills/cve-remediation/references/suppression-template.md
@@ -1,0 +1,133 @@
+# Suppression Template (Last Resort)
+
+Use ONLY after Steps 2-5 of `SKILL.md` have been exhausted. A suppression that omits any of the five required fields is incomplete and must not be merged.
+
+## Required Fields
+
+Every suppression — wherever it lives (`audit-ci.json`, `.snyk`, `pip-audit --ignore-vuln`, `cargo-deny.toml`, `go.work` exclusions, GitHub Dependabot dismissals, inline tool comments) — must carry these five fields, either inline or in a linked tracking issue:
+
+1. **Advisory ID** — `CVE-YYYY-NNNNN`, `GHSA-xxxx-xxxx-xxxx`, or `OSV-YYYY-NNNN` plus a link to the canonical advisory page.
+2. **Why no upgrade exists** — one sentence stating that the latest registry version is still vulnerable, plus a link to the upstream tracking issue or PR.
+3. **Reachability and exposure assessment** — whether the vulnerable code path is reachable from this app, what data it touches, and what the realistic blast radius is.
+4. **Review date** — concrete ISO 8601 date, no more than 30 days from today. Encoded as a label or due date on the tracking issue so it is rediscoverable.
+5. **Tracking issue** — link to the project issue created to re-evaluate. The issue references the upstream tracking link and carries the review date.
+
+## Justification Block (paste into the suppression file)
+
+```text
+Advisory:        <CVE / GHSA / OSV id>            (<link>)
+Latest version:  <version>  confirmed via <registry command>  on <YYYY-MM-DD>
+Patched in:      none yet
+Upstream:        <link to upstream issue or PR>
+Reachability:    <reachable | not reachable | unknown>  - <one-line evidence>
+Exposure:        <data touched, runtime context, public/internal>
+Reviewed by:     <name>                                       on <YYYY-MM-DD>
+Review by:       <YYYY-MM-DD>   (issue: <link>)
+```
+
+## Per-Tool Examples
+
+### `audit-ci.json` (npm / pnpm / yarn)
+
+```json
+{
+  "high": true,
+  "allowlist": [
+    {
+      "advisory": "GHSA-xxxx-yyyy-zzzz",
+      "comment": "Latest obscure-lib (0.3.1) still vulnerable. Upstream fix in obscure-lib#42. Not reachable from runtime (build-only). Review by 2026-05-30, tracking issue #138."
+    }
+  ]
+}
+```
+
+### `.snyk`
+
+```yaml
+ignore:
+  SNYK-JS-OBSCURELIB-12345:
+    - "*":
+        reason: |
+          Latest obscure-lib 0.3.1 still vulnerable (verified 2026-05-02 via npm view).
+          Upstream fix in obscure-lib#42. Build-only path, not reachable at runtime.
+          Tracking: github.com/our-org/our-repo/issues/138.
+        expires: 2026-05-30T00:00:00.000Z
+```
+
+### `pip-audit`
+
+```bash
+pip-audit --ignore-vuln GHSA-xxxx-yyyy-zzzz \
+  --desc "obscure-lib 0.3.1 latest, no patch; upstream PR #42; review 2026-05-30; issue #138"
+```
+
+Prefer encoding the same justification in a checked-in `pyproject.toml` block so it survives across runs:
+
+```toml
+[tool.pip-audit]
+# obscure-lib 0.3.1 latest, no patch yet.
+# Upstream: https://github.com/upstream/obscure-lib/pull/42
+# Reachability: build-time only.
+# Tracking issue: #138, review by 2026-05-30.
+ignore-vulns = ["GHSA-xxxx-yyyy-zzzz"]
+```
+
+### `cargo-deny.toml`
+
+```toml
+[advisories]
+ignore = [
+  # GHSA-xxxx-yyyy-zzzz: obscure-crate 0.3.1 latest, no patch yet.
+  # Upstream: https://github.com/upstream/obscure-crate/issues/42
+  # Reachability: not exercised in our binary (feature-gated).
+  # Tracking: #138, review by 2026-05-30.
+  "RUSTSEC-2025-XXXX",
+]
+```
+
+### Dependabot (`.github/dependabot.yml`)
+
+Dependabot does not natively support time-boxed ignores; encode the review date in the tracking issue title and re-enable the alert when revisiting.
+
+```yaml
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule: { interval: "weekly" }
+    ignore:
+      - dependency-name: "obscure-lib"
+        # Tracking: #138 (review 2026-05-30) - latest 0.3.1 still vulnerable
+```
+
+## Tracking Issue Template
+
+Title: `[CVE] <advisory-id> in <package> — review by <YYYY-MM-DD>`
+
+Body:
+
+```markdown
+**Advisory:** <link>
+**Package:** <ecosystem>/<package> @ <currently-installed-version>
+**Latest registry version:** <version> (confirmed <YYYY-MM-DD>)
+**Patched in:** none yet
+**Upstream tracking:** <link to upstream issue/PR>
+
+**Reachability:** <reachable | not reachable | unknown>
+<one paragraph evidence>
+
+**Exposure:** <data touched, runtime context, public/internal>
+
+**Suppression location:** `<path/to/file>` line <N>
+
+**Review by:** <YYYY-MM-DD>
+On the review date, re-run the scanner and check the upstream tracking link.
+If a patched version exists, remove the suppression and upgrade.
+If still no patch, re-justify and bump the review date by no more than 30 days,
+or escalate to the security team.
+```
+
+Apply labels: `security`, `cve-suppression`, and a date label (e.g. `review:2026-05-30`) so the backlog can be queried.
+
+## What This Template is NOT
+
+This is not a substitute for upgrading. If you find yourself filling it out without having completed Steps 2-5 of the main workflow, stop and go back. The completeness of this paperwork has zero correlation with the soundness of the suppression — only the upstream registry state and your reachability analysis do.

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: documentation
+description: >-
+  Write clear, comprehensive documentation with language-specific patterns.
+  Use when writing docstrings, module docs, README files, API references,
+  or architecture decision records. Covers Python, TypeScript, Go, and Rust
+  documentation conventions. Do NOT use for code style (use vibe skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Documentation
+
+Create clear, comprehensive documentation that serves as a reliable reference for both humans and AI agents.
+
+## Instructions
+
+### Step 1: Follow the Principles
+
+1. Write for your future self (you will forget)
+2. Document the "why", not just the "what"
+3. Keep documentation close to code
+4. Use examples liberally
+5. Update docs when changing code
+6. Make documentation searchable and navigable
+
+### Step 2: Apply Language-Specific Patterns
+
+See `references/` for detailed patterns:
+- `references/python-patterns.md` - Google-style docstrings, module docs
+- `references/typescript-patterns.md` - TSDoc comments, README sections
+- `references/go-patterns.md` - Package and function documentation
+- `references/rust-patterns.md` - Doc comments with examples
+
+### Step 3: Verify Completeness
+
+Use the documentation checklist:
+- [ ] All public functions have docstrings
+- [ ] All public classes have class docstrings
+- [ ] Module has module-level docstring
+- [ ] All parameters documented
+- [ ] Return values documented
+- [ ] All exceptions documented
+- [ ] At least one example provided
+- [ ] Complex logic has inline comments
+- [ ] Error messages are clear and actionable
+
+## Examples
+
+### Example 1: Python Function Documentation
+
+```python
+def process_file(
+    input_path: Path,
+    output_path: Path,
+    *,
+    encoding: str = "utf-8",
+    validate: bool = True,
+) -> dict[str, int]:
+    """Process input file and write results to output file.
+
+    Args:
+        input_path: Path to input file. Must exist and be readable.
+        output_path: Path to output file. Parent directory must exist.
+        encoding: Character encoding for file I/O. Defaults to UTF-8.
+        validate: Whether to validate input before processing.
+
+    Returns:
+        Dictionary with 'lines_processed', 'tokens_found', 'errors_encountered'.
+
+    Raises:
+        FileNotFoundError: If input_path does not exist.
+        ValueError: If validate=True and input content is invalid.
+
+    Examples:
+        >>> result = process_file(Path("input.txt"), Path("output.txt"))
+        >>> print(f"Processed {result['lines_processed']} lines")
+    """
+```
+
+### Example 2: Anti-Pattern vs Good Documentation
+
+**Bad** - documents implementation:
+```python
+def fetch_user(user_id: str) -> User:
+    """First we check the cache using a dict lookup.
+    If not found, we make an HTTP GET request to /api/users/{id}.
+    Then we parse the JSON response using json.loads()."""
+```
+
+**Good** - documents interface:
+```python
+def fetch_user(user_id: str) -> User:
+    """Retrieve user by ID from API.
+
+    Fetches user data from the API, using cache when available.
+
+    Args:
+        user_id: Unique user identifier
+
+    Returns:
+        User object with profile data
+
+    Raises:
+        UserNotFoundError: If user doesn't exist
+
+    Note:
+        Results are cached for 5 minutes.
+    """
+```
+
+## Troubleshooting
+
+### Error: Documentation gets stale after code changes
+- Update docs in the same commit as code changes
+- Add docstring checks to CI (e.g., interrogate for Python)
+- Review docstrings during PR review
+
+### Error: Documentation is too verbose
+- Focus on the "what" and "why", not the "how"
+- Use type hints to reduce parameter description length
+- Link to detailed examples instead of inlining them

--- a/.claude/skills/documentation/references/go-patterns.md
+++ b/.claude/skills/documentation/references/go-patterns.md
@@ -1,0 +1,75 @@
+# Go Documentation Patterns
+
+## Package Documentation
+
+```go
+// Package config provides configuration management for applications.
+//
+// This package supports loading configuration from JSON, YAML, and TOML files,
+// with environment-specific overrides and validation.
+//
+// Basic Usage
+//
+//	manager, err := config.NewManager("config.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	apiKey := manager.Get("api_key")
+//
+// Environment Overrides
+//
+//	export APP_API_KEY="override-key"
+//
+// See examples/ directory for complete usage examples.
+package config
+```
+
+## Function Documentation
+
+```go
+// LoadConfig loads configuration from the specified file path.
+//
+// Supports JSON, YAML, and TOML formats based on file extension.
+// Automatically applies environment variable overrides.
+//
+// Parameters:
+//   - path: Path to configuration file. Must exist and be readable.
+//
+// Returns:
+//   - *Config: Loaded configuration object
+//   - error: FileNotFoundError if file doesn't exist,
+//     ValidationError if content is invalid
+//
+// Example:
+//
+//	config, err := LoadConfig("config.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println("API Key:", config.APIKey)
+func LoadConfig(path string) (*Config, error) {
+    // Implementation...
+}
+```
+
+## Struct Documentation
+
+```go
+// Manager manages application configuration with validation and hot-reloading.
+//
+// Thread Safety:
+// Manager is safe for concurrent reads. Reload operations acquire an
+// exclusive lock.
+//
+// Example:
+//
+//	manager, err := NewManager("config.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	apiKey := manager.Get("api_key")
+type Manager struct {
+    ConfigPath    string
+    CurrentConfig *Config
+}
+```

--- a/.claude/skills/documentation/references/python-patterns.md
+++ b/.claude/skills/documentation/references/python-patterns.md
@@ -1,0 +1,101 @@
+# Python Documentation Patterns
+
+## Google-Style Docstrings
+
+```python
+def process_file(
+    input_path: Path,
+    output_path: Path,
+    *,
+    encoding: str = "utf-8",
+    validate: bool = True,
+) -> dict[str, int]:
+    """Process input file and write results to output file.
+
+    Reads the input file, performs validation if enabled, processes
+    the content, and writes formatted results to the output file.
+
+    Args:
+        input_path: Path to input file. Must exist and be readable.
+        output_path: Path to output file. Parent directory must exist.
+        encoding: Character encoding for file I/O. Defaults to UTF-8.
+        validate: Whether to validate input before processing.
+            When True, raises ValueError for invalid input.
+            When False, attempts best-effort processing.
+
+    Returns:
+        Dictionary containing processing statistics:
+            - 'lines_processed': Number of lines processed
+            - 'tokens_found': Number of tokens extracted
+            - 'errors_encountered': Number of validation errors
+
+    Raises:
+        FileNotFoundError: If input_path does not exist.
+        PermissionError: If input_path is not readable or output_path
+            is not writable.
+        ValueError: If validate=True and input content is invalid.
+
+    Examples:
+        Basic usage:
+        >>> result = process_file(Path("input.txt"), Path("output.txt"))
+        >>> print(f"Processed {result['lines_processed']} lines")
+
+        Skip validation:
+        >>> result = process_file(
+        ...     Path("messy.txt"), Path("out.txt"), validate=False
+        ... )
+
+    Note:
+        Uses atomic writes. Output file is never in a partial state.
+
+    See Also:
+        process_file_streaming: Memory-efficient alternative for large files
+    """
+```
+
+## Class Docstrings
+
+```python
+class ConfigurationManager:
+    """Manage application configuration with validation and reloading.
+
+    Handles loading, validating, and hot-reloading of application
+    configuration from JSON or YAML files.
+
+    Attributes:
+        config_path: Path to primary configuration file.
+        current_config: Currently loaded configuration dictionary.
+
+    Examples:
+        >>> manager = ConfigurationManager("config.json")
+        >>> api_key = manager.get("api_key")
+        >>> timeout = manager.get("timeout", default=30)
+
+    Note:
+        Thread-safe for concurrent reads. Write operations (reload)
+        acquire an exclusive lock.
+    """
+```
+
+## Module-Level Docstrings
+
+```python
+"""Configuration management for the application.
+
+This module provides configuration loading, validation, and management
+utilities. Supports JSON, YAML, TOML formats and environment overrides.
+
+Key Components:
+    - ConfigurationManager: Primary configuration interface
+    - ConfigValidator: Schema validation for configurations
+
+Usage:
+    >>> from myapp.config import ConfigurationManager
+    >>> manager = ConfigurationManager("config.json")
+    >>> api_key = manager.get("api_key")
+
+Environment Variables:
+    APP_CONFIG_PATH: Override default configuration file path
+    APP_ENV: Environment name (dev, staging, production)
+"""
+```

--- a/.claude/skills/documentation/references/rust-patterns.md
+++ b/.claude/skills/documentation/references/rust-patterns.md
@@ -1,0 +1,80 @@
+# Rust Documentation Patterns
+
+## Function Doc Comments
+
+```rust
+/// Process input file and write results to output file.
+///
+/// Reads the input file, performs validation if enabled, processes the content,
+/// and writes formatted results to the output file.
+///
+/// # Arguments
+///
+/// * `input_path` - Path to input file. Must exist and be readable.
+/// * `output_path` - Path to output file. Parent directory must exist.
+/// * `validate` - Whether to validate input before processing.
+///
+/// # Returns
+///
+/// Returns `HashMap` containing processing statistics:
+/// - `lines_processed`: Number of lines processed
+/// - `tokens_found`: Number of tokens extracted
+///
+/// # Errors
+///
+/// Returns error if:
+/// - Input file doesn't exist (`io::ErrorKind::NotFound`)
+/// - Permission denied (`io::ErrorKind::PermissionDenied`)
+/// - Validation fails (when `validate=true`)
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+///
+/// let stats = process_file(
+///     Path::new("input.txt"),
+///     Path::new("output.txt"),
+///     true
+/// ).expect("Failed to process file");
+///
+/// println!("Processed {} lines", stats.get("lines_processed").unwrap());
+/// ```
+///
+/// # See Also
+///
+/// * [`process_file_streaming`] - Memory-efficient alternative
+pub fn process_file(
+    input_path: &Path,
+    output_path: &Path,
+    validate: bool,
+) -> Result<HashMap<String, usize>, Error> {
+    // Implementation...
+}
+```
+
+## Struct Doc Comments
+
+```rust
+/// Configuration manager for application settings.
+///
+/// Handles loading, validation, and hot-reloading from JSON/YAML files.
+///
+/// # Thread Safety
+///
+/// `ConfigManager` is safe for concurrent reads using `Arc` and `RwLock`.
+///
+/// # Examples
+///
+/// ```
+/// let manager = ConfigManager::new("config.json")?;
+/// let api_key = manager.get("api_key")?;
+/// ```
+pub struct ConfigManager {
+    /// Path to primary configuration file
+    pub config_path: PathBuf,
+
+    /// Currently loaded configuration (read-only access via getter)
+    current_config: Arc<RwLock<Config>>,
+}
+```

--- a/.claude/skills/documentation/references/typescript-patterns.md
+++ b/.claude/skills/documentation/references/typescript-patterns.md
@@ -1,0 +1,110 @@
+# TypeScript Documentation Patterns
+
+## TSDoc Comments
+
+```typescript
+/**
+ * Process user input and validate against schema.
+ *
+ * Performs comprehensive validation including type checking,
+ * format validation, and business rule enforcement.
+ *
+ * @param input - Raw user input data (may be any type)
+ * @param schema - JSON schema for validation
+ * @param options - Optional validation settings
+ * @returns Validated and typed user data
+ *
+ * @throws {ValidationError} When input fails validation
+ * @throws {SchemaError} When schema itself is invalid
+ *
+ * @example
+ * Basic validation:
+ * ```typescript
+ * const userData = processInput(
+ *   { email: 'user@example.com', age: 25 },
+ *   userSchema
+ * );
+ * ```
+ *
+ * @see {@link ValidationOptions} for available options
+ * @since 1.0.0
+ */
+export function processInput(
+  input: unknown,
+  schema: JSONSchema,
+  options?: ValidationOptions
+): UserData {
+  // Implementation...
+}
+```
+
+## Class Documentation
+
+```typescript
+/**
+ * Configuration manager for application settings.
+ *
+ * Handles loading, validation, and hot-reloading from JSON/YAML files.
+ * Supports environment-specific overrides and type-safe access.
+ *
+ * @example
+ * ```typescript
+ * const manager = new ConfigManager('config.json');
+ * const apiKey = manager.get('apiKey');
+ * ```
+ *
+ * @example
+ * With auto-reload:
+ * ```typescript
+ * const manager = new ConfigManager('config.json', {
+ *   autoReload: true,
+ *   onReload: (config) => console.log('Config reloaded')
+ * });
+ * ```
+ */
+export class ConfigManager {
+  /** Path to primary configuration file. */
+  public readonly configPath: string;
+
+  /**
+   * Create new configuration manager.
+   *
+   * @param configPath - Path to configuration file
+   * @param options - Optional configuration settings
+   * @throws {FileNotFoundError} If config file doesn't exist
+   */
+  constructor(configPath: string, options?: ConfigManagerOptions) {
+    // Implementation...
+  }
+}
+```
+
+## README Structure
+
+```markdown
+# Component Name
+
+## Overview
+Brief description.
+
+## Installation
+npm install @scope/component
+
+## Quick Start
+[Code example]
+
+## API Reference
+### `ClassName`
+#### Constructor
+#### Methods
+
+## Configuration
+### Environment Variables
+### Configuration File
+
+## Error Handling
+[Typed errors and how to handle them]
+
+## Examples
+See examples/ directory.
+```

--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: error-handling
+description: >-
+  Implement robust error handling that fails fast with clear diagnostics.
+  Use when designing error strategies, writing exception handling,
+  creating custom error types, or implementing validation. Covers
+  Python, TypeScript, Go, and Rust patterns.
+  Do NOT use for security-specific input validation (use security skill)
+  or for auditing/rewriting the wording of user-facing error messages
+  (use user-facing-error-messages skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Error Handling
+
+Fail fast with clear error messages. Use typed exceptions, include context, never silence errors.
+
+## Instructions
+
+### Step 1: Follow the Principles
+
+1. Fail fast with clear error messages
+2. Use typed exceptions/errors over generic ones
+3. Include context in error messages (what, where, why)
+4. Never silence errors without logging
+5. Validate inputs at boundaries
+6. Handle errors at the appropriate abstraction level
+
+### Step 2: Apply Language-Specific Patterns
+
+See `references/patterns-by-language.md` for detailed patterns in Python, TypeScript, Go, and Rust.
+
+Key patterns:
+- **Python**: Typed exceptions with context, context managers for cleanup, specific exception catching
+- **TypeScript**: Custom error classes, Result type pattern, Promise error handling
+- **Go**: Error wrapping with `fmt.Errorf` and `%w`, custom error types, immediate error checking
+- **Rust**: Custom error enums with `Display`, `?` operator for propagation, `map_err` for context
+
+### Step 3: Avoid Anti-Patterns
+
+- **Silent failures**: `except: pass` - always log or re-raise
+- **Generic catching**: `except Exception` - catch specific exceptions
+- **Bare except**: Catches KeyboardInterrupt and SystemExit
+- **No context**: `raise ValueError("Invalid")` - include what, where, why
+- **Error codes**: Return -1 on error - use exceptions/Result types
+
+## Examples
+
+See `references/examples.md` for complete worked examples.
+
+### Example 1: Python - Typed Exception with Context
+
+```python
+class ConfigurationError(Exception):
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        self.field = field
+        self.value = value
+        super().__init__(f"Invalid {field}={value!r}: {reason}")
+
+# Usage
+raise ConfigurationError(
+    field="timeout",
+    value="abc",
+    reason="Must be a positive integer",
+)
+```
+
+### Example 2: TypeScript - Result Type Pattern
+
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+function parseConfig(content: string): Result<Config> {
+  try {
+    const data = JSON.parse(content);
+    if (!isValidConfig(data)) {
+      return { ok: false, error: new Error('Invalid config structure') };
+    }
+    return { ok: true, value: data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error('Unknown error') };
+  }
+}
+```
+
+## Troubleshooting
+
+### Error: Too many exception types making code complex
+- Create a base exception for your module, subclass for specific cases
+- Use 3-5 exception types per module, not one per function
+- Group by category: ValidationError, NotFoundError, PermissionError
+
+### Error: Error messages aren't helpful for debugging
+- Include the failing value: `f"Invalid email: {email!r}"`
+- Include the location: `f"in {path.absolute()}`
+- Include the expectation: `f"expected positive integer, got {value}"`

--- a/.claude/skills/error-handling/references/examples.md
+++ b/.claude/skills/error-handling/references/examples.md
@@ -1,0 +1,115 @@
+# Error Handling Examples
+
+## Example 1: API Client Error Handling (Python)
+
+```python
+class APIError(Exception):
+    def __init__(self, message: str, status_code: int | None = None, response_body: str | None = None) -> None:
+        self.status_code = status_code
+        self.response_body = response_body
+        super().__init__(message)
+
+class APIClient:
+    def fetch_user(self, user_id: str) -> dict:
+        if not user_id or not user_id.strip():
+            raise ValueError(f"Invalid user_id: {user_id!r} (must be non-empty)")
+
+        url = f"{self.base_url}/users/{user_id}"
+
+        try:
+            response = requests.get(url, timeout=10)
+        except requests.Timeout as e:
+            raise APIError(f"Request to {url} timed out after 10s") from e
+        except requests.ConnectionError as e:
+            raise APIError(f"Failed to connect to {url}: {e}") from e
+
+        if response.status_code == 404:
+            raise APIError(f"User not found: {user_id}", status_code=404, response_body=response.text)
+
+        if not response.ok:
+            raise APIError(f"API error for {url}: HTTP {response.status_code}", status_code=response.status_code)
+
+        try:
+            return response.json()
+        except ValueError as e:
+            raise APIError(f"Invalid JSON from {url}: {e}", status_code=response.status_code) from e
+```
+
+## Example 2: File Processing with Cleanup (Python)
+
+```python
+def process_file_safely(input_path: Path, output_path: Path, processor: Callable[[bytes], bytes]) -> None:
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_path.absolute()}")
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="process_"))
+    temp_output = temp_dir / "output"
+
+    try:
+        try:
+            input_data = input_path.read_bytes()
+        except PermissionError as e:
+            raise IOError(f"Cannot read {input_path}: permission denied") from e
+
+        try:
+            output_data = processor(input_data)
+        except Exception as e:
+            raise ProcessingError(f"Failed to process {input_path}: {e}") from e
+
+        temp_output.write_bytes(output_data)
+        shutil.move(str(temp_output), str(output_path))
+    finally:
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+```
+
+## Example 3: Validation with Error Collection (TypeScript)
+
+```typescript
+interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+function validateRegistration(data: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['Expected object, got ' + typeof data] };
+  }
+
+  const { email, password, username } = data as Record<string, unknown>;
+
+  if (typeof email !== 'string' || !email.includes('@')) {
+    errors.push('Invalid email format');
+  }
+  if (typeof password !== 'string' || password.length < 8) {
+    errors.push('Password must be at least 8 characters');
+  }
+  if (typeof username !== 'string' || username.length < 3) {
+    errors.push('Username must be at least 3 characters');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+```
+
+## Error Logging Best Practices
+
+```python
+# Include structured context
+logger.error("Failed to process user data", extra={
+    "user_id": user_id,
+    "operation": "update_profile",
+    "error_type": type(e).__name__,
+})
+
+# Use appropriate levels
+# ERROR: Operation failed, needs attention
+# WARNING: Degraded operation
+# INFO: Normal operation events
+# DEBUG: Detailed diagnostics
+
+# Include stack traces for debugging
+logger.error("Critical error occurred", exc_info=True)
+```

--- a/.claude/skills/error-handling/references/patterns-by-language.md
+++ b/.claude/skills/error-handling/references/patterns-by-language.md
@@ -1,0 +1,175 @@
+# Error Handling Patterns by Language
+
+## Python
+
+### Typed Exceptions with Context
+```python
+class ConfigurationError(Exception):
+    def __init__(self, field: str, value: str, reason: str) -> None:
+        self.field = field
+        self.value = value
+        self.reason = reason
+        super().__init__(f"Invalid {field}={value!r}: {reason}")
+
+def load_config(path: Path) -> dict[str, str]:
+    if not path.exists():
+        raise FileNotFoundError(f"Config not found: {path.absolute()}")
+    content = path.read_text()
+    if not content.strip():
+        raise ValueError(f"Config file is empty: {path.absolute()}")
+    config = parse_config(content)
+    required = {"api_key", "base_url"}
+    missing = required - config.keys()
+    if missing:
+        raise ConfigurationError("required_fields", str(missing), "Missing required fields")
+    return config
+```
+
+### Context Managers for Resource Cleanup
+```python
+@contextmanager
+def atomic_write(path: Path) -> Iterator[Path]:
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        yield temp_path
+        temp_path.replace(path)
+    except Exception as e:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise IOError(f"Failed to write {path}: {e}") from e
+```
+
+### Specific Exception Catching
+```python
+try:
+    content = path.read_text()
+except FileNotFoundError:
+    raise FileNotFoundError(f"JSON file not found: {path.absolute()}")
+except PermissionError as e:
+    raise PermissionError(f"Cannot read {path.absolute()}: {e}") from e
+
+try:
+    data = json.loads(content)
+except json.JSONDecodeError as e:
+    raise ValueError(f"Invalid JSON in {path}: {e.msg} at line {e.lineno}") from e
+```
+
+## TypeScript
+
+### Custom Error Classes
+```typescript
+class ValidationError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+    message: string
+  ) {
+    super(`Validation failed for ${field}: ${message}`);
+    this.name = 'ValidationError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ValidationError);
+    }
+  }
+}
+```
+
+### Result Type Pattern
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+function parseConfig(content: string): Result<Config> {
+  try {
+    const data = JSON.parse(content);
+    if (!isValidConfig(data)) {
+      return { ok: false, error: new Error('Invalid configuration') };
+    }
+    return { ok: true, value: data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error('Unknown error') };
+  }
+}
+```
+
+### Promise Error Handling
+```typescript
+async function fetchUserData(userId: string): Promise<UserData> {
+  try {
+    const response = await fetch(`/api/users/${userId}`);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    return validateUserData(await response.json());
+  } catch (error) {
+    if (error instanceof ValidationError) throw error;
+    throw new Error(`Failed to fetch user ${userId}: ${error instanceof Error ? error.message : 'Unknown'}`);
+  }
+}
+```
+
+## Go
+
+### Error Wrapping with Context
+```go
+func LoadConfig(path string) (*Config, error) {
+    file, err := os.Open(path)
+    if err != nil {
+        return nil, fmt.Errorf("failed to open config %q: %w", path, err)
+    }
+    defer file.Close()
+
+    config, err := parseConfig(file)
+    if err != nil {
+        return nil, fmt.Errorf("failed to parse config from %q: %w", path, err)
+    }
+    return config, nil
+}
+```
+
+### Custom Error Types
+```go
+type ValidationError struct {
+    Field  string
+    Value  interface{}
+    Reason string
+}
+
+func (e *ValidationError) Error() string {
+    return fmt.Sprintf("validation failed for %s=%v: %s", e.Field, e.Value, e.Reason)
+}
+```
+
+## Rust
+
+### Custom Error Enums
+```rust
+#[derive(Debug)]
+pub enum ConfigError {
+    NotFound(String),
+    ParseError(String),
+    ValidationError { field: String, reason: String },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConfigError::NotFound(path) => write!(f, "Config not found: {}", path),
+            ConfigError::ParseError(msg) => write!(f, "Parse failed: {}", msg),
+            ConfigError::ValidationError { field, reason } => write!(f, "Validation failed for {}: {}", field, reason),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+```
+
+### The ? Operator with Context
+```rust
+fn load_config(path: &str) -> Result<Config, String> {
+    let contents = read_file_contents(path)
+        .map_err(|e| format!("Failed to read config from {}: {}", path, e))?;
+    parse_config(&contents)
+        .map_err(|e| format!("Failed to parse config from {}: {}", path, e))
+}
+```

--- a/.claude/skills/frontend-aesthetics/SKILL.md
+++ b/.claude/skills/frontend-aesthetics/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: frontend-aesthetics
+description: >-
+  Produce polished, accessible frontend UI with design tokens, semantic
+  HTML, and Pico CSS. Use when creating HTML templates, adding CSS,
+  building user-facing pages, or working with Jinja2 templates.
+  Covers design tokens, typography, components, accessibility (WCAG 2.1 AA),
+  dark mode, and micro-interactions.
+  Do NOT use for backend API design or data modeling.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Frontend Aesthetics
+
+The difference between "works" and "wow" is 20 lines of CSS and semantic HTML choices.
+
+## Instructions
+
+### Step 1: Follow the Core Philosophy
+
+1. **Design with tokens, not magic numbers** - every value from a system
+2. **Semantic HTML is the foundation** - right element gets 80% of the way
+3. **Accessibility is not optional** - WCAG 2.1 AA minimum
+4. **Motion is meaning** - animate to communicate; respect `prefers-reduced-motion`
+5. **Dark mode is table stakes** - use CSS custom properties
+
+### Step 2: Use the Design Token System
+
+See `references/design-tokens.md` for the complete token system including colors, spacing, typography, shadows, and dark mode adaptation.
+
+Key rules:
+- Never use raw hex codes or pixel values in component styles
+- All colors from tokens or Pico defaults
+- All spacing uses `--space-*` tokens (8px rhythm)
+- Typography uses `clamp()` for fluid scaling
+
+### Step 3: Build with Component Patterns
+
+See `references/component-patterns.md` for cards, badges, forms, alerts, and layout patterns.
+
+### Step 4: Ensure Accessibility (Non-Negotiable)
+
+- **Color contrast**: 4.5:1 for body text, 3:1 for large text
+- **Focus management**: Visible `:focus-visible` ring on all interactive elements
+- **Motion safety**: `prefers-reduced-motion` rule in every template
+- **Semantic HTML**: `<nav>`, `<article>`, `<section>`, `role="alert"` for errors
+- **Touch targets**: Minimum 44px (2.75rem)
+
+### Step 5: Use the Pre-Ship Checklist
+
+- [ ] All colors from tokens or Pico defaults
+- [ ] All spacing uses `--space-*` tokens
+- [ ] Page has exactly one `<h1>`; heading levels don't skip
+- [ ] All interactive elements have `:focus-visible` states
+- [ ] `prefers-reduced-motion` is respected
+- [ ] `role="alert"` on error messages
+- [ ] No text wider than ~65ch
+- [ ] Touch targets >= 44px
+- [ ] Dark mode works (toggle `data-theme`)
+
+## Examples
+
+### Example 1: Jinja2 Card Grid with Conditional Badges
+
+```html
+<div class="card-grid">
+    {% for item in items %}
+    <article class="card {{ 'card-highlighted' if item.featured else '' }}">
+        <h3>{{ item.title }}</h3>
+        <p>{{ item.description }}</p>
+        {% if item.severity == 'high' %}
+            <span class="badge badge-danger">High</span>
+        {% elif item.severity == 'medium' %}
+            <span class="badge badge-warning">Medium</span>
+        {% endif %}
+    </article>
+    {% endfor %}
+</div>
+```
+
+### Example 2: Accessible Error Display
+
+```html
+{% if error %}
+<div class="alert alert-error" role="alert" aria-live="assertive">
+    <strong>Error:</strong> {{ error }}
+</div>
+{% endif %}
+```
+
+## Troubleshooting
+
+### Error: Colors look wrong in dark mode
+- Verify you're using CSS custom properties, not hardcoded colors
+- Check that dark mode tokens override light mode values
+- Test with both `prefers-color-scheme: dark` and `data-theme="dark"`
+
+### Error: Layout breaks on mobile
+- Use `min(72rem, 100% - var(--space-xl) * 2)` for containers
+- Use `100dvh` instead of `100vh` for full-height layouts
+- Use `minmax(min(250px, 100%), 1fr)` for grid columns

--- a/.claude/skills/frontend-aesthetics/references/component-patterns.md
+++ b/.claude/skills/frontend-aesthetics/references/component-patterns.md
@@ -1,0 +1,154 @@
+# Component Patterns
+
+## Cards
+
+```css
+.card {
+    background: var(--surface-1);
+    border: 1px solid var(--surface-3);
+    border-radius: var(--radius-md);
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow var(--duration-normal) var(--ease-out),
+                transform var(--duration-normal) var(--ease-out);
+}
+.card:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+@media (prefers-reduced-motion: reduce) {
+    .card:hover { transform: none; }
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(250px, 100%), 1fr));
+    gap: var(--space-lg);
+}
+```
+
+## Badges / Tags
+
+```css
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    line-height: 1;
+    border-radius: var(--radius-full);
+    white-space: nowrap;
+}
+.badge-danger  { background: hsl(0 72% 51% / 0.12);   color: hsl(0 72% 40%); }
+.badge-warning { background: hsl(38 92% 50% / 0.12);   color: hsl(38 70% 35%); }
+.badge-success { background: hsl(145 63% 42% / 0.12);  color: hsl(145 63% 30%); }
+.badge-info    { background: hsl(200 80% 50% / 0.12);  color: hsl(200 80% 35%); }
+```
+
+## Forms
+
+```css
+input, select, textarea {
+    border: 1.5px solid var(--surface-3);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm) var(--space-md);
+    font-size: var(--text-base);
+    background: var(--surface-1);
+    color: var(--text-1);
+    transition: border-color var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out);
+    min-height: 2.75rem;  /* 44px touch target */
+}
+input:focus-visible, select:focus-visible, textarea:focus-visible {
+    outline: none;
+    border-color: var(--brand);
+    box-shadow: var(--shadow-glow);
+}
+button, [type="submit"] {
+    min-height: 2.75rem;
+    padding: var(--space-sm) var(--space-xl);
+    font-weight: 600;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+}
+```
+
+## Alerts
+
+```css
+.alert {
+    padding: var(--space-md) var(--space-lg);
+    border-radius: var(--radius-md);
+    border-left: 4px solid;
+}
+.alert-error   { background: hsl(0 72% 51% / 0.08); border-color: var(--color-danger); }
+.alert-success { background: hsl(145 63% 42% / 0.08); border-color: var(--color-success); }
+.alert-info    { background: hsl(200 80% 50% / 0.08); border-color: var(--color-info); }
+```
+
+## Layout
+
+```css
+body { min-height: 100dvh; display: flex; flex-direction: column; background: var(--surface-2); }
+main { flex: 1; }
+footer { margin-top: auto; }
+
+.container { width: min(72rem, 100% - var(--space-xl) * 2); margin-inline: auto; }
+```
+
+## Accessibility Essentials
+
+```css
+:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
+:focus:not(:focus-visible) { outline: none; }
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+.sr-only {
+    position: absolute; width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+```
+
+## Micro-Interactions
+
+```css
+/* Page entrance */
+main { animation: fadeUp var(--duration-normal) var(--ease-out); }
+@keyframes fadeUp { from { opacity: 0; transform: translateY(8px); } }
+
+/* Skeleton loading */
+.skeleton-line {
+    height: 1em;
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, var(--surface-3) 25%, var(--surface-2) 50%, var(--surface-3) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+}
+@keyframes shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+
+/* Staggered card entrance */
+.card-grid > :nth-child(1) { animation-delay: 0ms; }
+.card-grid > :nth-child(2) { animation-delay: 50ms; }
+.card-grid > :nth-child(3) { animation-delay: 100ms; }
+.card-grid > * { animation: fadeUp var(--duration-normal) var(--ease-out) backwards; }
+```
+
+## Semantic HTML Quick Reference
+
+| Need | Use | NOT |
+|------|-----|-----|
+| Navigation | `<nav>` | `<div class="nav">` |
+| Page section | `<section>` with heading | `<div>` |
+| Self-contained | `<article>` | `<div class="card">` |
+| Error alert | `<div role="alert">` | `<div class="error">` |
+| Loading | `aria-busy="true"` | No indication |
+| Icon button | `<button aria-label="Close">` | `<button>X</button>` |

--- a/.claude/skills/frontend-aesthetics/references/design-tokens.md
+++ b/.claude/skills/frontend-aesthetics/references/design-tokens.md
@@ -1,0 +1,108 @@
+# Design Token System
+
+## Color Tokens
+
+```css
+:root {
+    /* Brand */
+    --brand-hue: 220;
+    --brand: hsl(var(--brand-hue) 70% 50%);
+    --brand-light: hsl(var(--brand-hue) 70% 92%);
+    --brand-dark: hsl(var(--brand-hue) 70% 30%);
+
+    /* Semantic */
+    --color-success: hsl(145 63% 42%);
+    --color-warning: hsl(38 92% 50%);
+    --color-danger: hsl(0 72% 51%);
+    --color-info: hsl(200 80% 50%);
+
+    /* Surface & Text (light mode) */
+    --surface-1: hsl(0 0% 100%);
+    --surface-2: hsl(0 0% 97%);
+    --surface-3: hsl(0 0% 93%);
+    --text-1: hsl(0 0% 10%);
+    --text-2: hsl(0 0% 35%);
+    --text-muted: hsl(0 0% 55%);
+
+    /* Shadows */
+    --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.05);
+    --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.08);
+    --shadow-lg: 0 12px 32px hsl(0 0% 0% / 0.12);
+    --shadow-glow: 0 0 0 3px hsl(var(--brand-hue) 70% 50% / 0.25);
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --surface-1: hsl(220 15% 12%);
+        --surface-2: hsl(220 15% 16%);
+        --surface-3: hsl(220 15% 21%);
+        --text-1: hsl(0 0% 93%);
+        --text-2: hsl(0 0% 72%);
+        --text-muted: hsl(0 0% 50%);
+        --brand-light: hsl(var(--brand-hue) 50% 20%);
+        --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.2);
+        --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.3);
+        --shadow-lg: 0 12px 32px hsl(0 0% 0% / 0.4);
+    }
+}
+```
+
+## Spacing Tokens (8px rhythm)
+
+```css
+:root {
+    --space-xs: 0.25rem;   /* 4px */
+    --space-sm: 0.5rem;    /* 8px */
+    --space-md: 1rem;      /* 16px */
+    --space-lg: 1.5rem;    /* 24px */
+    --space-xl: 2rem;      /* 32px */
+    --space-2xl: 3rem;     /* 48px */
+    --space-3xl: 4rem;     /* 64px */
+}
+```
+
+## Typography Tokens (major third scale: 1.25)
+
+```css
+:root {
+    --text-xs: clamp(0.7rem, 0.66rem + 0.2vw, 0.8rem);
+    --text-sm: clamp(0.8rem, 0.76rem + 0.2vw, 0.9rem);
+    --text-base: clamp(0.95rem, 0.91rem + 0.2vw, 1.05rem);
+    --text-lg: clamp(1.125rem, 1.05rem + 0.35vw, 1.3rem);
+    --text-xl: clamp(1.4rem, 1.3rem + 0.5vw, 1.65rem);
+    --text-2xl: clamp(1.75rem, 1.6rem + 0.75vw, 2.1rem);
+    --text-3xl: clamp(2.2rem, 2rem + 1vw, 2.8rem);
+}
+```
+
+## Radius and Transition Tokens
+
+```css
+:root {
+    --radius-sm: 0.375rem;
+    --radius-md: 0.625rem;
+    --radius-lg: 1rem;
+    --radius-full: 9999px;
+
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --duration-fast: 150ms;
+    --duration-normal: 250ms;
+}
+```
+
+## Typography Rules
+
+1. Maximum two font weights: 400 (regular) and 600 (semibold)
+2. Line height: 1.6 for body, 1.2 for headings
+3. Max width: 65ch for body text
+4. One `<h1>` per page, never skip heading levels
+5. Use `clamp()` tokens for fluid scaling
+
+```css
+body { font-size: var(--text-base); line-height: 1.6; color: var(--text-1); }
+h1, h2, h3 { line-height: 1.2; letter-spacing: -0.02em; }
+h1 { font-size: var(--text-3xl); }
+h2 { font-size: var(--text-2xl); }
+h3 { font-size: var(--text-xl); }
+```

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: git-workflow
+description: >-
+  Issue-first development workflow with template-file-based gh commands and
+  label hygiene. Use when creating issues, starting new work, making branches,
+  committing changes, or opening PRs. Covers the full issue-to-PR lifecycle
+  using file-based templates instead of inline strings. Do NOT use for
+  bug-specific debugging or RCA (use bug-squashing-methodology), PR code review
+  (use comprehensive-pr-review), or backlog cleanup and issue triage (use
+  backlog-grooming).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Git Workflow
+
+Issue-first development: every change starts with an issue, flows through a branch, and lands via a PR. Use template files for all gh commands instead of inline strings.
+
+## Instructions
+
+### Step 1: Check for Existing Issue
+
+Before any work, search for an existing issue:
+
+```bash
+gh issue list --search "keyword" --state open
+gh issue list --search "keyword" --state all
+```
+
+- If an issue exists, reference it and skip to Step 4.
+- If no issue exists, confirm with the user before creating one.
+
+### Step 2: Label Hygiene
+
+Before creating an issue, check existing labels:
+
+```bash
+gh label list
+```
+
+- Use an existing label if one fits.
+- Create a new label only if no similar one exists:
+  ```bash
+  gh label create "label-name" --description "What it covers" --color "hex"
+  ```
+
+### Step 3: Create Issue via Template File
+
+Write the issue body to a file, then pass it to `gh`:
+
+```bash
+mkdir -p plans/github-issues
+# Write body to plans/github-issues/ISSUE_NNN_slug.md
+gh issue create \
+  --title "type(scope): Brief description" \
+  --body-file plans/github-issues/ISSUE_NNN_slug.md \
+  --label "label1,label2"
+```
+
+Never inline long strings into `--body`. See `references/templates.md` for the issue body structure.
+
+After creation, note the issue number for branch naming and commit references.
+
+### Step 4: Branch from Issue
+
+Create a branch referencing the issue number:
+
+```bash
+git checkout -b type/short-description-NNN
+```
+
+Branch type prefixes:
+- `feat/` — new feature
+- `fix/` — bug fix
+- `chore/` — maintenance, deps, config
+- `docs/` — documentation only
+
+Example: `feat/add-user-search-42`, `fix/pagination-offset-87`
+
+### Step 5: Commit via Message File
+
+Write the commit message to a temp file, then commit with `-F`:
+
+```bash
+# Write message to plans/github-issues/COMMIT_NNN_slug.md
+git commit -F plans/github-issues/COMMIT_NNN_slug.md
+```
+
+Use conventional commit format in the message. See `references/templates.md` for the commit message structure.
+
+### Step 6: PR via Template File
+
+Write the PR body to a file, then create the PR:
+
+```bash
+# Write body to plans/github-issues/PR_NNN_slug.md
+gh pr create \
+  --title "type(scope): Brief description" \
+  --body-file plans/github-issues/PR_NNN_slug.md
+```
+
+The PR body must include `Closes #NNN` to auto-close the issue on merge. See `references/templates.md` for the PR body structure.
+
+### Step 7: Post-Merge Cleanup
+
+After the PR merges:
+
+```bash
+# Switch back to main and pull
+git checkout main && git pull
+
+# Delete the local branch
+git branch -d type/short-description-NNN
+
+# Verify the issue auto-closed
+gh issue view NNN --json state
+```
+
+## Examples
+
+### Example 1: Feature Development from Scratch
+
+User asks: "Add a /health endpoint to the API."
+
+**Search for existing issue:**
+```bash
+gh issue list --search "health endpoint" --state all
+# No results
+```
+
+**Confirm with user**, then check labels and create issue:
+```bash
+gh label list
+# "enhancement" exists, no need to create
+```
+
+Write `plans/github-issues/ISSUE_52_health-endpoint.md`:
+```markdown
+## Problem
+
+The API has no health check endpoint. Load balancers and monitoring tools
+need a lightweight endpoint to verify the service is running.
+
+## Proposed Solution
+
+Add a `GET /health` endpoint that returns `200 OK` with a JSON body
+containing service status and version.
+
+## Acceptance Criteria
+
+- [ ] `GET /health` returns 200 with `{"status": "ok", "version": "x.y.z"}`
+- [ ] Response time under 50ms (no DB calls)
+- [ ] Endpoint is unauthenticated
+```
+
+```bash
+gh issue create \
+  --title "feat(api): Add /health endpoint" \
+  --body-file plans/github-issues/ISSUE_52_health-endpoint.md \
+  --label "enhancement"
+# Created issue #52
+```
+
+**Branch and work:**
+```bash
+git checkout -b feat/add-health-endpoint-52
+# ... implement the feature ...
+```
+
+**Commit via file** — write `plans/github-issues/COMMIT_52_health-endpoint.md`:
+```
+feat(api): add /health endpoint
+
+Add lightweight health check endpoint for load balancer and monitoring
+integration. Returns service status and version without hitting the
+database.
+
+Refs #52
+```
+
+```bash
+git commit -F plans/github-issues/COMMIT_52_health-endpoint.md
+```
+
+**PR via file** — write `plans/github-issues/PR_52_health-endpoint.md`:
+```markdown
+## Summary
+
+Add a `GET /health` endpoint that returns service status and version
+for load balancer health checks.
+
+## Changes
+
+- Added `GET /health` route in `src/routes/health.ts`
+- Returns `{"status": "ok", "version": "1.2.0"}`
+- No authentication required, no database calls
+
+## Test Plan
+
+- [ ] `curl localhost:3000/health` returns 200
+- [ ] Response body matches expected schema
+- [ ] Response time under 50ms
+
+Closes #52
+```
+
+```bash
+gh pr create \
+  --title "feat(api): Add /health endpoint" \
+  --body-file plans/github-issues/PR_52_health-endpoint.md
+```
+
+### Example 2: Work Where Issue Already Exists
+
+User asks: "Fix the broken pagination on the users list."
+
+**Search for existing issue:**
+```bash
+gh issue list --search "pagination users" --state open
+# Found: #87 "bug: Users list pagination returns duplicates"
+```
+
+Issue #87 already exists — skip issue creation, go straight to branching:
+
+```bash
+git checkout -b fix/pagination-offset-87
+# ... fix the bug ...
+```
+
+**Commit via file** — write `plans/github-issues/COMMIT_87_pagination-fix.md`:
+```
+fix(users): correct pagination offset calculation
+
+Off-by-one error in offset: page * limit should be (page - 1) * limit
+since pages are 1-indexed.
+
+Fixes #87
+```
+
+```bash
+git commit -F plans/github-issues/COMMIT_87_pagination-fix.md
+```
+
+**PR via file** — write `plans/github-issues/PR_87_pagination-fix.md`:
+```markdown
+## Summary
+
+Fix off-by-one pagination bug causing duplicate items across pages.
+
+## Changes
+
+- Fixed offset calculation in `src/services/users.ts:45`
+- `offset = (page - 1) * limit` instead of `page * limit`
+
+## Test Plan
+
+- [ ] Page 1 and page 2 return no overlapping items
+- [ ] Last page returns correct number of items
+- [ ] Single-page result sets unaffected
+
+Closes #87
+```
+
+```bash
+gh pr create \
+  --title "fix(users): Correct pagination offset" \
+  --body-file plans/github-issues/PR_87_pagination-fix.md
+```
+
+## Troubleshooting
+
+### Error: No matching labels found
+
+If `gh label list` returns no relevant labels:
+1. Check if the repo uses a different labeling convention (e.g., `type:bug` vs `bug`).
+2. Create a new label only after confirming no similar one exists.
+3. Use descriptive names and colors consistent with existing labels.
+
+### Error: Issue already exists for this work
+
+If `gh issue list --search` finds a matching issue:
+1. Read the existing issue to confirm it covers the same scope.
+2. If it does, reference it directly — do not create a duplicate.
+3. If it's related but different, create a new issue and cross-reference.
+
+### Error: PR description file path issues
+
+If `gh pr create --body-file` fails:
+1. Verify the file exists: `ls plans/github-issues/PR_NNN_slug.md`
+2. Check for typos in the path — the directory may be `plan/` or `plans/`.
+3. Ensure the file is not empty (gh rejects empty body files).

--- a/.claude/skills/git-workflow/references/templates.md
+++ b/.claude/skills/git-workflow/references/templates.md
@@ -1,0 +1,92 @@
+# Git Workflow Templates
+
+## Issue Body Template
+
+Write to `plans/github-issues/ISSUE_NNN_slug.md`:
+
+```markdown
+## Problem
+
+[What is broken, missing, or needed. 2-3 sentences.]
+
+## Context
+
+[Why this matters. User impact, system impact, or business reason.]
+
+## Proposed Solution
+
+[How to fix or implement. Brief technical approach.]
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Labels
+
+[Suggested labels — verify against `gh label list` before applying.]
+```
+
+## PR Body Template
+
+Write to `plans/github-issues/PR_NNN_slug.md`:
+
+```markdown
+## Summary
+
+[1-3 sentences describing what this PR does and why.]
+
+## Changes
+
+- [Change 1 with file reference]
+- [Change 2 with file reference]
+- [Change 3 with file reference]
+
+## Test Plan
+
+- [ ] Test scenario 1
+- [ ] Test scenario 2
+- [ ] Test scenario 3
+
+Closes #NNN
+```
+
+## Commit Message Template
+
+Write to `plans/github-issues/COMMIT_NNN_slug.md`:
+
+```
+type(scope): brief description
+
+[Body: 1-3 sentences explaining WHY, not just WHAT. Include context
+that isn't obvious from the diff.]
+
+[Footer: issue reference]
+Refs #NNN
+```
+
+### Conventional Commit Types
+
+| Type       | When to Use                        |
+|------------|------------------------------------|
+| `feat`     | New feature                        |
+| `fix`      | Bug fix                            |
+| `chore`    | Maintenance, deps, config          |
+| `docs`     | Documentation only                 |
+| `refactor` | Code change that doesn't add/fix   |
+| `test`     | Adding or updating tests           |
+| `ci`       | CI/CD pipeline changes             |
+
+### Issue Reference Keywords
+
+Use in commit messages and PR bodies:
+
+| Keyword               | Effect on Merge              |
+|-----------------------|------------------------------|
+| `Closes #NNN`        | Auto-closes the issue        |
+| `Fixes #NNN`         | Auto-closes the issue        |
+| `Resolves #NNN`      | Auto-closes the issue        |
+| `Refs #NNN`          | Links without closing        |
+
+Use `Closes` in the PR body (auto-close on merge). Use `Refs` in commit messages (link without closing, since the PR handles closure).

--- a/.claude/skills/mutation-testing/SKILL.md
+++ b/.claude/skills/mutation-testing/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: mutation-testing
+description: >-
+  Write high-value tests that kill mutants through logic validation.
+  Use when writing tests that need to verify behavior, improving
+  mutation scores, or evaluating test quality. Covers boundary testing,
+  exact value assertions, error message validation, and state verification.
+  Do NOT use for general test writing (use testing skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Mutation Testing
+
+Mutation testing reveals whether your tests verify behavior or just achieve coverage. A test that doesn't kill mutants doesn't test.
+
+## Instructions
+
+### Step 1: Apply the Mutant-Killing Checklist
+
+For every test, ask:
+
+1. **Would this fail if I changed a constant by 1?** -> Test exact values
+2. **Would this fail if I changed an operator?** -> Test exact boundaries
+3. **Would this fail if I removed a check?** -> Test that validation happens
+4. **Would this fail if I changed an error message?** -> Validate message content
+
+### Step 2: Use High-Value Test Patterns
+
+- **Exact constants**: `assert MAX_RETRIES == 3` (not just `assert MAX_RETRIES > 0`)
+- **Boundary testing**: Test at, above, and below the boundary
+- **Complete error messages**: Match on message content, not just exception type
+- **State verification**: Assert before and after state changes
+- **Collection contents**: Test exact contents and order, not just size
+
+### Step 3: Write Testable Code
+
+- Use named constants for magic numbers
+- Write specific error messages
+- Make behavior testable (raise exceptions, don't just print)
+
+### Step 4: Run Mutation Tests
+
+```bash
+./scripts/mutation.sh --paths-to-mutate src/module.py
+./scripts/analyze_mutations.py
+# Target: >= 80% mutation score
+```
+
+## Examples
+
+See `references/practical-examples.md` for complete worked examples.
+
+### Example 1: Boundary Testing
+
+```python
+# BAD: Doesn't kill MAX_LENGTH = 100 -> 101
+assert len(name) <= MAX_PROJECT_NAME_LENGTH
+
+# GOOD: Kills the mutant
+assert MAX_PROJECT_NAME_LENGTH == 100
+assert is_valid("a" * 100) == True   # At max
+assert is_valid("a" * 101) == False  # Over max
+assert is_valid("a" * 99) == True    # Under max
+```
+
+### Example 2: Error Message Validation
+
+```python
+# BAD: Doesn't kill message mutations
+with pytest.raises(FileNotFoundError):
+    load_config(missing_file)
+
+# GOOD: Validates exact message
+with pytest.raises(FileNotFoundError) as exc:
+    load_config(missing_file)
+assert "Configuration file not found" in str(exc.value)
+assert str(missing_file) in str(exc.value)
+```
+
+## Troubleshooting
+
+### Error: Mutation score below 80%
+- Run `mutmut show <id>` to see surviving mutants
+- Focus on logic mutations (constants, operators, conditions) first
+- Add exact value assertions, not just truthiness checks
+- Test both branches of every condition
+
+### Error: Too many equivalent mutants
+- Some mutations produce equivalent behavior and can't be killed
+- Focus on mutations that actually change observable behavior
+- Use `mutmut show` to identify which are truly equivalent

--- a/.claude/skills/mutation-testing/references/practical-examples.md
+++ b/.claude/skills/mutation-testing/references/practical-examples.md
@@ -1,0 +1,110 @@
+# Mutation Testing Practical Examples
+
+## Example 1: Password Validation
+
+```python
+# Code
+MIN_PASSWORD_LENGTH = 8
+MAX_PASSWORD_LENGTH = 128
+
+def validate_password(password: str) -> None:
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise ValueError(f"Password too short. Minimum {MIN_PASSWORD_LENGTH} characters.")
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise ValueError(f"Password too long. Maximum {MAX_PASSWORD_LENGTH} characters.")
+
+# HIGH-VALUE Tests
+def test_password_min_length_exact():
+    """Kills: MIN_PASSWORD_LENGTH = 8 -> 7, 9"""
+    assert MIN_PASSWORD_LENGTH == 8
+    validate_password("a" * 8)  # Should pass
+    with pytest.raises(ValueError, match="Password too short"):
+        validate_password("a" * 7)  # Should fail
+
+def test_password_max_length_exact():
+    """Kills: MAX_PASSWORD_LENGTH = 128 -> 127, 129"""
+    assert MAX_PASSWORD_LENGTH == 128
+    validate_password("a" * 128)  # Should pass
+    with pytest.raises(ValueError, match="Password too long"):
+        validate_password("a" * 129)  # Should fail
+
+def test_password_error_messages_exact():
+    """Kills: error message string mutations"""
+    with pytest.raises(ValueError) as exc:
+        validate_password("short")
+    error = str(exc.value)
+    assert "Password too short" in error
+    assert "8 characters" in error
+```
+
+## Example 2: State Machine
+
+```python
+# Code
+class OrderStateMachine:
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+
+    def __init__(self):
+        self.state = self.PENDING
+
+    def start_processing(self):
+        if self.state != self.PENDING:
+            raise ValueError(f"Cannot process order in state: {self.state}")
+        self.state = self.PROCESSING
+
+    def complete(self):
+        if self.state != self.PROCESSING:
+            raise ValueError(f"Cannot complete order in state: {self.state}")
+        self.state = self.COMPLETED
+
+# HIGH-VALUE Tests
+def test_state_constants_exact():
+    """Kills: state string mutations"""
+    assert OrderStateMachine.PENDING == "pending"
+    assert OrderStateMachine.PROCESSING == "processing"
+    assert OrderStateMachine.COMPLETED == "completed"
+
+def test_initial_state_exact():
+    """Kills: wrong initial state"""
+    order = OrderStateMachine()
+    assert order.state == OrderStateMachine.PENDING
+    assert order.state != OrderStateMachine.PROCESSING
+
+def test_state_transition_exact():
+    """Kills: missing state updates, wrong transitions"""
+    order = OrderStateMachine()
+    order.start_processing()
+    assert order.state == OrderStateMachine.PROCESSING
+    assert order.state != OrderStateMachine.PENDING
+    order.complete()
+    assert order.state == OrderStateMachine.COMPLETED
+
+def test_invalid_transitions_blocked():
+    """Kills: missing validation checks"""
+    order = OrderStateMachine()
+    with pytest.raises(ValueError, match="Cannot complete order in state: pending"):
+        order.complete()
+    assert order.state == OrderStateMachine.PENDING  # State unchanged
+```
+
+## Common Mutation Categories
+
+| Mutation Type | How to Kill It |
+|---------------|----------------|
+| Constant Mutations | Test exact value with equality assertions |
+| Operator Mutations | Test boundary cases and edge values |
+| Boolean Mutations | Test both True and False branches explicitly |
+| String Mutations | Test exact string contents with equality |
+| Collection Mutations | Test exact size, order, and contents |
+| None Mutations | Test both None and not-None cases |
+| Return Mutations | Test exact return values, not just type |
+
+## Red Flags (Tests That Don't Kill Mutants)
+
+- `assert result` - truthy test misses specific values
+- `assert function() is not None` - doesn't test what the value IS
+- `assert len(result) > 0` - doesn't test exact size or contents
+- `assert "error" in output` - weak string matching
+- Tests with no assertions - coverage without verification

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: security
+description: >-
+  Implement secure coding practices against common vulnerabilities.
+  Use when handling user input, file paths, subprocess calls, SQL queries,
+  API keys, or building web endpoints. Covers input validation, injection
+  prevention, secret management, and XSS/CSRF protection across Python,
+  TypeScript, Go, and Rust. Do NOT use for general error handling
+  (use error-handling skill) or for remediating dependency vulnerability
+  scanner failures and CVE / GHSA advisories (use cve-remediation skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Security
+
+Defense in depth, least privilege, fail securely, never trust user input.
+
+## Instructions
+
+### Step 1: Follow the Principles
+
+1. Defense in depth - multiple layers of security
+2. Least privilege - minimal access required
+3. Fail securely - errors don't expose sensitive data
+4. Input validation at all boundaries
+5. Never trust user input
+6. Secure by default, not by configuration
+
+### Step 2: Apply Security Patterns
+
+See `references/patterns-by-language.md` for language-specific implementations.
+
+Key areas:
+- **Input validation**: Allowlist characters, validate format, limit length
+- **Path traversal prevention**: Resolve paths, verify within base directory
+- **Command injection prevention**: Never use `shell=True`, validate arguments
+- **SQL injection prevention**: Always use parameterized queries
+- **XSS prevention**: Escape HTML output, use framework defaults
+- **Secret management**: Use OS keyring, never hardcode secrets
+- **CSRF protection**: Use tokens with constant-time comparison
+
+### Step 3: Run the Security Checklist
+
+Before deploying:
+- [ ] All user inputs validated at boundaries
+- [ ] No SQL injection (parameterized queries)
+- [ ] No command injection (no `shell=True`)
+- [ ] No path traversal (validated file paths)
+- [ ] No XSS (escaped HTML)
+- [ ] API keys in OS keyring, not code
+- [ ] Secrets not committed to git
+- [ ] HTTPS for all external requests
+- [ ] SSL certificates validated
+- [ ] Error messages don't leak sensitive data
+- [ ] Logging doesn't include secrets or PII
+
+## Examples
+
+See `references/examples.md` for complete worked examples.
+
+### Example 1: Safe Path Handling (Python)
+
+```python
+def safe_path_join(base_dir: Path, user_path: str) -> Path:
+    base_dir = base_dir.resolve()
+    target = (base_dir / user_path).resolve()
+    try:
+        target.relative_to(base_dir)
+    except ValueError:
+        raise ValueError(f"Path traversal detected: {user_path!r}") from None
+    return target
+```
+
+### Example 2: Safe Subprocess Call (Python)
+
+```python
+# WRONG - shell injection vulnerability
+subprocess.run(f"git clone {user_repo}", shell=True)
+
+# CORRECT - no injection possible
+subprocess.run(["git", "clone", user_repo], check=True)
+```
+
+## Troubleshooting
+
+### Error: Keyring not available in CI/headless environment
+- Use environment variables as fallback for CI only
+- Document the fallback in CI configuration
+- Never use environment variables for production secret storage
+
+### Error: Path validation too restrictive
+- Check if you're resolving symlinks unnecessarily
+- Verify the base directory itself is resolved before comparison
+- Test with both relative and absolute user paths

--- a/.claude/skills/security/references/examples.md
+++ b/.claude/skills/security/references/examples.md
@@ -1,0 +1,124 @@
+# Security Examples
+
+## Example 1: Comprehensive Input Validator (Python)
+
+```python
+import re
+from pathlib import Path
+from typing import Optional
+
+class InputValidator:
+    """Validate user inputs for security."""
+
+    PROJECT_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9_-]+$')
+    EMAIL_PATTERN = re.compile(r'^[^@]+@[^@]+\.[^@]+$')
+    RESERVED_NAMES = {'con', 'prn', 'aux', 'nul', 'com1', 'com2', 'lpt1', 'lpt2'}
+
+    @staticmethod
+    def validate_project_name(name: str) -> str:
+        name = name.strip()
+        if not name:
+            raise ValueError("Project name cannot be empty")
+        if len(name) > 100:
+            raise ValueError(f"Project name too long: {len(name)} chars (max 100)")
+        if not InputValidator.PROJECT_NAME_PATTERN.match(name):
+            raise ValueError(f"Invalid project name: {name!r}")
+        if name[0] in ('-', '_'):
+            raise ValueError(f"Project name cannot start with {name[0]!r}")
+        if name.lower() in InputValidator.RESERVED_NAMES:
+            raise ValueError(f"Project name {name!r} is reserved")
+        return name
+
+    @staticmethod
+    def validate_email(email: str) -> str:
+        email = email.strip().lower()
+        if not email:
+            raise ValueError("Email cannot be empty")
+        if len(email) > 254:
+            raise ValueError("Email address too long")
+        if not InputValidator.EMAIL_PATTERN.match(email):
+            raise ValueError(f"Invalid email format: {email!r}")
+        if any(c in email for c in ['\n', '\r', '\0', ';']):
+            raise ValueError("Email contains invalid characters")
+        return email
+
+    @staticmethod
+    def validate_url(url: str, allowed_schemes: Optional[list[str]] = None) -> str:
+        if allowed_schemes is None:
+            allowed_schemes = ['https', 'git', 'ssh']
+        url = url.strip()
+        if not url:
+            raise ValueError("URL cannot be empty")
+        if not any(url.startswith(f"{scheme}://") for scheme in allowed_schemes):
+            raise ValueError(f"Invalid URL scheme. Allowed: {', '.join(allowed_schemes)}")
+        # Prevent SSRF
+        dangerous_hosts = ['localhost', '127.0.0.1', '0.0.0.0', '169.254', '10.', '172.16.', '192.168.']
+        if any(host in url.lower() for host in dangerous_hosts):
+            raise ValueError("URLs pointing to localhost or private IPs are not allowed")
+        return url
+```
+
+## Example 2: Secure File Manager (Python)
+
+```python
+class SecureFileManager:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir.resolve()
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _validate_path(self, file_path: str) -> Path:
+        target = (self.base_dir / file_path).resolve()
+        try:
+            target.relative_to(self.base_dir)
+        except ValueError:
+            raise ValueError(f"Path traversal detected: {file_path!r}") from None
+        return target
+
+    def write_file(self, file_path: str, content: str) -> None:
+        target = self._validate_path(file_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write using temporary file
+        temp_fd, temp_path = tempfile.mkstemp(dir=target.parent)
+        try:
+            with open(temp_fd, 'w', encoding='utf-8') as f:
+                f.write(content)
+            Path(temp_path).replace(target)
+        except Exception:
+            Path(temp_path).unlink(missing_ok=True)
+            raise
+
+    def read_file(self, file_path: str) -> str:
+        target = self._validate_path(file_path)
+        if not target.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        return target.read_text(encoding='utf-8')
+```
+
+## Example 3: Secure API Client (Python)
+
+```python
+class SecureAPIClient:
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self.base_url = base_url.rstrip('/')
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'MyApp/1.0',
+            'X-API-Key': api_key,
+        })
+
+    def request(self, method: str, path: str, data: dict | None = None, timeout: int = 30) -> dict:
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        response = self.session.request(
+            method=method,
+            url=url,
+            json=data if method in ('POST', 'PUT', 'PATCH') else None,
+            timeout=timeout,
+            verify=True,           # Verify SSL certificates
+            allow_redirects=False,  # Don't follow redirects (prevent SSRF)
+        )
+        response.raise_for_status()
+        content_type = response.headers.get('Content-Type', '')
+        if 'application/json' not in content_type:
+            raise ValueError(f"Unexpected content type: {content_type}")
+        return response.json()
+```

--- a/.claude/skills/security/references/patterns-by-language.md
+++ b/.claude/skills/security/references/patterns-by-language.md
@@ -1,0 +1,178 @@
+# Security Patterns by Language
+
+## Python
+
+### Input Validation
+```python
+import re
+
+def validate_project_name(name: str) -> None:
+    if not re.match(r'^[a-zA-Z0-9_-]+$', name):
+        raise ValueError(f"Invalid project name: {name!r}. Only letters, numbers, hyphens, underscores.")
+    if len(name) > 100:
+        raise ValueError(f"Project name too long: {len(name)} chars (max 100)")
+    if name.startswith(('-', '_')):
+        raise ValueError(f"Project name cannot start with {name[0]!r}")
+    reserved = {'con', 'prn', 'aux', 'nul', 'com1', 'lpt1'}
+    if name.lower() in reserved:
+        raise ValueError(f"Project name {name!r} is reserved")
+```
+
+### Path Traversal Prevention
+```python
+def safe_path_join(base_dir: Path, user_path: str) -> Path:
+    base_dir = base_dir.resolve()
+    target = (base_dir / user_path).resolve()
+    try:
+        target.relative_to(base_dir)
+    except ValueError:
+        raise ValueError(f"Path traversal detected: {user_path!r}") from None
+    return target
+```
+
+### Subprocess Safety
+```python
+def run_git_command(args: list[str], cwd: Path) -> str:
+    dangerous_chars = {';', '|', '&', '$', '`', '\n', '\r'}
+    for arg in args:
+        if any(char in arg for char in dangerous_chars):
+            raise ValueError(f"Argument contains dangerous characters: {arg!r}")
+    # NEVER use shell=True
+    result = subprocess.run(['git'] + args, cwd=cwd, capture_output=True, text=True, check=True)
+    return result.stdout
+```
+
+### SQL Injection Prevention
+```python
+# WRONG - SQL injection
+query = f"SELECT * FROM users WHERE email = '{email}'"
+cursor.execute(query)
+
+# CORRECT - parameterized query
+query = "SELECT * FROM users WHERE email = ?"
+cursor.execute(query, (email,))
+```
+
+### API Key Management
+```python
+import keyring
+
+def get_api_key(key_name: str) -> str:
+    api_key = keyring.get_password("my_app", key_name)
+    if not api_key:
+        raise ValueError(f"API key '{key_name}' not found in OS keyring.")
+    return api_key
+
+# WRONG: API_KEY = "sk-ant-1234567890"
+# WRONG: api_key = os.environ.get("API_KEY")
+# CORRECT: api_key = get_api_key("claude_api_key")
+```
+
+## TypeScript
+
+### Input Validation
+```typescript
+export class InputValidator {
+  static validateEmail(email: string): string {
+    email = email.trim().toLowerCase();
+    if (!validator.isEmail(email)) throw new Error(`Invalid email: ${email}`);
+    if (email.length > 254) throw new Error('Email too long');
+    return email;
+  }
+
+  static sanitizeHtml(html: string): string {
+    return validator.escape(html);
+  }
+}
+```
+
+### XSS Prevention
+```typescript
+function renderUserContent(content: string): string {
+  return content
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+// React/JSX escapes by default - {content} is safe
+// dangerouslySetInnerHTML should be avoided
+```
+
+### CSRF Protection
+```typescript
+import crypto from 'crypto';
+
+function generateCsrfToken(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+function validateCsrfToken(token: string, sessionToken: string): boolean {
+  return crypto.timingSafeEqual(Buffer.from(token), Buffer.from(sessionToken));
+}
+```
+
+## Go
+
+### Input Validation
+```go
+var projectNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+func ValidateProjectName(name string) error {
+    name = strings.TrimSpace(name)
+    if name == "" { return errors.New("project name cannot be empty") }
+    if len(name) > 100 { return errors.New("project name too long (max 100)") }
+    if !projectNameRegex.MatchString(name) { return errors.New("invalid characters in project name") }
+    return nil
+}
+```
+
+### Path Traversal Prevention
+```go
+func SafePathJoin(baseDir, userPath string) (string, error) {
+    baseDir = filepath.Clean(baseDir)
+    target := filepath.Join(baseDir, filepath.Clean(userPath))
+    if !strings.HasPrefix(target, baseDir+string(filepath.Separator)) {
+        return "", errors.New("path traversal detected")
+    }
+    return target, nil
+}
+```
+
+### Command Injection Prevention
+```go
+// exec.Command does NOT use shell - safe by default
+cmd := exec.CommandContext(ctx, "git", args...)
+cmd.Dir = dir
+output, err := cmd.CombinedOutput()
+```
+
+## Rust
+
+### Input Validation
+```rust
+lazy_static! {
+    static ref PROJECT_NAME_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
+}
+
+pub fn validate_project_name(name: &str) -> Result<String, Box<dyn Error>> {
+    let name = name.trim();
+    if name.is_empty() { return Err("Project name cannot be empty".into()); }
+    if name.len() > 100 { return Err("Project name too long".into()); }
+    if !PROJECT_NAME_REGEX.is_match(name) { return Err("Invalid characters".into()); }
+    Ok(name.to_string())
+}
+```
+
+### Path Traversal Prevention
+```rust
+pub fn safe_path_join(base_dir: &Path, user_path: &str) -> Result<PathBuf, io::Error> {
+    let base_dir = base_dir.canonicalize()?;
+    let target = base_dir.join(user_path).canonicalize()?;
+    if !target.starts_with(&base_dir) {
+        return Err(io::Error::new(io::ErrorKind::PermissionDenied, "Path traversal detected"));
+    }
+    Ok(target)
+}
+```

--- a/.claude/skills/skill-craft/SKILL.md
+++ b/.claude/skills/skill-craft/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: skill-craft
+description: >-
+  Build and validate Claude Code skills to production quality. Use when
+  creating new skills, modifying existing SKILL.md files, writing skill
+  descriptions, structuring skill directories, or reviewing skill quality.
+  Ensures progressive disclosure, trigger optimization, and composability.
+  Do NOT use for general documentation or code quality guidance.
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Skill Craft
+
+Meta-skill for creating world-class Claude Code skills. Every skill this produces must pass the same quality bar it enforces — including itself.
+
+## Instructions
+
+### Step 1: Define Use Cases Before Writing
+
+Identify 2-3 concrete use cases before any code or markdown. For each:
+- What does the user want to accomplish?
+- What trigger phrases would they use?
+- What should the skill NOT handle? (prevents overtriggering)
+
+### Step 2: Structure the Directory
+
+```
+skill-name/
+├── SKILL.md          # Required — core instructions
+├── references/       # Optional — detailed docs loaded on demand
+├── scripts/          # Optional — executable validation/tooling
+└── assets/           # Optional — templates, icons, fonts
+```
+
+Rules:
+- Folder name: kebab-case, no spaces, no capitals, no underscores
+- File: exactly `SKILL.md` (case-sensitive, not `skill.md` or `SKILL.MD`)
+- No `README.md` inside the skill folder
+
+### Step 3: Write the YAML Frontmatter
+
+The frontmatter is the most important part — it determines when Claude loads the skill.
+
+```yaml
+---
+name: skill-name-in-kebab-case
+description: >-
+  [What it does]. Use when [specific trigger phrases the user would say].
+  [Key capabilities]. Do NOT use for [exclusions with cross-references].
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+```
+
+**Frontmatter rules:**
+- `name`: kebab-case, must match folder name
+- `description`: under 1024 characters, MUST include:
+  - What the skill does (1 sentence)
+  - When to use it with specific trigger phrases
+  - What NOT to use it for (with cross-references to correct skill)
+- No XML angle brackets (`<` or `>`) anywhere in frontmatter
+- No "claude" or "anthropic" in the name (reserved)
+
+### Step 4: Write the Body with Progressive Disclosure
+
+SKILL.md body structure:
+
+```markdown
+# Skill Name
+
+[1-2 sentence overview of the skill's purpose]
+
+## Instructions
+### Step 1: [First action]
+### Step 2: [Second action]
+
+## Examples
+### Example 1: [Common scenario]
+### Example 2: [Edge case or alternative]
+
+## Troubleshooting
+### Error: [Common problem]
+```
+
+**Progressive disclosure levels:**
+1. **Frontmatter** (always loaded): Just enough for Claude to know WHEN to use it
+2. **SKILL.md body** (loaded when relevant): Full instructions and guidance
+3. **references/** (loaded on demand): Detailed docs, language-specific patterns, worked examples
+
+Keep SKILL.md under 5,000 words. Move verbose content to `references/`.
+
+### Step 5: Optimize the Description for Triggering
+
+The description field controls whether the skill activates. Test mentally:
+
+- **Too vague**: "Helps with projects" — won't trigger on anything specific
+- **Missing triggers**: "Creates sophisticated multi-page documentation systems" — no user phrases
+- **Too technical**: "Implements the entity model with hierarchical relationships" — no user language
+
+**Good pattern**: `[Verb phrase]. Use when [user says X, Y, or Z]. [Capabilities]. Do NOT use for [exclusions].`
+
+### Step 6: Ensure Composability
+
+Skills load simultaneously. Your skill must:
+- Work alongside others without assuming it's the only capability
+- Have bilateral exclusions with related skills (if skill A excludes B's domain, B should exclude A's)
+- Use cross-references in "Do NOT use for" clauses (e.g., "use security skill" not just "use another skill")
+
+### Step 7: Validate Before Shipping
+
+Run the checklist in `references/quality-checklist.md`. Every item must pass.
+
+Quick self-test: Ask "When would you use the [skill-name] skill?" — if the answer is vague, the description needs work.
+
+## Examples
+
+### Example 1: Creating a New Skill from a Simple Prompt
+
+User says: "Create a skill for database migration best practices"
+
+1. Define use cases: schema changes, data migration, rollback procedures
+2. Define triggers: "migrate database", "schema change", "add column", "data migration"
+3. Define exclusions: "Do NOT use for general SQL queries (use appropriate language docs)"
+4. Create `database-migrations/SKILL.md` with frontmatter, instructions, examples, troubleshooting
+5. If content exceeds ~200 lines, extract language-specific patterns to `references/`
+6. Validate against checklist
+
+### Example 2: Reviewing an Existing Skill
+
+User says: "Review this skill for quality"
+
+1. Check frontmatter: name kebab-case, description has WHAT + WHEN + DO NOT, under 1024 chars, no XML
+2. Check body: has Instructions, Examples (2+), Troubleshooting sections
+3. Check progressive disclosure: SKILL.md focused, verbose content in references/
+4. Check composability: exclusions are bilateral with related skills
+5. Check triggering: description includes phrases users would actually say
+6. Report issues with specific fixes
+
+### Example 3: Fixing an Overtriggering Skill
+
+Symptom: Skill loads for unrelated queries.
+
+1. Add negative triggers: "Do NOT use for [unrelated domain]"
+2. Make description more specific: "Processes PDF legal documents for contract review" not "Processes documents"
+3. Clarify scope: "Use specifically for online payment workflows, not for general financial queries"
+4. Test with unrelated queries to confirm it no longer triggers
+
+## Troubleshooting
+
+### Error: Skill doesn't trigger when it should
+- Description is too generic — add specific trigger phrases users would say
+- Missing keywords — include technical terms relevant to the domain
+- Debug: Ask Claude "When would you use the [skill-name] skill?" and adjust based on what's missing
+
+### Error: Skill triggers too often
+- Description is too broad — add "Do NOT use for" exclusions
+- Clarify scope with specific domains, file types, or contexts
+- Add negative triggers referencing the correct alternative skill
+
+### Error: Instructions not followed
+- Instructions too verbose — keep SKILL.md focused, move detail to references/
+- Critical instructions buried — put them at the top, use `## Important` headers
+- Ambiguous language — replace "validate things properly" with specific checklists
+
+### Error: Skill content too large / slow responses
+- Move detailed reference material to `references/` files
+- Keep SKILL.md under 5,000 words
+- Link to references instead of inlining content

--- a/.claude/skills/skill-craft/references/patterns.md
+++ b/.claude/skills/skill-craft/references/patterns.md
@@ -1,0 +1,151 @@
+# Skill Design Patterns
+
+Patterns that consistently produce effective skills, derived from Anthropic's guide and production experience.
+
+## Pattern 1: Sequential Workflow Orchestration
+
+**Use when**: Users need multi-step processes in a specific order.
+
+```markdown
+## Workflow: [Task Name]
+
+### Step 1: [Action]
+[What to do, what tool to call, what parameters]
+
+### Step 2: [Action]
+[Dependencies on Step 1 output]
+
+### Step 3: [Validation]
+[How to verify the workflow succeeded]
+```
+
+Key techniques:
+- Explicit step ordering with dependencies between steps
+- Validation at each stage
+- Rollback instructions for failures
+
+## Pattern 2: Iterative Refinement
+
+**Use when**: Output quality improves with iteration.
+
+```markdown
+### Initial Draft
+1. Generate first version
+2. Save to temporary location
+
+### Quality Check
+1. Run validation (script or checklist)
+2. Identify issues
+
+### Refinement Loop
+1. Address each issue
+2. Regenerate affected sections
+3. Re-validate
+4. Repeat until quality threshold met
+
+### Finalization
+1. Apply final formatting
+2. Generate summary
+```
+
+Key techniques:
+- Explicit quality criteria (what "done" looks like)
+- Validation scripts where possible (deterministic > language instructions)
+- Clear stopping conditions
+
+## Pattern 3: Context-Aware Selection
+
+**Use when**: Same goal, different approach depending on context.
+
+```markdown
+### Decision Tree
+1. Assess context: [what to check]
+2. Determine approach:
+   - If [condition A]: [approach A]
+   - If [condition B]: [approach B]
+   - Default: [safe fallback]
+
+### Execute
+Based on decision, follow the appropriate path.
+
+### Explain
+Tell the user why that approach was chosen.
+```
+
+Key techniques:
+- Clear decision criteria
+- Fallback options
+- Transparency about choices
+
+## Pattern 4: Domain-Specific Intelligence
+
+**Use when**: The skill adds specialized knowledge beyond tool access.
+
+```markdown
+### Before Action (Domain Check)
+1. Gather context
+2. Apply domain rules:
+   - [Rule 1]
+   - [Rule 2]
+3. Document decision
+
+### Execute
+IF checks passed: proceed
+ELSE: flag for review, explain why
+
+### Audit Trail
+- Log all decisions
+- Record reasoning
+```
+
+Key techniques:
+- Domain expertise embedded in logic
+- Validation before action
+- Comprehensive documentation of decisions
+
+## Description Field Patterns
+
+### Good Descriptions (with analysis)
+
+```yaml
+# Pattern: [Verb phrase] + [Trigger phrases] + [Capabilities] + [Exclusions]
+description: >-
+  Analyzes Figma design files and generates developer handoff documentation.
+  Use when user uploads .fig files, asks for "design specs", "component
+  documentation", or "design-to-code handoff".
+  Do NOT use for general design discussion (use design-review skill).
+```
+
+Why this works:
+- Starts with what it does (analyzes Figma files)
+- Includes 4 specific trigger phrases
+- Mentions file types (.fig)
+- Has exclusions with cross-reference
+
+### Bad Descriptions (with fixes)
+
+| Bad | Problem | Fix |
+|-----|---------|-----|
+| "Helps with projects" | Too vague, no triggers | "Manages project setup including repository creation, CI configuration, and team onboarding. Use when..." |
+| "Creates sophisticated multi-page documentation systems" | No trigger phrases | Add: "Use when user asks to 'generate docs', 'write API reference', or 'create a README'" |
+| "Implements the entity model with hierarchical relationships" | Too technical, no user language | Rewrite from user perspective: "Sets up database models for hierarchical data..." |
+
+## Anti-Patterns to Avoid
+
+### 1. The Kitchen Sink Skill
+Trying to do everything. Split into focused skills with clear boundaries.
+
+### 2. The Invisible Skill
+Vague description that never triggers. Include specific phrases users say.
+
+### 3. The Greedy Skill
+Overly broad triggers that fire on unrelated queries. Add "Do NOT use for" exclusions.
+
+### 4. The Monolith
+Everything in SKILL.md with no progressive disclosure. Move reference content to `references/`.
+
+### 5. The Island
+No exclusions or cross-references. Every skill should acknowledge its neighbors.
+
+### 6. The One-Way Door
+Exclusions only go in one direction. If skill A says "don't use for B's domain", skill B should say "don't use for A's domain".

--- a/.claude/skills/skill-craft/references/quality-checklist.md
+++ b/.claude/skills/skill-craft/references/quality-checklist.md
@@ -1,0 +1,77 @@
+# Skill Quality Checklist
+
+Every item must pass before a skill ships. This checklist is derived from Anthropic's Complete Guide to Building Skills for Claude and validated against production skills.
+
+## Structure
+
+- [ ] Folder named in kebab-case (no spaces, capitals, or underscores)
+- [ ] `SKILL.md` file exists with exact spelling (case-sensitive)
+- [ ] No `README.md` inside the skill folder
+- [ ] `references/` used for verbose content (if SKILL.md > ~200 lines)
+- [ ] `scripts/` used for executable validation (if applicable)
+
+## YAML Frontmatter
+
+- [ ] `---` delimiters present (opening and closing)
+- [ ] `name` field: kebab-case, matches folder name
+- [ ] `name` does not contain "claude" or "anthropic" (reserved)
+- [ ] `description` field present and under 1024 characters
+- [ ] `description` includes WHAT the skill does
+- [ ] `description` includes WHEN to use it (with specific trigger phrases)
+- [ ] `description` includes "Do NOT use for" exclusions with cross-references
+- [ ] No XML angle brackets (`<` or `>`) anywhere in frontmatter
+- [ ] `metadata.author` present
+- [ ] `metadata.version` present (semver format)
+
+## Body Structure
+
+- [ ] Starts with `# Skill Name` heading
+- [ ] 1-2 sentence overview immediately after heading
+- [ ] `## Instructions` section with numbered steps
+- [ ] `## Examples` section with at least 2 examples
+- [ ] `## Troubleshooting` section with at least 1 error case
+- [ ] Instructions are specific and actionable (not "validate things properly")
+- [ ] References to bundled files use explicit paths (`references/filename.md`)
+
+## Progressive Disclosure
+
+- [ ] Frontmatter is minimal: just WHAT, WHEN, and DO NOT
+- [ ] SKILL.md body contains full instructions but stays under 5,000 words
+- [ ] Verbose content (language-specific patterns, worked examples, templates) lives in `references/`
+- [ ] SKILL.md links to reference files where appropriate
+
+## Triggering Quality
+
+- [ ] Description includes phrases users would actually say
+- [ ] Description is NOT too vague (e.g., "Helps with projects")
+- [ ] Description is NOT missing trigger conditions
+- [ ] Description is NOT overly technical without user-facing language
+- [ ] Negative triggers present for related skill domains
+- [ ] Mental test: "When would you use the [skill-name] skill?" produces a clear, specific answer
+
+## Composability
+
+- [ ] Works alongside other skills without assuming exclusivity
+- [ ] Exclusions are bilateral (if A excludes B's domain, B excludes A's)
+- [ ] Cross-references name the specific alternative skill
+- [ ] No overlapping trigger phrases with existing skills (or properly disambiguated)
+
+## Content Quality
+
+- [ ] Instructions use imperative voice ("Do X" not "You should do X")
+- [ ] Examples cover both common scenarios and edge cases
+- [ ] Troubleshooting addresses real failure modes, not hypothetical ones
+- [ ] No over-engineering or unnecessary complexity
+- [ ] Error handling guidance included where applicable
+
+## Meta-Recursive Validity
+
+This checklist applies to itself. The skill-craft skill:
+- [x] Is in kebab-case folder (`skill-craft/`)
+- [x] Has `SKILL.md` with valid frontmatter
+- [x] Description includes WHAT + WHEN + DO NOT
+- [x] Description under 1024 characters
+- [x] Has Instructions, Examples (3), Troubleshooting sections
+- [x] Uses `references/` for this checklist
+- [x] Has bilateral exclusions with related skills
+- [x] No XML angle brackets in frontmatter

--- a/.claude/skills/user-facing-error-messages/SKILL.md
+++ b/.claude/skills/user-facing-error-messages/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: user-facing-error-messages
+description: >-
+  Audit and rewrite user-facing error messages so users can self-serve instead
+  of emailing support. Use when auditing error messages across an app,
+  improving or rewriting error wording, reviewing toasts, alerts, flash
+  messages, form validation copy, or empty/failure states, or when a message
+  feels opaque, blame-y, or ends in "contact support". Covers the four-part
+  rubric (what / why / next / escape), an inventory-and-triage audit workflow,
+  rewrite templates, and security-safe disclosure rules.
+  Do NOT use for exception architecture, typed errors, or developer-facing
+  logging (use error-handling skill); for the security rules around what
+  errors may safely disclose in auth/crypto paths (use security skill); or
+  for the visual styling of alerts, toasts, and banners (use
+  frontend-aesthetics skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# User-Facing Error Messages
+
+Write every error message as if you are the user reading it at 2am trying to get unstuck. The goal is self-service, not a support ticket.
+
+## Core Principle
+
+If a user hits this error, they have exactly one question: **"What do I do now?"** An error message that cannot answer that question has failed, no matter how technically accurate it is.
+
+"Contact support" is never a primary call-to-action. It is the last-resort escape hatch after you have done everything you can to let the user self-serve.
+
+## Instructions
+
+### Step 1: Adopt the User Empathy Lens
+
+Before writing or reviewing any message, answer these out loud:
+
+1. **Who hits this?** (End user? Admin? Developer integrating the API?)
+2. **What were they trying to do?** (The task, not the code path.)
+3. **What can they actually change?** (Their input? A setting? Wait and retry? Nothing?)
+4. **What is the emotional state?** (Lost work = high stakes. Typo in a form = low stakes. Tone must match.)
+
+If the answer to #3 is "nothing", the message must say so explicitly and offer an escape (status page, support link with a pre-filled trace ID, retry button).
+
+### Step 2: Apply the Four-Part Rubric
+
+Every user-facing error message is scored on four components. A passing message hits all four in plain language.
+
+| Component | Question it answers | Example |
+|-----------|--------------------|---------|
+| **What** | What went wrong, in human terms? | "We couldn't save your draft." |
+| **Why** | Why it happened — only if the user can act on it | "Your network dropped mid-save." |
+| **Next** | The single most useful next action | "Check your connection and tap Retry." |
+| **Escape** | Where to go if Next fails | "Still stuck? [Open a ticket] (ref: 7F3A2)" |
+
+Skip **Why** when it leaks internals, blames the user, or gives them no lever. Skip it; don't lie or filler.
+
+### Step 3: Run the Audit Workflow
+
+For a full-app audit, follow `references/audit-workflow.md`. The short version:
+
+1. **Inventory** every user-facing error source: `raise`/`throw`, toast/flash/snackbar calls, HTTP error responses rendered to users, form validation strings, empty-state copy, 4xx/5xx pages, email/SMS failures.
+2. **Classify** each string: user-facing vs. developer-facing (logs, stack traces). Only user-facing strings are in scope.
+3. **Score** each against the four-part rubric. Flag any message that scores below 3/4 or contains an anti-pattern from Step 4.
+4. **Triage** by blast radius: high-traffic paths first (login, checkout, save), then happy-path adjacent, then rare edge cases.
+5. **Rewrite** using the templates in `references/rewrite-templates.md`.
+6. **Preserve debuggability**: surface a short trace ID/error code so support can find the log line, but never make the code the whole message.
+
+### Step 4: Eliminate the Anti-Patterns
+
+Reject and rewrite any message matching these:
+
+- **The shrug**: "An error occurred." / "Something went wrong." / "Oops!"
+- **The opaque code**: "Error 0x80042108" with no human sentence.
+- **The blame**: "You entered an invalid email." (Use "That email is missing an @ — did you mean `name@example.com`?")
+- **The dev leak**: "NullPointerException in UserService.load()" / "ECONNREFUSED 127.0.0.1:5432".
+- **The dead-end**: ends in "contact support" with no trace ID, no link, and no attempt at self-serve.
+- **The jargon**: "Malformed payload", "Constraint violation", "Upstream 502" — translate.
+- **The panic**: ALL CAPS, stacked exclamation points, red-on-red screaming banners for recoverable cases.
+- **The liar**: "Please try again" when the request will deterministically fail again (e.g., invalid credentials, validation errors).
+- **The thief**: silently loses the user's work. Always confirm what was saved/preserved.
+
+### Step 5: Respect Security Boundaries
+
+Some errors intentionally stay vague. Coordinate with the `security` skill for these categories:
+
+- **Auth failures**: "Email or password is incorrect" (do not confirm which). Still actionable: "Reset password" link.
+- **Authorization**: "You don't have access to this project. Ask the project owner to invite you." Do not reveal existence of protected resources to unauthenticated users.
+- **Rate limits on sensitive endpoints**: give a cooldown window, not the exact counter state.
+
+Security vagueness is not an excuse for useless messages — the **Next** and **Escape** components still apply.
+
+### Step 6: Apply the Self-Service Sanity Check
+
+Before shipping, read the rewritten message aloud and ask:
+
+- [ ] Can a non-technical user name what broke?
+- [ ] Does it tell them exactly what to try next?
+- [ ] Does it preserve their work, or tell them it's lost?
+- [ ] Is there a trace ID or error code they can quote to support?
+- [ ] Does the tone match the severity (calm for recoverable, serious for data loss)?
+- [ ] Would I, half-asleep at 2am, know what to do?
+
+If any checkbox fails, rewrite.
+
+## Examples
+
+### Example 1: Form Validation — Specific, Actionable, Kind
+
+**Before:** `Invalid input.`
+
+**After:** `Phone number must be 10 digits — you entered 9. Example: (555) 123-4567.`
+
+- **What**: phone number wrong length
+- **Why**: 9 vs 10 digits (specific)
+- **Next**: implicit — add the missing digit, format example shown
+- **Escape**: not needed at this severity
+
+### Example 2: Server Error — Preserve Work, Offer Trace
+
+**Before:** `An unexpected error occurred. Please try again or contact support.`
+
+**After:**
+> We couldn't publish your post, but your draft is saved.
+>
+> Our servers hiccuped on the way to the database. Try again in a minute — if it happens twice, [open a ticket] and mention **ref: 7F3A2-B9**.
+
+- **What**: publish failed, draft safe
+- **Why**: brief, non-blaming, non-technical
+- **Next**: wait and retry
+- **Escape**: ticket link with pre-filled trace ID
+
+### Example 3: Auth Failure — Security-Safe Without Being Useless
+
+**Before:** `Login failed.`
+
+**After:** `That email and password don't match. [Reset password] or [create an account] if you're new here.`
+
+Note: does not confirm which field is wrong (security), but still points to the two real next actions.
+
+### Example 4: Full-App Audit Kickoff
+
+User says: *"We keep getting support emails that are just screenshots of error toasts. Do an audit."*
+
+1. Run Step 3 inventory (`references/audit-workflow.md` for grep patterns by stack).
+2. Produce a spreadsheet: message text, file:line, trigger frequency (from logs if available), rubric score, proposed rewrite.
+3. Sort by frequency × severity; fix the top decile first.
+4. For each rewrite, add a trace ID surface if one doesn't exist.
+5. Open a PR per subsystem, not one giant PR, so each is reviewable.
+
+## Troubleshooting
+
+### Error: The "why" would leak implementation details
+
+Drop the **Why** line. Keep **What** / **Next** / **Escape**. "Why" is optional; it is never worth a security or confusion cost to force one in.
+
+### Error: There's genuinely nothing the user can do
+
+Say so, and redirect energy usefully: "Our payments provider is down. You don't need to do anything — we'll retry automatically and email you when the charge goes through. [Status page]." The user's next action is "close this and stop worrying", which is a real, valid **Next**.
+
+### Error: Product/legal pushes back on specifics
+
+Push back with data: support-ticket volume traceable to opaque messages. If specifics are truly blocked (compliance, trade secret), the compromise is a trace ID the user can quote — never just "contact support".
+
+### Error: The message has to be short (toast, inline)
+
+Layer the disclosure: short message + "Details" link or expandable. The 4 components don't have to be in one sentence, they have to be in one experience.
+
+### Error: Message is internationalized and rewrite must pass translation
+
+Avoid idioms, contractions, and puns. Keep trace IDs and example values out of the translated string (interpolate them). See `references/rewrite-templates.md` for i18n-safe patterns.

--- a/.claude/skills/user-facing-error-messages/references/audit-workflow.md
+++ b/.claude/skills/user-facing-error-messages/references/audit-workflow.md
@@ -1,0 +1,111 @@
+# Audit Workflow
+
+A repeatable process for auditing every user-facing error message in an application. Use this when the task is "go wide" rather than "fix this one message".
+
+## 1. Inventory
+
+Cast a wide net. The goal is to collect every string that could ever reach a user in a failure state.
+
+### Where user-facing errors live
+
+- **Form validation**: inline field errors, form-level summary errors
+- **Toast / snackbar / flash messages**: ephemeral notifications
+- **Alert / banner / modal dialogs**: blocking or prominent errors
+- **4xx / 5xx pages**: 400, 401, 403, 404, 409, 422, 429, 500, 502, 503, 504
+- **Empty states with failure context**: "We couldn't load your projects"
+- **Email / SMS / push failures**: both the user's copy and the admin's copy
+- **API error bodies**: if the API is consumed by a third-party UI or CLI
+- **CLI stderr**: for developer-facing tools, the CLI *is* the UI
+- **Webhook failure notifications**: delivery retries, dead-letter queues
+- **Payment / billing failures**: card declines, subscription lapses
+
+### Grep patterns by stack
+
+Adjust to your codebase. Start broad, then narrow.
+
+```bash
+# Python (Flask/Django/FastAPI)
+rg -n 'flash\(|messages\.error|raise.*Error\(|HTTPException\(|abort\(' --glob '*.py'
+
+# JavaScript / TypeScript
+rg -n 'toast\.|showError|throw new \w*Error|res\.status\(\d+\)\.(json|send)' --glob '*.{ts,tsx,js,jsx}'
+
+# Templates (Jinja2 / ERB / Blade)
+rg -n 'error|alert' --glob '*.{html,jinja,erb,blade.php}'
+
+# Generic: quoted strings near error handling
+rg -B1 -A1 'error|failed|invalid|unable' --glob '!*.{lock,min.js}'
+```
+
+### Output shape
+
+Put the inventory in a spreadsheet or markdown table — one row per message:
+
+| # | File:Line | Trigger path | Current text | User-facing? | Frequency (30d) |
+|---|-----------|--------------|--------------|--------------|-----------------|
+| 1 | `auth/login.py:42` | POST /login bad creds | "Login failed." | Yes | 18,400 |
+| 2 | `api/users.py:88` | 500 fallback | "Internal server error" | Yes | 230 |
+
+## 2. Classify
+
+Mark each message:
+
+- **User-facing** — rendered to a human through the product UI. In scope.
+- **Developer-facing** — logs, stack traces, telemetry. Out of scope for this audit (see `error-handling` skill).
+- **Mixed** — e.g., an API error body that both logs emit *and* consumers render. Treat as user-facing; developers can read user-friendly text too.
+
+If classification is unclear, ask: *"If my parent hit this, would they see this exact string?"*
+
+## 3. Score
+
+For each user-facing message, score 0 or 1 on each rubric component:
+
+- [ ] **What**: names what failed in human terms
+- [ ] **Why**: gives a cause the user can act on (skip safely if N/A)
+- [ ] **Next**: specifies a concrete next action
+- [ ] **Escape**: offers a path when Next fails (trace ID, status page, support link)
+
+Also flag any message containing an anti-pattern (shrug, opaque code, blame, dev leak, dead-end, jargon, panic, liar, thief — see SKILL.md Step 4).
+
+A message passing fewer than 3/4 components or containing any anti-pattern is a rewrite candidate.
+
+## 4. Triage
+
+Sort rewrite candidates by **blast radius**:
+
+```
+priority_score = frequency × severity × stuck_factor
+```
+
+- **Frequency**: how often this message is seen (from logs, analytics, or support tickets).
+- **Severity**: 3 for data loss / payment / auth, 2 for core workflow, 1 for edge cases.
+- **Stuck factor**: 3 if no self-serve path exists, 2 if partial, 1 if easy workaround.
+
+Fix the top decile first. A full audit that ships nothing is worse than a focused audit that ships the top 20 messages.
+
+## 5. Rewrite
+
+Use templates from `rewrite-templates.md`. Each rewrite includes:
+
+- New message text
+- Trace ID surface (add one if missing — even a short hash of request ID helps support)
+- Severity / tone check (calm vs. serious)
+- Preservation statement if applicable ("your draft is saved")
+
+Keep the old error code or create a new one; map it in a lookup table so support can still match tickets to log lines.
+
+## 6. Ship in Reviewable Chunks
+
+- One PR per subsystem (auth, billing, forms, API, etc.), not one mega-PR.
+- Include before/after in the PR description so reviewers can feel the improvement.
+- Add a regression test or snapshot where feasible, so future commits can't quietly downgrade a message back to "An error occurred".
+
+## 7. Measure
+
+After shipping, watch:
+
+- Support-ticket volume tagged with the subsystem.
+- "Same user retried same action" rate (are they getting unstuck?).
+- Error-toast dismiss time (too fast = they didn't read; too slow = confusion).
+
+A good audit reduces support-ticket volume in the audited subsystem within the first month.

--- a/.claude/skills/user-facing-error-messages/references/rewrite-templates.md
+++ b/.claude/skills/user-facing-error-messages/references/rewrite-templates.md
@@ -1,0 +1,190 @@
+# Rewrite Templates
+
+Copy-pasteable before/after pairs organized by error category. Each template applies the four-part rubric (What / Why / Next / Escape) from `SKILL.md`.
+
+## Form & Input Validation
+
+### Required field missing
+
+- **Bad:** `This field is required.`
+- **Good:** `Email address is required — we'll send your receipt here.`
+
+Include the *purpose* of the field so the user sees why we're asking.
+
+### Format mismatch
+
+- **Bad:** `Invalid date.`
+- **Good:** `Use the format MM/DD/YYYY — for example, 04/13/2026.`
+
+Always show one concrete example in the right format.
+
+### Length / range
+
+- **Bad:** `Password does not meet requirements.`
+- **Good:** `Passwords need at least 12 characters. Yours has 7 — try a memorable passphrase like "tree-river-sunset".`
+
+Name the requirement, name the actual value, and suggest an approach.
+
+### Uniqueness / taken
+
+- **Bad:** `Username unavailable.`
+- **Good:** `"geoff" is taken. Try **geoff2026**, **geoff-g**, or [sign in] if it's you.`
+
+Offer suggestions derived from the user's input.
+
+## Authentication & Authorization
+
+### Bad credentials
+
+- **Bad:** `Authentication failed.`
+- **Good:** `That email and password don't match. [Reset password] or [create an account].`
+
+Do not disclose which field was wrong. Both next actions still work.
+
+### Session expired
+
+- **Bad:** `Unauthorized.`
+- **Good:** `You were signed out after 30 minutes of inactivity. [Sign in again] — your draft is saved.`
+
+Name the cause in user terms. Confirm preserved work.
+
+### Permission denied
+
+- **Bad:** `403 Forbidden.`
+- **Good:** `You don't have access to the "Marketing" workspace. Ask its owner, **Sam Rivera**, to invite you — or [switch workspaces].`
+
+Name the missing grant and the person who can give it.
+
+### MFA / 2FA failure
+
+- **Bad:** `Invalid code.`
+- **Good:** `That 6-digit code didn't match. Codes expire every 30 seconds — open your authenticator app and try the newest one. [Lost access?]`
+
+Explain the time-boxing and give the lost-device escape hatch.
+
+## Network / Service Failures
+
+### Transient server error
+
+- **Bad:** `Something went wrong. Please try again.`
+- **Good:**
+  > We couldn't save your changes — our server hiccuped.
+  >
+  > Your work is still in the form. [Try again] — if it fails twice, check [status.example.com] or [open a ticket] (ref: 7F3A2).
+
+Confirm preserved state; give retry, status page, and ticket path.
+
+### Offline / network down
+
+- **Bad:** `Network error.`
+- **Good:** `You're offline. We'll save your changes as soon as you're back on the internet — don't close this tab.`
+
+Own the user's fear (data loss). Tell them the action they *shouldn't* take.
+
+### Upstream/3rd-party down
+
+- **Bad:** `Gateway timeout.`
+- **Good:** `Our payment processor (Stripe) is slow right now. Your card wasn't charged. [Try again] in a minute, or [choose a different payment method].`
+
+Name the upstream plainly. Confirm no side effects.
+
+### Rate limited
+
+- **Bad:** `429 Too Many Requests.`
+- **Good:** `You've hit the limit of 60 messages per minute. You can send again in **42 seconds**.`
+
+Quantify the limit and the countdown. Avoid giving attackers exact state on sensitive endpoints — coordinate with `security` skill.
+
+## Payment & Billing
+
+### Card declined
+
+- **Bad:** `Payment failed.`
+- **Good:** `Your card ending in **1234** was declined by the issuing bank. Try a different card or contact your bank — we never see why they declined.`
+
+Say what you know and what you *don't* know. Prevent users from blaming you.
+
+### Subscription lapsed
+
+- **Bad:** `Access denied.`
+- **Good:** `Your Pro subscription ended on April 1. [Renew now] to restore team members, integrations, and analytics — nothing has been deleted.`
+
+Reassure about data. List what they're missing to create a clear value case.
+
+## Data / Storage
+
+### Not found
+
+- **Bad:** `404 Not Found.`
+- **Good:** `We couldn't find a project at that link. It may have been deleted or renamed. [See all your projects] or [search].`
+
+Offer two ways to rediscover.
+
+### Conflict / stale edit
+
+- **Bad:** `409 Conflict.`
+- **Good:** `Alex edited this page after you opened it. [See their changes], [overwrite with yours], or [merge both].`
+
+Name the other actor. Give a real choice.
+
+### Upload too large
+
+- **Bad:** `File too large.`
+- **Good:** `That file is **18 MB** — the limit is **10 MB**. [Compress it here] or email it as a link instead.`
+
+Actual size, actual limit, actual alternative.
+
+## CLI / Developer Tools
+
+CLIs *are* a UI. The same rubric applies, adjusted for a technical audience.
+
+- **Bad:** `ENOENT`
+- **Good:**
+  ```
+  ✗ Couldn't find config file at ./well-worn.toml
+
+    We checked: .  ../  ~/
+    Run `well-worn init` to create one, or pass --config <path>.
+  ```
+
+Show the search path. Name the fix command.
+
+## Empty / Zero-State Failures
+
+Failure isn't always red. Sometimes it's an empty page.
+
+- **Bad:** `No results.`
+- **Good:** `No projects match "archive 2019". Try removing a filter, or [clear all filters] to start over.`
+
+Name the query, name the levers.
+
+## i18n-Safe Patterns
+
+Messages that must translate cleanly:
+
+- Interpolate variables — don't concatenate strings.
+- Avoid contractions, idioms, puns.
+- Keep trace IDs, example values, and numbers out of the translatable string.
+
+```python
+# Bad
+msg = "Couldn't find " + name + " — did you mean " + suggestion + "?"
+
+# Good
+msg = _("We couldn't find {name}. Did you mean {suggestion}?").format(
+    name=name, suggestion=suggestion
+)
+```
+
+## Tone Ladder
+
+Pick severity, match tone:
+
+| Severity | Example scenario | Tone | Example opening |
+|----------|-----------------|------|-----------------|
+| Low | Typo in form | Helpful, light | "Almost! …" |
+| Medium | Request failed, recoverable | Calm, factual | "We couldn't save …" |
+| High | Data loss possible | Serious, direct | "Your changes weren't saved …" |
+| Critical | Security / account takeover | Urgent, action-first | "Sign out of all devices now …" |
+
+Never use exclamation points on Medium+. Never use "Oops" or "Uh oh" on High+.

--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -1,0 +1,95 @@
+name: Iteration Trigger
+
+# Posts a brief executive summary on a PR (commenting as Geoffe-Ga via PAT)
+# whenever CI completes fully green AND a Claude review has been posted.
+# The comment is intended to fire a webhook that wakes the Claude Code mobile
+# app via MCP so it can continue iterating on feedback. Capped at 10 self-posts
+# per PR to avoid runaway loops.
+#
+# Required secrets:
+#   GEOFFE_GA_PAT  - personal access token for Geoffe-Ga with `pull-requests: write`.
+#                    Without this the comment would post as github-actions[bot]
+#                    and the mobile webhook would not recognize the author.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  nudge:
+    name: Post executive summary
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number from head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          PR=$(gh pr list -R "$REPO" --head "$BRANCH" --state open \
+                 --json number --jq '.[0].number // empty')
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Compose and post summary
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          MARKER: '<!-- iteration-trigger -->'
+        run: |
+          set -euo pipefail
+
+          # Pull PR comments once (first 100 is plenty for an active PR).
+          gh api "repos/$REPO/issues/$PR/comments?per_page=100" > comments.json
+
+          # Cap: stop after 10 prior self-posts on this PR.
+          PRIOR=$(grep -c "$MARKER" comments.json || true)
+          if [ "$PRIOR" -ge 10 ]; then
+            echo "Cap reached ($PRIOR/10) - skipping"
+            exit 0
+          fi
+
+          # Find latest Claude review comment (its body contains 'Verdict').
+          CLAUDE=$(jq -c '[.[] | select(.body | test("Verdict"))] | last // empty' comments.json)
+          if [ -z "$CLAUDE" ]; then
+            echo "No Claude review yet - skipping"
+            exit 0
+          fi
+          ID=$(jq -r '.id'   <<<"$CLAUDE")
+          BODY=$(jq -r '.body' <<<"$CLAUDE")
+
+          # Summarize verdict via grep on the Claude comment body.
+          if   grep -qE 'CHANGES[_ ]REQUESTED' <<<"$BODY"; then VERDICT='CHANGES REQUESTED'
+          elif grep -q   'LGTM'                <<<"$BODY"; then VERDICT='LGTM'
+          else                                                  VERDICT='COMMENTS'
+          fi
+
+          # CI status from check-runs on the head SHA.
+          gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" > runs.json
+          TOTAL=$(jq '.check_runs | length'                                       runs.json)
+          GREEN=$(jq '[.check_runs[] | select(.conclusion=="success")] | length' runs.json)
+
+          if [ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]; then
+            ACTION="You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed."
+          else
+            ACTION="pull comment ${ID} to see in-depth feedback and continue iterating"
+          fi
+
+          BODY=$(printf '%s\n%s\n%s\n%s\n' \
+            "$MARKER" \
+            "**CI**: ${GREEN}/${TOTAL} Green" \
+            "**VERDICT**: ${VERDICT}" \
+            "**Action**: ${ACTION}")
+          gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY"


### PR DESCRIPTION
## Summary

Adds 12 skill(s) and 1 workflow(s) from [`Geoffe-Ga/well-worn-tools`](https://github.com/Geoffe-Ga/well-worn-tools/tree/22ee048) to this repo.

## Skills

- **address-feedback** — - Iterate on Claude PR review feedback intelligently and merge when ready.
- **await-claude-review** — - Subscribe to GitHub PR activity and wait — without polling — for the Claude reviewer's verdict comment on the current HEAD.
- **concurrency** — - Safe and efficient concurrent code patterns across languages.
- **cve-remediation** — - Remediate dependency vulnerability scanner failures by verifying live package registry data and upgrading instead of suppressing.
- **documentation** — - Write clear, comprehensive documentation with language-specific patterns.
- **error-handling** — - Implement robust error handling that fails fast with clear diagnostics.
- **frontend-aesthetics** — - Produce polished, accessible frontend UI with design tokens, semantic HTML, and Pico CSS.
- **git-workflow** — - Issue-first development workflow with template-file-based gh commands and label hygiene.
- **mutation-testing** — - Write high-value tests that kill mutants through logic validation.
- **security** — - Implement secure coding practices against common vulnerabilities.
- **skill-craft** — - Build and validate Claude Code skills to production quality.
- **user-facing-error-messages** — - Audit and rewrite user-facing error messages so users can self-serve instead of emailing support.

## Workflows

- **iteration-trigger.yml** — Posts a brief CI / Claude-verdict / next-action summary comment (as the repo owner via PAT) whenever CI completes fully green and a Claude review comment exists, capped at 10 self-posts per PR. Designed to wake a Claude Code mobile session via webhook so it can keep iterating on review feedback.
  - **Requires:** (a) a workflow named `CI` in the target repo so the `workflow_run` trigger matches; (b) repo secret `GEOFFE_GA_PAT` — a PAT with `pull-requests: write` so the comment posts under the owner's identity rather than github-actions[bot]; (c) an active Claude review workflow whose comments include a `Verdict` line (see `claude-code-review.yml` upstream).

## Provenance

Source SHA: `22ee0481d6609a647feef742417b02692434cd08`
Distributed via the `distribute-skills` skill (`metadata.distribute: false`, stays in well-worn-tools).

## Test plan

- [ ] Confirm `.claude/skills/` directory structure looks right
- [ ] Spot-check one SKILL.md frontmatter for syntax
- [ ] Decide whether each skill's triggers fit this repo's workflows
- [ ] Confirm each new file under `.github/workflows/` parses (actionlint)
- [ ] Wire any required secrets noted under **Workflows** above
- [ ] Confirm any referenced workflow names exist in this repo