### PR TITLE
refactor(navigation): extract NavigationSyncModifier (#295)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -193,7 +193,8 @@ struct ContentView: View {
     }
   }
 
-  /// Adds lifecycle hooks and state-sync `onChange` handlers.
+  /// Adds lifecycle hooks and routes navigation-state synchronization
+  /// through `NavigationSyncModifier`.
   private var contentWithEvents: some View {
     contentZStack
       .ignoresSafeArea(edges: .bottom)
@@ -207,65 +208,13 @@ struct ContentView: View {
       .onChange(of: syncService.syncStatus) { _, newValue in
         viewModel.handleSyncStatusChange(newValue, totalPending: journalQueue.pendingCount)
       }
-      .onChange(of: viewModel.phaseOrder) {
-        adjustPhaseSelection()
-      }
-      .onChange(of: layerSelection) { _, newValue in
-        // Convert filtered index to layer ID
-        if let layerId = viewModel.filteredIndexToLayerId(newValue) {
-          viewModel.selectedLayerId = layerId
-          // Convert layer ID to full array index
-          if let fullIndex = viewModel.layerIdToIndex(layerId) {
-            viewModel.selectedLayerIndex = fullIndex
-            storedLayerIndex = fullIndex
-          }
-        }
-      }
-      .onChange(of: viewModel.selectedLayerId) { _, newLayerId in
-        // When selectedLayerId changes, update layerSelection to match in filtered array
-        guard let layerId = newLayerId else { return }
-        if let filteredIndex = viewModel.layerIdToFilteredIndex(layerId) {
-          if layerSelection != filteredIndex {
-            layerSelection = filteredIndex
-          }
-        }
-      }
-      .onChange(of: viewModel.layerFilterMode) { _, _ in
-        // When filter mode changes, actively sync layerSelection to the correct filtered index
-        // for the current selectedLayerId. This fixes #180: strategy cards rendering tiny after
-        // flow completion because layerSelection wasn't synced to the new filtered index.
-        guard let layerId = viewModel.selectedLayerId,
-              let filteredIndex = viewModel.layerIdToFilteredIndex(layerId)
-        else {
-          // Fallback: clamp to valid range if no selected layer ID
-          let maxIndex = max(0, viewModel.filteredLayers.count - 1)
-          if layerSelection > maxIndex {
-            layerSelection = maxIndex
-          }
-          return
-        }
-
-        // Actively set layerSelection to the correct filtered index for the selected layer
-        if layerSelection != filteredIndex {
-          layerSelection = filteredIndex
-        }
-      }
-      .onChange(of: phaseSelection) { _, newValue in
-        guard viewModel.phaseOrder.count > 0 else { return }
-        let adjusted = PhaseNavigator.adjustedSelection(newValue, phaseCount: viewModel.phaseOrder.count)
-        if adjusted != newValue {
-          phaseSelection = adjusted
-        }
-        let normalized = PhaseNavigator.normalizedIndex(adjusted, phaseCount: viewModel.phaseOrder.count)
-        viewModel.selectedPhaseIndex = normalized
-        storedPhaseIndex = normalized
-      }
-      .onChange(of: viewModel.selectedPhaseIndex) { _, newValue in
-        let expected = newValue + 1
-        if phaseSelection != expected {
-          phaseSelection = expected
-        }
-      }
+      .navigationSync(
+        viewModel: viewModel,
+        layerSelection: $layerSelection,
+        phaseSelection: $phaseSelection,
+        storedLayerIndex: $storedLayerIndex,
+        storedPhaseIndex: $storedPhaseIndex
+      )
   }
 
   /// Adds the alert presentations, sheet stack, and onboarding-check task.
@@ -356,14 +305,6 @@ struct ContentView: View {
       layerSelection: $layerSelection,
       phaseSelection: $phaseSelection
     )
-  }
-
-  private func adjustPhaseSelection() {
-    guard viewModel.phaseOrder.count > 0 else { return }
-    let adjusted = PhaseNavigator.adjustedSelection(phaseSelection, phaseCount: viewModel.phaseOrder.count)
-    if adjusted != phaseSelection {
-      phaseSelection = adjusted
-    }
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/NavigationSyncModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/NavigationSyncModifier.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+/// Keeps the dual-axis navigation state (`layerSelection` / `phaseSelection`
+/// in the view, plus the AppStorage-backed persistence values) synchronized
+/// with the ground-truth IDs and indices that `ContentViewModel` exposes.
+///
+/// SwiftUI's `@State` and `ContentViewModel`'s `@Published` properties form
+/// two parallel state machines for the same conceptual values — selected
+/// layer, selected phase. This modifier handles the six observer paths that
+/// reconcile them whenever either side moves:
+///
+/// 1. `phaseOrder` changes → re-normalize the offset-by-one phase selection.
+/// 2. `layerSelection` (filtered index) changes → write the layer ID and
+///    full-array index back to the view model + AppStorage.
+/// 3. `selectedLayerId` changes → mirror it back into the filtered index.
+/// 4. `layerFilterMode` changes → re-derive the filtered index for the
+///    currently-selected layer (or clamp to valid range).
+/// 5. `phaseSelection` changes → normalize the infinite-scroll offset and
+///    write the canonical index to the view model + AppStorage.
+/// 6. `selectedPhaseIndex` changes → mirror it back as the offset value.
+///
+/// Phase 2b (#296) will refactor `PhaseNavigator` and the layer filtering
+/// system, at which point this modifier collapses into a proper
+/// `NavigationViewModel`. For now it isolates the synchronization noise
+/// from `ContentView`'s body.
+struct NavigationSyncModifier: ViewModifier {
+  @ObservedObject var viewModel: ContentViewModel
+  @Binding var layerSelection: Int
+  @Binding var phaseSelection: Int
+  @Binding var storedLayerIndex: Int
+  @Binding var storedPhaseIndex: Int
+
+  func body(content: Content) -> some View {
+    content
+      .onChange(of: viewModel.phaseOrder) {
+        adjustPhaseSelection()
+      }
+      .onChange(of: layerSelection) { _, newValue in
+        // Filtered index → layer ID → full array index → AppStorage.
+        if let layerId = viewModel.filteredIndexToLayerId(newValue) {
+          viewModel.selectedLayerId = layerId
+          if let fullIndex = viewModel.layerIdToIndex(layerId) {
+            viewModel.selectedLayerIndex = fullIndex
+            storedLayerIndex = fullIndex
+          }
+        }
+      }
+      .onChange(of: viewModel.selectedLayerId) { _, newLayerId in
+        // Mirror an externally-set layer ID into the filtered index.
+        guard let layerId = newLayerId,
+              let filteredIndex = viewModel.layerIdToFilteredIndex(layerId)
+        else { return }
+        if layerSelection != filteredIndex {
+          layerSelection = filteredIndex
+        }
+      }
+      .onChange(of: viewModel.layerFilterMode) { _, _ in
+        // Filter changes invalidate the filtered index for the current
+        // layer ID — fixes #180 (strategy cards rendered tiny after flow
+        // completion because layerSelection wasn't re-derived).
+        guard let layerId = viewModel.selectedLayerId,
+              let filteredIndex = viewModel.layerIdToFilteredIndex(layerId)
+        else {
+          let maxIndex = max(0, viewModel.filteredLayers.count - 1)
+          if layerSelection > maxIndex {
+            layerSelection = maxIndex
+          }
+          return
+        }
+        if layerSelection != filteredIndex {
+          layerSelection = filteredIndex
+        }
+      }
+      .onChange(of: phaseSelection) { _, newValue in
+        guard !viewModel.phaseOrder.isEmpty else { return }
+        let adjusted = PhaseNavigator.adjustedSelection(newValue, phaseCount: viewModel.phaseOrder.count)
+        if adjusted != newValue {
+          phaseSelection = adjusted
+        }
+        let normalized = PhaseNavigator.normalizedIndex(adjusted, phaseCount: viewModel.phaseOrder.count)
+        viewModel.selectedPhaseIndex = normalized
+        storedPhaseIndex = normalized
+      }
+      .onChange(of: viewModel.selectedPhaseIndex) { _, newValue in
+        let expected = newValue + 1
+        if phaseSelection != expected {
+          phaseSelection = expected
+        }
+      }
+  }
+
+  private func adjustPhaseSelection() {
+    guard !viewModel.phaseOrder.isEmpty else { return }
+    let adjusted = PhaseNavigator.adjustedSelection(phaseSelection, phaseCount: viewModel.phaseOrder.count)
+    if adjusted != phaseSelection {
+      phaseSelection = adjusted
+    }
+  }
+}
+
+extension View {
+  /// Attaches the dual-axis navigation state-sync modifier. See
+  /// `NavigationSyncModifier` for the per-observer contract.
+  func navigationSync(
+    viewModel: ContentViewModel,
+    layerSelection: Binding<Int>,
+    phaseSelection: Binding<Int>,
+    storedLayerIndex: Binding<Int>,
+    storedPhaseIndex: Binding<Int>
+  ) -> some View {
+    modifier(NavigationSyncModifier(
+      viewModel: viewModel,
+      layerSelection: layerSelection,
+      phaseSelection: phaseSelection,
+      storedLayerIndex: storedLayerIndex,
+      storedPhaseIndex: storedPhaseIndex
+    ))
+  }
+}


### PR DESCRIPTION
Part of #295 (Phase 2a — fifth slice).

## Summary

\`ContentView\` carried six \`onChange\` handlers (~60 lines) reconciling SwiftUI \`@State\` (\`layerSelection\` / \`phaseSelection\` / \`storedLayerIndex\` / \`storedPhaseIndex\`) with \`ContentViewModel\`'s \`@Published\` ground-truth IDs and indices. These form two parallel state machines for the same conceptual values; the handlers translate between them on every external change.

Bundles all six into a **\`NavigationSyncModifier\`** + a \`.navigationSync(...)\` View extension. The synchronization noise lives in one focused file with a doc-comment enumerating the six observer paths and what each one writes. \`ContentView.contentWithEvents\` now reads as genuine lifecycle (\`.task\` / \`.ignoresSafeArea\` / sync-status handler) without the index-conversion churn.

Also removes the now-unused private \`adjustPhaseSelection()\` helper — its single caller was one of the moved onChange handlers, and the modifier inlines the same logic.

## Impact

| File | Before | After |
|---|---|---|
| \`ContentView.swift\` | 372 | **313** |
| \`NavigationSyncModifier.swift\` | — | 119 |

ContentView is now under 320 lines. Remaining single-PR candidates: the \`init\` dependency-wiring block (~55 lines), the three sheets + onboarding-task block in \`contentWithDialogs\` (~50 lines).

## Phase 2b note

This modifier shape is a deliberate stepping stone — Phase 2b (#296) will refactor \`PhaseNavigator\` and the layer filtering system, at which point the synchronization logic collapses into a proper \`NavigationViewModel\` that owns the \`@State\` directly. The modifier is the smallest seam that lets us continue the file-size decomposition now without prematurely committing to a VM shape that the filtering refactor will reshape anyway.

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: vertical scroll updates the layer indicator and persists via AppStorage; horizontal phase scroll wraps correctly; filter-mode change re-derives the filtered index.