### PR TITLE
refactor(navigation): extract FlowConfirmationAlertsModifier (#295)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -274,55 +274,11 @@ struct ContentView: View {
       .alert(item: $viewModel.journalFeedback) { feedback in
         JournalFeedbackAlert.make(feedback) { viewModel.journalFeedback = nil }
       }
-      .alert("Primary emotion selected", isPresented: .constant(flowCoordinator.currentStep == .confirmingPrimary)) {
-        Button("Add Secondary Emotion") {
-          flowCoordinator.promptForSecondary()
-        }
-        Button("Add Strategy") {
-          flowCoordinator.promptForStrategy()
-        }
-        Button("Done") {
-          Task { await submitFlowEntry(failurePrefix: "Failed to log emotion") }
-        }
-        Button("Cancel", role: .cancel) {
-          flowCoordinator.cancel()
-        }
-      } message: {
-        if let primary = flowCoordinator.selections.primary {
-          Text("You selected \"\(primary.expression)\". What would you like to do next?")
-        }
-      }
-      .alert("Secondary emotion selected", isPresented: .constant(flowCoordinator.currentStep == .confirmingSecondary)) {
-        Button("Add Strategy") {
-          flowCoordinator.promptForStrategy()
-        }
-        Button("Done") {
-          Task { await submitFlowEntry(failurePrefix: "Failed to log emotions") }
-        }
-        Button("Cancel", role: .cancel) {
-          flowCoordinator.cancel()
-        }
-      } message: {
-        if let secondary = flowCoordinator.selections.secondary {
-          Text("You selected \"\(secondary.expression)\". What would you like to do next?")
-        } else {
-          Text("What would you like to do next?")
-        }
-      }
-      .alert("Strategy selected", isPresented: .constant(flowCoordinator.currentStep == .confirmingStrategy)) {
-        Button("Continue to Review") {
-          flowCoordinator.showReview()
-        }
-        Button("Cancel", role: .cancel) {
-          flowCoordinator.cancel()
-        }
-      } message: {
-        if let strategy = flowCoordinator.selections.strategy {
-          Text("You selected \"\(strategy.strategy)\". Continue to review?")
-        } else {
-          Text("Continue to review?")
-        }
-      }
+      .flowConfirmationAlerts(
+        flowCoordinator: flowCoordinator,
+        onPrimarySubmit: { await submitFlowEntry(failurePrefix: "Failed to log emotion") },
+        onSecondarySubmit: { await submitFlowEntry(failurePrefix: "Failed to log emotions") }
+      )
       .onChange(of: notificationDelegate.scheduledNotificationReceived) { _, newValue in
         if let notification = newValue {
           viewModel.setInitiatedBy(notification.initiatedBy)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowConfirmationAlertsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowConfirmationAlertsModifier.swift
@@ -57,11 +57,22 @@ struct FlowConfirmationAlertsModifier: ViewModifier {
       }
   }
 
-  /// `.constant`-style presenter that flips true while the coordinator is
-  /// in the given step. Dismissing the alert via a button reverts the
-  /// step to a non-confirming state, which auto-flips this back to false.
+  /// Binding whose value tracks whether the coordinator is in `step`.
+  /// Action buttons (Done / Continue / Cancel / etc.) transition the
+  /// coordinator out of the step explicitly. A swipe-down or tap-outside
+  /// dismissal writes `false` into the binding, which is treated as an
+  /// implicit cancel — without this, `.constant()` would silently ignore
+  /// the system dismissal and the alert would immediately re-present
+  /// because `currentStep == step` is still true.
   private func presenter(for step: FlowCoordinator.FlowStep) -> Binding<Bool> {
-    .constant(flowCoordinator.currentStep == step)
+    Binding(
+      get: { flowCoordinator.currentStep == step },
+      set: { isPresented in
+        if !isPresented, flowCoordinator.currentStep == step {
+          flowCoordinator.cancel()
+        }
+      }
+    )
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowConfirmationAlertsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowConfirmationAlertsModifier.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Three "Are you sure?" alerts that drive the journal flow's
+/// confirmation steps (primary emotion → secondary → strategy).
+///
+/// Each alert is gated on the matching `FlowCoordinator.Step` and offers
+/// a small set of "next step" buttons. The two submit-capable steps
+/// (`.confirmingPrimary`, `.confirmingSecondary`) route through the
+/// caller-supplied async closures so the alert layer doesn't need to
+/// know about journal persistence, queueing, or feedback rendering.
+struct FlowConfirmationAlertsModifier: ViewModifier {
+  @ObservedObject var flowCoordinator: FlowCoordinator
+  let onPrimarySubmit: () async -> Void
+  let onSecondarySubmit: () async -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .alert(
+        "Primary emotion selected",
+        isPresented: presenter(for: .confirmingPrimary)
+      ) {
+        Button("Add Secondary Emotion") { flowCoordinator.promptForSecondary() }
+        Button("Add Strategy") { flowCoordinator.promptForStrategy() }
+        Button("Done") { Task { await onPrimarySubmit() } }
+        Button("Cancel", role: .cancel) { flowCoordinator.cancel() }
+      } message: {
+        if let primary = flowCoordinator.selections.primary {
+          Text("You selected \"\(primary.expression)\". What would you like to do next?")
+        }
+      }
+      .alert(
+        "Secondary emotion selected",
+        isPresented: presenter(for: .confirmingSecondary)
+      ) {
+        Button("Add Strategy") { flowCoordinator.promptForStrategy() }
+        Button("Done") { Task { await onSecondarySubmit() } }
+        Button("Cancel", role: .cancel) { flowCoordinator.cancel() }
+      } message: {
+        if let secondary = flowCoordinator.selections.secondary {
+          Text("You selected \"\(secondary.expression)\". What would you like to do next?")
+        } else {
+          Text("What would you like to do next?")
+        }
+      }
+      .alert(
+        "Strategy selected",
+        isPresented: presenter(for: .confirmingStrategy)
+      ) {
+        Button("Continue to Review") { flowCoordinator.showReview() }
+        Button("Cancel", role: .cancel) { flowCoordinator.cancel() }
+      } message: {
+        if let strategy = flowCoordinator.selections.strategy {
+          Text("You selected \"\(strategy.strategy)\". Continue to review?")
+        } else {
+          Text("Continue to review?")
+        }
+      }
+  }
+
+  /// `.constant`-style presenter that flips true while the coordinator is
+  /// in the given step. Dismissing the alert via a button reverts the
+  /// step to a non-confirming state, which auto-flips this back to false.
+  private func presenter(for step: FlowCoordinator.FlowStep) -> Binding<Bool> {
+    .constant(flowCoordinator.currentStep == step)
+  }
+}
+
+extension View {
+  /// Attaches the journal-flow confirmation alerts to the receiver.
+  /// See `FlowConfirmationAlertsModifier` for the per-alert contract.
+  func flowConfirmationAlerts(
+    flowCoordinator: FlowCoordinator,
+    onPrimarySubmit: @escaping () async -> Void,
+    onSecondarySubmit: @escaping () async -> Void
+  ) -> some View {
+    modifier(FlowConfirmationAlertsModifier(
+      flowCoordinator: flowCoordinator,
+      onPrimarySubmit: onPrimarySubmit,
+      onSecondarySubmit: onSecondarySubmit
+    ))
+  }
+}


### PR DESCRIPTION
Part of #295 (Phase 2a — fourth slice).

## Summary

\`ContentView.contentWithDialogs\` still carried the three journal-flow confirmation alerts (primary → secondary → strategy) inline as ~50 lines of structurally similar \`.alert(_:isPresented:actions:message:)\` calls. Each alert gates on a \`FlowCoordinator.FlowStep\` and offers a small set of "next step" buttons; the two submit-capable steps delegate to caller-supplied async closures.

Bundles all three into a **\`FlowConfirmationAlertsModifier\`** + a \`.flowConfirmationAlerts(...)\` View extension. The modifier reads \`flowCoordinator\` directly via \`@ObservedObject\`; the submit closures flow in as parameters so the alert layer doesn't need to know about journal persistence, queueing, or feedback rendering — that stays in \`ContentView.submitFlowEntry\`.

## Impact

| File | Before | After |
|---|---|---|
| \`ContentView.swift\` | 416 | **372** |
| \`FlowConfirmationAlertsModifier.swift\` | — | 82 |

\`ContentView\` is now under 400 lines. The remaining single-PR decomposition targets are the \`init\` dependency-wiring block (~55 lines), the three sheets + onboarding-task block, and the seven-handler \`onChange\` block in \`contentWithEvents\`.

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: journal flow walks primary → secondary → strategy confirmations; "Done" submits, "Cancel" returns to idle.