### PR TITLE
refactor(navigation): extract JournalFeedbackAlert + MainNavigationToolbar (#295)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -272,38 +272,7 @@ struct ContentView: View {
   private var contentWithDialogs: some View {
     contentWithEvents
       .alert(item: $viewModel.journalFeedback) { feedback in
-        switch feedback.kind {
-        case .success:
-          Alert(
-            title: Text("Entry Logged"),
-            message: Text("Thanks for checking in."),
-            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
-          )
-        case let .queued(message):
-          Alert(
-            title: Text("Saved Offline"),
-            message: Text(message),
-            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
-          )
-        case let .syncing(current, total):
-          Alert(
-            title: Text("Syncing"),
-            message: Text("Syncing \(current) of \(total) entr\(total == 1 ? "y" : "ies")…"),
-            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
-          )
-        case let .syncSuccess(count):
-          Alert(
-            title: Text("Synced"),
-            message: Text("\(count) entr\(count == 1 ? "y" : "ies") synced successfully."),
-            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
-          )
-        case let .failure(message):
-          Alert(
-            title: Text("Something went wrong"),
-            message: Text(message),
-            dismissButton: .default(Text("OK")) { viewModel.journalFeedback = nil }
-          )
-        }
+        JournalFeedbackAlert.make(feedback) { viewModel.journalFeedback = nil }
       }
       .alert("Primary emotion selected", isPresented: .constant(flowCoordinator.currentStep == .confirmingPrimary)) {
         Button("Add Secondary Emotion") {
@@ -416,31 +385,13 @@ struct ContentView: View {
   }
 
   /// Top-bar toolbar: back chevron when in flow mode, menu button otherwise.
-  @ToolbarContentBuilder
   private var toolbarContent: some ToolbarContent {
-    if !isShowingDetailView {
-      ToolbarItem(placement: .topBarLeading) {
-        if flowCoordinator.currentStep != .idle {
-          Button {
-            flowCoordinator.cancel()
-          } label: {
-            Image(systemName: "chevron.left")
-              .font(.system(size: UIConstants.menuButtonSize))
-              .foregroundColor(.white.opacity(0.7))
-          }
-          .buttonStyle(.plain)
-        } else {
-          Button {
-            showingMenu = true
-          } label: {
-            Image(systemName: "ellipsis.circle")
-              .font(.system(size: UIConstants.menuButtonSize))
-              .foregroundColor(.white.opacity(0.7))
-          }
-          .buttonStyle(.plain)
-        }
-      }
-    }
+    MainNavigationToolbar(
+      isShowingDetailView: isShowingDetailView,
+      isInFlow: flowCoordinator.currentStep != .idle,
+      onBack: { flowCoordinator.cancel() },
+      onMenu: { showingMenu = true }
+    )
   }
 
   private var layeredContent: some View {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalFeedbackAlert.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalFeedbackAlert.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Factory for the user-facing `Alert` that surfaces a
+/// `ContentViewModel.JournalFeedback`. Centralizes the five-way switch
+/// on `Kind` so the call site (currently `ContentView`'s alert modifier)
+/// stays a one-liner.
+enum JournalFeedbackAlert {
+  /// Builds the alert for a given feedback record. The `dismiss` closure
+  /// is invoked when the user taps the lone dismiss button; the caller
+  /// typically uses it to clear the bound feedback state so the alert
+  /// disappears.
+  static func make(
+    _ feedback: ContentViewModel.JournalFeedback,
+    dismiss: @escaping () -> Void
+  ) -> Alert {
+    switch feedback.kind {
+    case .success:
+      return Alert(
+        title: Text("Entry Logged"),
+        message: Text("Thanks for checking in."),
+        dismissButton: .default(Text("OK"), action: dismiss)
+      )
+    case let .queued(message):
+      return Alert(
+        title: Text("Saved Offline"),
+        message: Text(message),
+        dismissButton: .default(Text("OK"), action: dismiss)
+      )
+    case let .syncing(current, total):
+      let suffix = total == 1 ? "y" : "ies"
+      return Alert(
+        title: Text("Syncing"),
+        message: Text("Syncing \(current) of \(total) entr\(suffix)…"),
+        dismissButton: .default(Text("OK"), action: dismiss)
+      )
+    case let .syncSuccess(count):
+      let suffix = count == 1 ? "y" : "ies"
+      return Alert(
+        title: Text("Synced"),
+        message: Text("\(count) entr\(suffix) synced successfully."),
+        dismissButton: .default(Text("OK"), action: dismiss)
+      )
+    case let .failure(message):
+      return Alert(
+        title: Text("Something went wrong"),
+        message: Text(message),
+        dismissButton: .default(Text("OK"), action: dismiss)
+      )
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainNavigationToolbar.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainNavigationToolbar.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Top-bar toolbar for the main shell: back chevron while a journal flow
+/// is in progress, ellipsis-circle menu button otherwise. Suppressed
+/// entirely while the user is in a detail view so the system back
+/// chevron has the leading slot to itself.
+struct MainNavigationToolbar: ToolbarContent {
+  let isShowingDetailView: Bool
+  let isInFlow: Bool
+  let onBack: () -> Void
+  let onMenu: () -> Void
+
+  var body: some ToolbarContent {
+    if !isShowingDetailView {
+      ToolbarItem(placement: .topBarLeading) {
+        if isInFlow {
+          Button(action: onBack) {
+            Image(systemName: "chevron.left")
+              .font(.system(size: UIConstants.menuButtonSize))
+              .foregroundColor(.white.opacity(0.7))
+          }
+          .buttonStyle(.plain)
+        } else {
+          Button(action: onMenu) {
+            Image(systemName: "ellipsis.circle")
+              .font(.system(size: UIConstants.menuButtonSize))
+              .foregroundColor(.white.opacity(0.7))
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of #295 (Phase 2a — third slice).

## Summary

\`ContentView\` carried two self-contained chunks that read as flat data more than view logic:

- **\`JournalFeedbackAlert\`** (51 lines) — the 5-case switch on \`ContentViewModel.JournalFeedback.Kind\` returning different \`Alert\` instances. Pure factory; the dismiss action is identical on every branch. Centralizing it lets the call-site \`.alert(item:)\` be a single line.
- **\`MainNavigationToolbar\`** (34 lines) — the back-chevron / menu-button leading toolbar item, suppressed entirely in detail views. Becomes a proper \`ToolbarContent\` struct taking plain values + closures instead of reading \`ContentView\`'s state directly — easier to reason about and reuse when Phase 2b's filter-aware nav lands.

## Impact

| File | Before | After |
|---|---|---|
| \`ContentView.swift\` | 465 | **416** |
| \`JournalFeedbackAlert.swift\` | — | 51 |
| \`MainNavigationToolbar.swift\` | — | 34 |

Still over the Phase 2a \`≤200\` target for ContentView; further slices will continue (next candidates: the \`init\` dependency-wiring block, the three flow-confirmation alerts, the menu sheet).

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: journal feedback alert renders for each of the five \`Kind\` cases (success, queued, syncing, syncSuccess, failure).
- [ ] Manual smoke: top-bar shows ellipsis-circle in idle state, chevron-back during journal flow, hidden while in a detail view.