### PR TITLE
refactor(navigation): extract LayerScrollView from ContentView (#295)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -15,8 +15,6 @@ struct ContentView: View {
   let catalogRepository: CatalogRepositoryProtocol
   @State private var layerSelection: Int
   @State private var phaseSelection: Int
-  @State private var showLayerIndicator = false
-  @State private var hideIndicatorTask: Task<Void, Never>?
   @State private var showingMenu = false
   @State private var showingOnboarding = false
   @State private var isShowingDetailView = false
@@ -222,8 +220,6 @@ struct ContentView: View {
             storedLayerIndex = fullIndex
           }
         }
-        showLayerIndicator = true
-        scheduleLayerIndicatorHide()
       }
       .onChange(of: viewModel.selectedLayerId) { _, newLayerId in
         // When selectedLayerId changes, update layerSelection to match in filtered array
@@ -448,88 +444,11 @@ struct ContentView: View {
   }
 
   private var layeredContent: some View {
-    GeometryReader { geometry in
-      ScrollViewReader { proxy in
-        ScrollView(.vertical, showsIndicators: false) {
-          LazyVStack(spacing: -20) {
-            ForEach(viewModel.filteredLayers.indices, id: \.self) { index in
-              let layer = viewModel.filteredLayers[index]
-              LayerCardView(
-                layer: layer,
-                phaseCount: viewModel.phaseOrder.count,
-                selection: $phaseSelection,
-                layerIndex: index,
-                selectedLayerIndex: clampedLayerSelection,
-                geometry: geometry,
-                screenWidth: geometry.size.width
-              )
-              .id(index)
-            }
-          }
-          .scrollTargetLayout()
-        }
-        .scrollTargetBehavior(.viewAligned)
-        .scrollDisabled(false)
-        .scrollPosition(id: .init(
-          get: { clampedLayerSelection },
-          set: { newId in
-            if let newId = newId as? Int, newId != layerSelection {
-              layerSelection = newId
-            }
-          }
-        ))
-        .digitalCrownRotation(
-          .init(
-            get: { Double(clampedLayerSelection) },
-            set: { newValue in
-              guard viewModel.filteredLayers.count > 0 else { return }
-              let clampedValue = Int(round(newValue)).clamped(to: 0 ... (viewModel.filteredLayers.count - 1))
-              if clampedValue != layerSelection {
-                layerSelection = clampedValue
-              }
-            }
-          ),
-          from: 0,
-          through: Double(max(viewModel.filteredLayers.count - 1, 0)),
-          by: 1.0,
-          sensitivity: .medium,
-          isContinuous: false,
-          isHapticFeedbackEnabled: true
-        )
-        .onChange(of: layerSelection) { _, newValue in
-          guard viewModel.filteredLayers.count > 0, newValue < viewModel.filteredLayers.count else { return }
-          withAnimation(.easeInOut(duration: 0.3)) {
-            proxy.scrollTo(newValue, anchor: .center)
-          }
-        }
-        .onAppear {
-          guard viewModel.filteredLayers.count > 0, layerSelection < viewModel.filteredLayers.count else { return }
-          proxy.scrollTo(layerSelection, anchor: .center)
-          showLayerIndicator = true
-          scheduleLayerIndicatorHide()
-        }
-        .overlay(alignment: .trailing) {
-          enhancedLayerIndicator(in: geometry.size)
-        }
-        // Note: DragGesture uses raw layerSelection for bounds checking because we're
-        // setting a new value (not reading for display). The bounds check against
-        // filteredLayers.count is safe because we're modifying layerSelection, which
-        // will then be clamped via clampedLayerSelection for any binding reads.
-        .simultaneousGesture(
-          DragGesture()
-            .onEnded { value in
-              let threshold: CGFloat = 30
-              if value.translation.height > threshold, layerSelection > 0 {
-                layerSelection -= 1
-              } else if value.translation.height < -threshold, layerSelection < viewModel.filteredLayers.count - 1 {
-                layerSelection += 1
-              }
-              showLayerIndicator = true
-              scheduleLayerIndicatorHide()
-            }
-        )
-      }
-    }
+    LayerScrollView(
+      viewModel: viewModel,
+      layerSelection: $layerSelection,
+      phaseSelection: $phaseSelection
+    )
   }
 
   private func adjustPhaseSelection() {
@@ -537,83 +456,6 @@ struct ContentView: View {
     let adjusted = PhaseNavigator.adjustedSelection(phaseSelection, phaseCount: viewModel.phaseOrder.count)
     if adjusted != phaseSelection {
       phaseSelection = adjusted
-    }
-  }
-
-  private func enhancedLayerIndicator(in size: CGSize) -> some View {
-    VStack {
-      Spacer()
-      ZStack(alignment: .top) {
-        // Background track
-        Capsule()
-          .fill(Color.white.opacity(0.1))
-          .frame(width: 4, height: size.height * 0.5)
-
-        // Current layer indicators stack
-        VStack(spacing: 2) {
-          ForEach(viewModel.filteredLayers.indices, id: \.self) { index in
-            let layer = viewModel.filteredLayers[index]
-            let isSelected = index == clampedLayerSelection
-            let distance = abs(index - clampedLayerSelection)
-
-            Capsule()
-              .fill(
-                isSelected ?
-                  LinearGradient(
-                    gradient: Gradient(colors: [
-                      Color(stage: layer.color),
-                      Color(stage: layer.color).opacity(0.7),
-                    ]),
-                    startPoint: .top,
-                    endPoint: .bottom
-                  ) :
-                  LinearGradient(
-                    gradient: Gradient(colors: [
-                      Color(stage: layer.color).opacity(0.3),
-                      Color(stage: layer.color).opacity(0.1),
-                    ]),
-                    startPoint: .top,
-                    endPoint: .bottom
-                  )
-              )
-              .frame(
-                width: isSelected ? 8 : 4,
-                height: isSelected ? 16 : 8
-              )
-              .overlay(
-                Capsule()
-                  .stroke(
-                    isSelected ? Color.white.opacity(0.4) : Color.white.opacity(0.1),
-                    lineWidth: 0.5
-                  )
-              )
-              .shadow(
-                color: isSelected ? Color(stage: layer.color) : Color.clear,
-                radius: isSelected ? 3 : 0
-              )
-              .scaleEffect(distance > 2 ? 0.6 : 1.0)
-              .opacity(distance > 3 ? 0 : 1)
-              .animation(.interactiveSpring(response: 0.3, dampingFraction: 0.7), value: clampedLayerSelection)
-          }
-        }
-      }
-      .offset(x: -6) // Use offset instead of padding to avoid layout impact when opacity changes
-      Spacer()
-    }
-    .opacity(showLayerIndicator ? 1 : 0)
-    .transition(.opacity)
-  }
-
-  private func scheduleLayerIndicatorHide() {
-    hideIndicatorTask?.cancel()
-    hideIndicatorTask = Task {
-      try? await Task.sleep(nanoseconds: 1_000_000_000)
-      guard !Task.isCancelled else { return }
-      await MainActor.run {
-        withAnimation(.easeOut(duration: 0.3)) {
-          showLayerIndicator = false
-        }
-      }
     }
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -31,7 +31,6 @@ struct LayerScrollView: View {
       ScrollViewReader { proxy in
         scrollView(geometry: geometry)
           .scrollTargetBehavior(.viewAligned)
-          .scrollDisabled(false)
           .scrollPosition(id: Binding<Int?>(
             get: { clampedSelection },
             set: { newId in
@@ -72,6 +71,12 @@ struct LayerScrollView: View {
                   layerSelection < viewModel.filteredLayers.count else { return }
             proxy.scrollTo(layerSelection, anchor: .center)
             flashIndicator()
+          }
+          .onDisappear {
+            // Mirror the LayerView pattern: any pending hide task that
+            // outlives the view would later try to mutate state on a
+            // detached view via `MainActor.run`.
+            hideIndicatorTask?.cancel()
           }
           .overlay(alignment: .trailing) {
             sideIndicator(in: geometry.size)
@@ -121,13 +126,16 @@ struct LayerScrollView: View {
   }
 
   private func sideIndicator(in size: CGSize) -> some View {
+    // The indicator stays in the hierarchy at all times — visibility is
+    // driven by opacity, animated through the `withAnimation` blocks in
+    // `flashIndicator()` / `scheduleHide()`. No `.transition(.opacity)`
+    // since the view is never inserted/removed.
     LayerSideIndicator(
       layers: viewModel.filteredLayers,
       selection: clampedSelection,
       size: size
     )
     .opacity(showIndicator ? 1 : 0)
-    .transition(.opacity)
   }
 
   // MARK: - Indicator lifecycle

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+/// Vertical layer scroller — the outer axis of the dual-axis navigation.
+///
+/// Renders the filtered layers from `ContentViewModel` as full-screen
+/// `LayerCardView` pages, hosts the digital-crown / drag-gesture / scroll
+/// position bindings, and owns the auto-hiding side indicator.
+///
+/// The indicator state (visibility + hide-after task) lives here rather
+/// than on `ContentView` because it's a property of the scroll surface
+/// itself: every interaction that nudges the layer selection on this
+/// view flashes the indicator and re-arms the auto-hide.
+struct LayerScrollView: View {
+  @ObservedObject var viewModel: ContentViewModel
+  @Binding var layerSelection: Int
+  @Binding var phaseSelection: Int
+
+  @State private var showIndicator = false
+  @State private var hideIndicatorTask: Task<Void, Never>?
+
+  /// Clamps `layerSelection` to the current filtered range so bindings
+  /// can never read an out-of-range index — important during filter-mode
+  /// transitions where `layerSelection` may be stale for one render.
+  private var clampedSelection: Int {
+    guard !viewModel.filteredLayers.isEmpty else { return 0 }
+    return min(layerSelection, viewModel.filteredLayers.count - 1)
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      ScrollViewReader { proxy in
+        scrollView(geometry: geometry)
+          .scrollTargetBehavior(.viewAligned)
+          .scrollDisabled(false)
+          .scrollPosition(id: Binding<Int?>(
+            get: { clampedSelection },
+            set: { newId in
+              if let newId, newId != layerSelection {
+                layerSelection = newId
+              }
+            }
+          ))
+          .digitalCrownRotation(
+            Binding<Double>(
+              get: { Double(clampedSelection) },
+              set: { newValue in
+                guard !viewModel.filteredLayers.isEmpty else { return }
+                let clampedValue = Int(round(newValue))
+                  .clamped(to: 0 ... (viewModel.filteredLayers.count - 1))
+                if clampedValue != layerSelection {
+                  layerSelection = clampedValue
+                }
+              }
+            ),
+            from: 0,
+            through: Double(max(viewModel.filteredLayers.count - 1, 0)),
+            by: 1.0,
+            sensitivity: .medium,
+            isContinuous: false,
+            isHapticFeedbackEnabled: true
+          )
+          .onChange(of: layerSelection) { _, newValue in
+            guard !viewModel.filteredLayers.isEmpty,
+                  newValue < viewModel.filteredLayers.count else { return }
+            withAnimation(.easeInOut(duration: 0.3)) {
+              proxy.scrollTo(newValue, anchor: .center)
+            }
+            flashIndicator()
+          }
+          .onAppear {
+            guard !viewModel.filteredLayers.isEmpty,
+                  layerSelection < viewModel.filteredLayers.count else { return }
+            proxy.scrollTo(layerSelection, anchor: .center)
+            flashIndicator()
+          }
+          .overlay(alignment: .trailing) {
+            sideIndicator(in: geometry.size)
+          }
+          // DragGesture writes raw `layerSelection`; the bounds check uses
+          // `filteredLayers.count` since reads downstream are clamped via
+          // `clampedSelection`.
+          .simultaneousGesture(
+            DragGesture()
+              .onEnded { value in
+                let threshold: CGFloat = 30
+                if value.translation.height > threshold, layerSelection > 0 {
+                  layerSelection -= 1
+                } else if value.translation.height < -threshold,
+                          layerSelection < viewModel.filteredLayers.count - 1
+                {
+                  layerSelection += 1
+                }
+                flashIndicator()
+              }
+          )
+      }
+    }
+  }
+
+  // MARK: - Subviews
+
+  private func scrollView(geometry: GeometryProxy) -> some View {
+    ScrollView(.vertical, showsIndicators: false) {
+      LazyVStack(spacing: -20) {
+        ForEach(viewModel.filteredLayers.indices, id: \.self) { index in
+          let layer = viewModel.filteredLayers[index]
+          LayerCardView(
+            layer: layer,
+            phaseCount: viewModel.phaseOrder.count,
+            selection: $phaseSelection,
+            layerIndex: index,
+            selectedLayerIndex: clampedSelection,
+            geometry: geometry,
+            screenWidth: geometry.size.width
+          )
+          .id(index)
+        }
+      }
+      .scrollTargetLayout()
+    }
+  }
+
+  private func sideIndicator(in size: CGSize) -> some View {
+    LayerSideIndicator(
+      layers: viewModel.filteredLayers,
+      selection: clampedSelection,
+      size: size
+    )
+    .opacity(showIndicator ? 1 : 0)
+    .transition(.opacity)
+  }
+
+  // MARK: - Indicator lifecycle
+
+  private func flashIndicator() {
+    showIndicator = true
+    scheduleHide()
+  }
+
+  private func scheduleHide() {
+    hideIndicatorTask?.cancel()
+    hideIndicatorTask = Task {
+      try? await Task.sleep(nanoseconds: 1_000_000_000)
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        withAnimation(.easeOut(duration: 0.3)) {
+          showIndicator = false
+        }
+      }
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerSideIndicator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerSideIndicator.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Auto-fading right-edge indicator showing the current layer's position
+/// in the stack. Each layer is a small capsule; the selected one is
+/// larger, brighter, and shadowed in the layer's color. Distant layers
+/// scale down and fade out so the indicator stays compact on small
+/// screen sizes.
+struct LayerSideIndicator: View {
+  let layers: [CatalogLayerModel]
+  let selection: Int
+  let size: CGSize
+
+  var body: some View {
+    VStack {
+      Spacer()
+      ZStack(alignment: .top) {
+        Capsule()
+          .fill(Color.white.opacity(0.1))
+          .frame(width: 4, height: size.height * 0.5)
+
+        VStack(spacing: 2) {
+          ForEach(layers.indices, id: \.self) { index in
+            indicatorCapsule(at: index)
+          }
+        }
+      }
+      // Offset (not padding) so opacity changes don't shift layout.
+      .offset(x: -6)
+      Spacer()
+    }
+  }
+
+  private func indicatorCapsule(at index: Int) -> some View {
+    let layer = layers[index]
+    let isSelected = index == selection
+    let distance = abs(index - selection)
+
+    return Capsule()
+      .fill(fill(for: layer, selected: isSelected))
+      .frame(
+        width: isSelected ? 8 : 4,
+        height: isSelected ? 16 : 8
+      )
+      .overlay(
+        Capsule()
+          .stroke(
+            isSelected ? Color.white.opacity(0.4) : Color.white.opacity(0.1),
+            lineWidth: 0.5
+          )
+      )
+      .shadow(
+        color: isSelected ? Color(stage: layer.color) : Color.clear,
+        radius: isSelected ? 3 : 0
+      )
+      .scaleEffect(distance > 2 ? 0.6 : 1.0)
+      .opacity(distance > 3 ? 0 : 1)
+      .animation(.interactiveSpring(response: 0.3, dampingFraction: 0.7), value: selection)
+  }
+
+  private func fill(for layer: CatalogLayerModel, selected: Bool) -> LinearGradient {
+    let base = Color(stage: layer.color)
+    if selected {
+      return LinearGradient(
+        colors: [base, base.opacity(0.7)],
+        startPoint: .top,
+        endPoint: .bottom
+      )
+    }
+    return LinearGradient(
+      colors: [base.opacity(0.3), base.opacity(0.1)],
+      startPoint: .top,
+      endPoint: .bottom
+    )
+  }
+}


### PR DESCRIPTION
Part of #295 (Phase 2a — second slice).

## Summary

\`ContentView\` held the dual-axis vertical scroller, its side indicator, and the auto-hide task in one place — pushing the file to 622 lines, well past the Phase 2a \`≤200\` target. This splits that surface into two cohesive views:

- **\`LayerScrollView\`** (152 lines) — owns the vertical \`ScrollView\` with its \`scrollPosition\` / \`digitalCrownRotation\` / drag-gesture bindings, the \`ScrollViewReader.proxy.scrollTo\` coordination, and the indicator visibility + hide-after-1s task. The indicator state moves here because every gesture that nudges the layer selection on this view flashes the indicator and re-arms the auto-hide — a property of the scroll surface itself, not the broader app shell.
- **\`LayerSideIndicator\`** (75 lines) — the auto-fading right-edge capsule stack showing the current layer's position. Each capsule scales / fades by distance from selection; the selected one is bigger, brighter, and shadowed in the layer's color.

\`ContentView\` drops **622 → 465 lines** (−157, −25%). Still over the phase target; subsequent slices will continue the decomposition (the \`#available\` body chunks, the toolbar content, and the lifecycle modifier block are next candidates).

## Behavior preservation

The \`.onChange(of: layerSelection)\` handler on the main shell loses its \`showLayerIndicator = true; scheduleHide()\` lines because the indicator now reacts to the same \`layerSelection\` change from inside \`LayerScrollView\`. No other call-site changes; no public API changes.

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: vertical layer scroll, digital crown rotation, drag gesture each flash the side indicator and auto-hide after 1s.
- [ ] Manual smoke: layer indicator capsules render correctly (selected one is bigger / colored / shadowed, distant ones fade out).