### PR TITLE
feat(navigation): wire wlNavigationBar() into the main shell (#295)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -145,6 +145,7 @@ struct ContentView: View {
         .toolbar { toolbarContent }
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle("")
+        .wlNavigationBar()
         .navigationDestination(for: DetailDestination.self) { destination in
           switch destination {
           case let .curriculum(layer, phase, colorName):


### PR DESCRIPTION
Closes part of #295 (Phase 2a — first slice).

## Summary

First piece of Phase 2a. The design-system modifier \`wlNavigationBar()\` was wired by #320 but had no callers — adding it to \`ContentView\`'s NavigationStack chain is its first real use, and the smallest possible step toward the *"Liquid Glass applied to navigation chrome (backward-compatible)"* acceptance criterion.

## Behavior

- **watchOS 26+:** modifier is a no-op — the system renders Liquid Glass on the toolbar automatically when the background isn't hidden. Visual stays identical to today.
- **Pre-26 runtimes:** applies \`.toolbarBackground(.hidden, for: .navigationBar)\` so content shows through, matching the design intent of letting the dual-axis layer content read as the visual surface.

## Out of scope (next slices of #295)

- \`NavigationViewModel\` extraction (testable VM acceptance criterion).
- File-size decomposition (ContentView is 622 lines, PhasePageView 203; target ≤200 per file).

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --files\` clean.
- [ ] Manual smoke on watchOS 26 simulator (visual confirm glass renders on top toolbar).
- [ ] Manual smoke on watchOS 11 simulator (visual confirm transparent toolbar with content showing through).