### PR TITLE
chore: target Xcode 26 / watchOS 26 SDK in CI and local toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,20 +83,22 @@ jobs:
 
       - name: Select Xcode
         run: |
-          # Use Xcode 16.x for watchOS 11.x deployment targets (Swift 5 mode).
-          # The project hasn't migrated to the watchOS 26 SDK yet — switch to
-          # Xcode 26.x here once that migration is complete.
-          # GitHub runners use versioned names (Xcode_16.4.app, Xcode_26.3.app, etc.)
-          XCODE_16=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          # Prefer Xcode 26.x so the build sees the watchOS 26 SDK and the
+          # `if #available(watchOS 26, *)` Liquid Glass gates resolve against
+          # real symbols. Fall back to Xcode 16.x if 26 is unavailable on the
+          # runner image — the project's deployment target (watchOS 11) and
+          # Swift 5 mode keep both toolchains buildable for now.
+          # GitHub runners use versioned names (Xcode_26.3.app, Xcode_16.4.app, etc.)
           XCODE_26=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
-          if [ -n "$XCODE_16" ]; then
-            echo "Selected: $XCODE_16"
-            sudo xcode-select -s "$XCODE_16/Contents/Developer"
-          elif [ -n "$XCODE_26" ]; then
-            echo "Falling back to: $XCODE_26"
+          XCODE_16=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$XCODE_26" ]; then
+            echo "Selected: $XCODE_26"
             sudo xcode-select -s "$XCODE_26/Contents/Developer"
+          elif [ -n "$XCODE_16" ]; then
+            echo "Falling back to: $XCODE_16"
+            sudo xcode-select -s "$XCODE_16/Contents/Developer"
           else
-            echo "No Xcode 16.x or 26.x found. Available installations:"
+            echo "No Xcode 26.x or 16.x found. Available installations:"
             ls /Applications/Xcode*.app 2>/dev/null || echo "  (none)"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ swiftformat frontend
 swiftformat --lint frontend  # Check formatting without modifying
 
 # Build (use Xcode for running)
-# Open frontend/WavelengthWatch/WavelengthWatch.xcodeproj in Xcode 16.4+ (or Xcode 18+)
+# Open frontend/WavelengthWatch/WavelengthWatch.xcodeproj in Xcode 26.3+ (Xcode 16.4 still builds, but Liquid Glass APIs need 26+)
 # Select Apple Watch target and build/run
 
 # Testing

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ When the backend changes environment (e.g., staging vs. production), check in th
 ## Getting Started
 
 ### Frontend (watchOS)
-1. Open `frontend/WavelengthWatch/WavelengthWatch.xcodeproj` in Xcode 16.4 or newer.
+1. Open `frontend/WavelengthWatch/WavelengthWatch.xcodeproj` in Xcode 26.3 or newer (Xcode 16.4 still builds, but Liquid Glass APIs require the watchOS 26 SDK).
 2. Select an Apple Watch simulator (or paired device) as the run destination.
 3. Update `APIConfiguration.plist` with your backend URL, then press ▶ to build and run.
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -141,29 +141,62 @@ struct ContentView: View {
 
   var body: some View {
     NavigationStack(path: $navigationPath) {
-      ZStack {
-        if viewModel.layers.isEmpty {
-          if viewModel.isLoading {
-            ProgressView("Loading curriculum…")
-              .foregroundStyle(.white)
-          } else if let error = viewModel.loadErrorMessage {
-            VStack(spacing: 12) {
-              Text(error)
-                .multilineTextAlignment(.center)
-              Button("Retry") {
-                Task { await viewModel.retry() }
-              }
-            }
-            .padding()
-          } else {
-            ProgressView("Loading curriculum…")
+      contentWithDialogs
+        .toolbar { toolbarContent }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("")
+        .navigationDestination(for: DetailDestination.self) { destination in
+          switch destination {
+          case let .curriculum(layer, phase, colorName):
+            CurriculumDetailView(layer: layer, phase: phase, color: Color(stage: colorName))
+          case let .strategy(phase, colorName):
+            StrategyListView(phase: phase, color: Color(stage: colorName))
           }
-        } else if viewModel.phaseOrder.isEmpty {
-          Text("No phase information available.")
-        } else {
-          layeredContent
         }
+    }
+    .environmentObject(viewModel)
+    .environmentObject(flowCoordinator)
+    .environment(\.isShowingDetailView, $isShowingDetailView)
+  }
+
+  // MARK: - Body decomposition
+
+  // The view body chains ~30 modifiers across lifecycle, onChange, alerts,
+  // sheets, toolbar, and navigation. Swift 6's type checker can't resolve
+  // that single expression in reasonable time, so we stage the chain
+  // through intermediate `some View` properties — each return type erases
+  // the upstream complexity, letting the checker rest.
+
+  /// Inner content — the ZStack only, no modifiers.
+  private var contentZStack: some View {
+    ZStack {
+      if viewModel.layers.isEmpty {
+        if viewModel.isLoading {
+          ProgressView("Loading curriculum…")
+            .foregroundStyle(.white)
+        } else if let error = viewModel.loadErrorMessage {
+          VStack(spacing: 12) {
+            Text(error)
+              .multilineTextAlignment(.center)
+            Button("Retry") {
+              Task { await viewModel.retry() }
+            }
+          }
+          .padding()
+        } else {
+          ProgressView("Loading curriculum…")
+        }
+      } else if viewModel.phaseOrder.isEmpty {
+        Text("No phase information available.")
+      } else {
+        layeredContent
       }
+    }
+  }
+
+  /// Adds lifecycle hooks and state-sync `onChange` handlers.
+  private var contentWithEvents: some View {
+    contentZStack
       .ignoresSafeArea(edges: .bottom)
       .task { await viewModel.loadCatalog() }
       .task {
@@ -236,6 +269,11 @@ struct ContentView: View {
           phaseSelection = expected
         }
       }
+  }
+
+  /// Adds the alert presentations, sheet stack, and onboarding-check task.
+  private var contentWithDialogs: some View {
+    contentWithEvents
       .alert(item: $viewModel.journalFeedback) { feedback in
         switch feedback.kind {
         case .success:
@@ -378,46 +416,34 @@ struct ContentView: View {
           showingOnboarding = true
         }
       }
-      .toolbar {
-        if !isShowingDetailView {
-          ToolbarItem(placement: .topBarLeading) {
-            // Show back chevron when in flow mode, menu button otherwise
-            if flowCoordinator.currentStep != .idle {
-              Button {
-                flowCoordinator.cancel()
-              } label: {
-                Image(systemName: "chevron.left")
-                  .font(.system(size: UIConstants.menuButtonSize))
-                  .foregroundColor(.white.opacity(0.7))
-              }
-              .buttonStyle(.plain)
-            } else {
-              Button {
-                showingMenu = true
-              } label: {
-                Image(systemName: "ellipsis.circle")
-                  .font(.system(size: UIConstants.menuButtonSize))
-                  .foregroundColor(.white.opacity(0.7))
-              }
-              .buttonStyle(.plain)
-            }
+  }
+
+  /// Top-bar toolbar: back chevron when in flow mode, menu button otherwise.
+  @ToolbarContentBuilder
+  private var toolbarContent: some ToolbarContent {
+    if !isShowingDetailView {
+      ToolbarItem(placement: .topBarLeading) {
+        if flowCoordinator.currentStep != .idle {
+          Button {
+            flowCoordinator.cancel()
+          } label: {
+            Image(systemName: "chevron.left")
+              .font(.system(size: UIConstants.menuButtonSize))
+              .foregroundColor(.white.opacity(0.7))
           }
-        }
-      }
-      .navigationBarTitleDisplayMode(.inline)
-      .navigationTitle("")
-      .navigationDestination(for: DetailDestination.self) { destination in
-        switch destination {
-        case let .curriculum(layer, phase, colorName):
-          CurriculumDetailView(layer: layer, phase: phase, color: Color(stage: colorName))
-        case let .strategy(phase, colorName):
-          StrategyListView(phase: phase, color: Color(stage: colorName))
+          .buttonStyle(.plain)
+        } else {
+          Button {
+            showingMenu = true
+          } label: {
+            Image(systemName: "ellipsis.circle")
+              .font(.system(size: UIConstants.menuButtonSize))
+              .foregroundColor(.white.opacity(0.7))
+          }
+          .buttonStyle(.plain)
         }
       }
     }
-    .environmentObject(viewModel)
-    .environmentObject(flowCoordinator)
-    .environment(\.isShowingDetailView, $isShowingDetailView)
   }
 
   private var layeredContent: some View {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLTheme.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLTheme.swift
@@ -15,11 +15,13 @@ enum WLTheme {
   /// Checks watchOS 26 availability. On older versions, all Glass
   /// modifiers degrade to fallback styling automatically.
   ///
-  /// - Note: Until Xcode 18 ships with the watchOS 26 SDK, this
-  ///   always returns `false`. Remove the early return when the
-  ///   SDK is available.
+  /// The build now targets the watchOS 26 SDK (via Xcode 26), so the
+  /// `if #available(watchOS 26, *)` gate resolves to real API calls
+  /// at runtime on supported hardware and to fallbacks elsewhere.
   static var isGlassAvailable: Bool {
-    // TODO: watchOS 26 — Remove early return when Xcode 18 SDK ships
-    false
+    if #available(watchOS 26, *) {
+      return true
+    }
+    return false
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLGlassModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLGlassModifierTests.swift
@@ -34,8 +34,15 @@ struct WLGlassModifierTests {
     #expect(modifier.tint == .blue)
   }
 
-  @Test func glassAvailable_returnsFalseOnCurrentSDK() {
-    // Until Xcode 18 ships, Glass APIs are not available
-    #expect(WLTheme.isGlassAvailable == false)
+  @Test func glassAvailable_tracksRuntimeSDK() {
+    // The build now targets the watchOS 26 SDK (Xcode 26), so Glass APIs
+    // resolve at runtime against `if #available(watchOS 26, *)`. On a
+    // watchOS 26+ simulator the flag is true; on older runtimes it stays
+    // false and modifiers fall back automatically.
+    if #available(watchOS 26, *) {
+      #expect(WLTheme.isGlassAvailable == true)
+    } else {
+      #expect(WLTheme.isGlassAvailable == false)
+    }
   }
 }


### PR DESCRIPTION
## Summary

Flips CI to prefer Xcode 26.x (falling back to 16.x) so the build sees the watchOS 26 SDK. With the new SDK in scope, the existing \`if #available(watchOS 26, *)\` Liquid Glass gates resolve to real symbols instead of dead fallbacks — unblocking subsequent PRs to replace \`// TODO: watchOS 26\` stubs with actual \`.glassEffect()\`, \`.glassProminent\`, \`safeAreaBar(...)\` calls.

Required three follow-on changes to keep the suite green under Xcode 26:

1. **\`ContentView.swift\` body decomposition.** The body chained ~30 modifiers (2 \`.task\`, 9 \`.onChange\`, 4 \`.alert\`, 3 \`.sheet\`, \`.toolbar\`, navigation modifiers). Swift 6's tighter type checker fails with *"unable to type-check this expression in reasonable time"*. Staged through \`contentZStack\` → \`contentWithEvents\` → \`contentWithDialogs\` so each \`some View\` boundary gives the checker a resting point; \`.toolbar\` content is now a \`@ToolbarContentBuilder\` property. Pure refactor, no behavior change.
2. **\`WLTheme.isGlassAvailable\`.** Was a stub returning \`false\` with a TODO to remove "when Xcode 18 ships". Updated to runtime-check \`#available(watchOS 26, *)\` — true on supported hardware, false elsewhere (existing fallback path).
3. **\`WLGlassModifierTests/glassAvailable_returnsFalseOnCurrentSDK\`** → renamed to \`glassAvailable_tracksRuntimeSDK\` and asserts the runtime-correct value.

Stale \`Xcode 16.4+ / Xcode 18+\` references in \`CLAUDE.md\` and \`README.md\` are updated.

## Scope (intentionally narrow)

- Deployment target stays at \`watchOS 11.0/11.5\` so older Apple Watches keep running this build.
- \`SWIFT_VERSION = 5.0\` stays; Swift 6 strict-concurrency adoption is a separate concern (e.g., \`JournalQueue\` main-actor isolation warnings would become errors and need their own fix).
- No \`// TODO: watchOS 26\` stub replacement yet — those land in follow-up PRs that wire real Liquid Glass APIs into specific surfaces.

## Test plan

- [x] \`frontend/WavelengthWatch/run-tests-individually.sh\` — all 43 suites pass under Xcode 26.3 locally.
- [x] \`pre-commit run --all-files\` — clean.
- [ ] CI verifies Xcode 26 build (the runner image must have Xcode 26.x installed; falls back to 16.x otherwise).
- [ ] Manual smoke on a watchOS 26 simulator: navigation, sheets, alerts, toolbar all render correctly.