### PR TITLE
refactor(navigation): extract ContentViewDependencies bundle (#295)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/AppStorageKeys.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/AppStorageKeys.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Single source of truth for `UserDefaults` / `@AppStorage` keys used
+/// to persist root navigation state across launches. Centralizing them
+/// here keeps the two sites that read the same value (the
+/// `@AppStorage(...)` declaration in `ContentView` and the raw
+/// `UserDefaults.standard.integer(forKey:)` calls in
+/// `ContentViewDependencies`) from drifting if a key is ever renamed.
+enum AppStorageKeys {
+  /// Persisted layer index (full-array, not filtered) for the dual-axis
+  /// navigation.
+  static let selectedLayerIndex = "selectedLayerIndex"
+
+  /// Persisted phase index (zero-indexed canonical value; the SwiftUI
+  /// tab model adds a +1 offset internally for its infinite-scroll
+  /// behavior).
+  static let selectedPhaseIndex = "selectedPhaseIndex"
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Bundle of everything `ContentView` needs to wire up its root view
+/// hierarchy: the live API client, repositories, queue, journal client,
+/// sync service, content view-model, flow coordinator, and the
+/// AppStorage-backed initial layer / phase selections.
+///
+/// Lives outside `ContentView` so the dependency-construction logic
+/// (which has progressive fallback paths for SQLite open failures and
+/// the offline journal queue) doesn't dominate the view's `init`. The
+/// view then just unpacks the bundle into its `@StateObject` /
+/// `@State` wrappers.
+///
+/// Marked `@MainActor` because the constructed types (`NetworkMonitor`,
+/// `JournalClient`, `JournalSyncService`, `FlowCoordinator`,
+/// `SyncSettingsViewModel`, `JournalQueue`) are themselves main-actor
+/// isolated under Swift 6; building them from a nonisolated context
+/// would be a data-race error. `ContentView.init` is `@MainActor` so
+/// callers naturally satisfy the requirement.
+@MainActor
+struct ContentViewDependencies {
+  let viewModel: ContentViewModel
+  let flowCoordinator: FlowCoordinator
+  let syncSettingsViewModel: SyncSettingsViewModel
+  let networkMonitor: NetworkMonitor
+  let journalQueue: JournalQueue
+  let syncService: JournalSyncService
+  let journalClient: JournalClientProtocol
+  let journalRepository: JournalRepositoryProtocol
+  let catalogRepository: CatalogRepositoryProtocol
+  let initialLayer: Int
+  let initialPhase: Int
+
+  /// Builds the live dependency graph: real API, on-disk SQLite,
+  /// real network monitor. Used by the app's runtime entry point.
+  static func live() -> ContentViewDependencies {
+    let configuration = AppConfiguration()
+    let apiClient = APIClient(baseURL: configuration.apiBaseURL)
+    let catalogRepository = CatalogRepository(
+      remote: CatalogAPIService(apiClient: apiClient),
+      cache: FileCatalogCacheStore()
+    )
+    let journalRepository = Self.makeJournalRepository()
+    let syncSettings = SyncSettings()
+    let journalQueue = Self.makeJournalQueue()
+    let networkMonitor = NetworkMonitor()
+    let journalClient = JournalClient(
+      apiClient: apiClient,
+      repository: journalRepository,
+      syncSettings: syncSettings,
+      queue: journalQueue
+    )
+    let syncService = JournalSyncService(
+      queue: journalQueue,
+      apiClient: apiClient,
+      networkMonitor: networkMonitor
+    )
+    let initialLayer = UserDefaults.standard.integer(forKey: "selectedLayerIndex")
+    let initialPhase = UserDefaults.standard.integer(forKey: "selectedPhaseIndex")
+    let viewModel = ContentViewModel(
+      catalogRepository: catalogRepository,
+      journalRepository: journalRepository,
+      journalClient: journalClient,
+      initialLayerIndex: initialLayer,
+      initialPhaseIndex: initialPhase
+    )
+    let flowCoordinator = FlowCoordinator(contentViewModel: viewModel)
+    let syncSettingsViewModel = SyncSettingsViewModel(syncSettings: syncSettings)
+    return ContentViewDependencies(
+      viewModel: viewModel,
+      flowCoordinator: flowCoordinator,
+      syncSettingsViewModel: syncSettingsViewModel,
+      networkMonitor: networkMonitor,
+      journalQueue: journalQueue,
+      syncService: syncService,
+      journalClient: journalClient,
+      journalRepository: journalRepository,
+      catalogRepository: catalogRepository,
+      initialLayer: initialLayer,
+      initialPhase: initialPhase
+    )
+  }
+
+  // MARK: - Repository / queue construction
+
+  /// Opens the on-disk SQLite journal repository, falling back to
+  /// in-memory storage if open fails (SwiftUI previews, test harness,
+  /// or a corrupted database file). The fallback keeps the app
+  /// functional but entries logged in the session don't persist.
+  private static func makeJournalRepository() -> JournalRepositoryProtocol {
+    let persistentRepo = JournalRepository()
+    do {
+      try persistentRepo.open()
+      return persistentRepo
+    } catch {
+      print("⚠️ Failed to open journal database: \(error). Falling back to in-memory storage.")
+      return InMemoryJournalRepository()
+    }
+  }
+
+  /// Builds a `JournalQueue` with progressive fallback: documents
+  /// directory → `NSTemporaryDirectory` → in-memory SQLite. The
+  /// in-memory leg has no filesystem dependency, so it cannot fail in
+  /// normal operation; if even that throws, the device is in a state
+  /// where no offline persistence is possible and crashing surfaces
+  /// the problem rather than silently dropping entries.
+  private static func makeJournalQueue() -> JournalQueue {
+    do {
+      return try JournalQueue()
+    } catch {
+      print("⚠️ Documents-dir journal queue init failed: \(error). Trying temp dir.")
+    }
+    let fallbackPath = NSTemporaryDirectory() + "journal_queue_fallback.sqlite"
+    do {
+      return try JournalQueue(databasePath: fallbackPath)
+    } catch {
+      print("⚠️ Temp-dir journal queue init failed: \(error). Falling back to in-memory.")
+    }
+    do {
+      return try JournalQueue(databasePath: ":memory:")
+    } catch {
+      fatalError("In-memory journal queue init failed unexpectedly: \(error)")
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -28,8 +28,14 @@ struct ContentViewDependencies {
   let journalClient: JournalClientProtocol
   let journalRepository: JournalRepositoryProtocol
   let catalogRepository: CatalogRepositoryProtocol
+  /// Persisted layer index (full-array, zero-indexed). Unpacked into
+  /// `ContentView.layerSelection` as-is.
   let initialLayer: Int
-  let initialPhase: Int
+
+  /// SwiftUI tab-model index for the inner phase scroller. Already
+  /// includes the +1 offset that the infinite-scroll TabView expects;
+  /// `init(dependencies:)` unpacks this directly with no arithmetic.
+  let initialPhaseSelection: Int
 
   /// Builds the live dependency graph: real API, on-disk SQLite,
   /// real network monitor. Used by the app's runtime entry point.
@@ -55,14 +61,14 @@ struct ContentViewDependencies {
       apiClient: apiClient,
       networkMonitor: networkMonitor
     )
-    let initialLayer = UserDefaults.standard.integer(forKey: "selectedLayerIndex")
-    let initialPhase = UserDefaults.standard.integer(forKey: "selectedPhaseIndex")
+    let initialLayer = UserDefaults.standard.integer(forKey: AppStorageKeys.selectedLayerIndex)
+    let storedPhase = UserDefaults.standard.integer(forKey: AppStorageKeys.selectedPhaseIndex)
     let viewModel = ContentViewModel(
       catalogRepository: catalogRepository,
       journalRepository: journalRepository,
       journalClient: journalClient,
       initialLayerIndex: initialLayer,
-      initialPhaseIndex: initialPhase
+      initialPhaseIndex: storedPhase
     )
     let flowCoordinator = FlowCoordinator(contentViewModel: viewModel)
     let syncSettingsViewModel = SyncSettingsViewModel(syncSettings: syncSettings)
@@ -77,7 +83,10 @@ struct ContentViewDependencies {
       journalRepository: journalRepository,
       catalogRepository: catalogRepository,
       initialLayer: initialLayer,
-      initialPhase: initialPhase
+      // +1: the infinite-scroll TabView treats index 0 as a "lead-in"
+      // page; the canonical zero-indexed phase value lives in
+      // ContentViewModel and is converted here for SwiftUI's tab model.
+      initialPhaseSelection: storedPhase + 1
     )
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct ContentView: View {
-  @AppStorage("selectedLayerIndex") private var storedLayerIndex = 0
-  @AppStorage("selectedPhaseIndex") private var storedPhaseIndex = 0
+  @AppStorage(AppStorageKeys.selectedLayerIndex) private var storedLayerIndex = 0
+  @AppStorage(AppStorageKeys.selectedPhaseIndex) private var storedPhaseIndex = 0
   @StateObject private var viewModel: ContentViewModel
   @StateObject private var flowCoordinator: FlowCoordinator
   @StateObject private var syncSettingsViewModel: SyncSettingsViewModel
@@ -38,7 +38,7 @@ struct ContentView: View {
     _journalQueue = StateObject(wrappedValue: dependencies.journalQueue)
     _syncService = StateObject(wrappedValue: dependencies.syncService)
     _layerSelection = State(initialValue: dependencies.initialLayer)
-    _phaseSelection = State(initialValue: dependencies.initialPhase + 1)
+    _phaseSelection = State(initialValue: dependencies.initialPhaseSelection)
   }
 
   /// Submits the current FlowCoordinator entry and renders the appropriate

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -21,85 +21,24 @@ struct ContentView: View {
   @State private var navigationPath = NavigationPath()
 
   init() {
-    let configuration = AppConfiguration()
-    let apiClient = APIClient(baseURL: configuration.apiBaseURL)
-    let repository = CatalogRepository(
-      remote: CatalogAPIService(apiClient: apiClient),
-      cache: FileCatalogCacheStore()
-    )
-    let persistentRepo = JournalRepository()
-    let journalRepository: JournalRepositoryProtocol
-    do {
-      try persistentRepo.open()
-      journalRepository = persistentRepo
-    } catch {
-      // Fallback to in-memory storage when SQLite fails (e.g., in SwiftUI previews,
-      // during testing, or if database is corrupted). This keeps the app functional
-      // but data won't persist. Analytics will show empty until journal entries are
-      // logged in this session.
-      print("⚠️ Failed to open journal database: \(error). Falling back to in-memory storage.")
-      journalRepository = InMemoryJournalRepository()
-    }
-    self.journalRepository = journalRepository
-    self.catalogRepository = repository
-    let syncSettings = SyncSettings()
-    let journalQueue = Self.makeJournalQueue()
-    _journalQueue = StateObject(wrappedValue: journalQueue)
-    let monitor = NetworkMonitor()
-    _networkMonitor = StateObject(wrappedValue: monitor)
-    let journalClient = JournalClient(
-      apiClient: apiClient,
-      repository: journalRepository,
-      syncSettings: syncSettings,
-      queue: journalQueue
-    )
-    self.journalClient = journalClient
-    let sync = JournalSyncService(
-      queue: journalQueue,
-      apiClient: apiClient,
-      networkMonitor: monitor
-    )
-    _syncService = StateObject(wrappedValue: sync)
-    let initialLayer = UserDefaults.standard.integer(forKey: "selectedLayerIndex")
-    let initialPhase = UserDefaults.standard.integer(forKey: "selectedPhaseIndex")
-    let model = ContentViewModel(
-      catalogRepository: repository,
-      journalRepository: journalRepository,
-      journalClient: journalClient,
-      initialLayerIndex: initialLayer,
-      initialPhaseIndex: initialPhase
-    )
-    _viewModel = StateObject(wrappedValue: model)
-    _syncSettingsViewModel = StateObject(wrappedValue: SyncSettingsViewModel(syncSettings: syncSettings))
-    let coordinator = FlowCoordinator(contentViewModel: model)
-    _flowCoordinator = StateObject(wrappedValue: coordinator)
-    _layerSelection = State(initialValue: initialLayer)
-    _phaseSelection = State(initialValue: initialPhase + 1)
+    self.init(dependencies: .live())
   }
 
-  /// Builds a JournalQueue with progressive fallback: documents directory →
-  /// NSTemporaryDirectory → in-memory SQLite. The in-memory leg has no
-  /// filesystem dependency, so it cannot fail in normal operation; if even
-  /// that throws, the device is in a state where no offline persistence is
-  /// possible and crashing surfaces the problem rather than silently
-  /// dropping entries.
-  private static func makeJournalQueue() -> JournalQueue {
-    do {
-      return try JournalQueue()
-    } catch {
-      print("⚠️ Documents-dir journal queue init failed: \(error). Trying temp dir.")
-    }
-    let fallbackPath = NSTemporaryDirectory() + "journal_queue_fallback.sqlite"
-    do {
-      return try JournalQueue(databasePath: fallbackPath)
-    } catch {
-      print("⚠️ Temp-dir journal queue init failed: \(error). Falling back to in-memory.")
-    }
-    do {
-      return try JournalQueue(databasePath: ":memory:")
-    } catch {
-      fatalError("In-memory journal queue init failed unexpectedly: \(error)")
-    }
+  /// Designated initializer; takes a pre-built dependency bundle so the
+  /// `live()` graph is testable and substitutable. See
+  /// `ContentViewDependencies` for the construction logic.
+  init(dependencies: ContentViewDependencies) {
+    self.journalRepository = dependencies.journalRepository
+    self.catalogRepository = dependencies.catalogRepository
+    self.journalClient = dependencies.journalClient
+    _viewModel = StateObject(wrappedValue: dependencies.viewModel)
+    _flowCoordinator = StateObject(wrappedValue: dependencies.flowCoordinator)
+    _syncSettingsViewModel = StateObject(wrappedValue: dependencies.syncSettingsViewModel)
+    _networkMonitor = StateObject(wrappedValue: dependencies.networkMonitor)
+    _journalQueue = StateObject(wrappedValue: dependencies.journalQueue)
+    _syncService = StateObject(wrappedValue: dependencies.syncService)
+    _layerSelection = State(initialValue: dependencies.initialLayer)
+    _phaseSelection = State(initialValue: dependencies.initialPhase + 1)
   }
 
   /// Submits the current FlowCoordinator entry and renders the appropriate


### PR DESCRIPTION
Part of #295 (Phase 2a — seventh slice).

## Summary

\`ContentView.init\` carried ~75 lines of dependency-construction logic — \`APIClient\`, repositories with SQLite-open fallback, \`NetworkMonitor\`, \`JournalQueue\` with three-level filesystem fallback, journal client, sync service, content view-model, flow coordinator, and reading the AppStorage initial selections. The actual wiring (\`self.*\` assignments + \`@StateObject\` wrappers) was a small fraction; the construction logic was the bulk.

Moves it into a **\`ContentViewDependencies\`** struct + \`.live()\` factory in \`App/ContentViewDependencies.swift\`. \`ContentView\` now has:

- A no-arg \`init()\` that forwards to the designated init with \`.live()\`.
- A designated \`init(dependencies:)\` that unpacks the bundle into \`@StateObject\` / \`@State\` wrappers.

Tests and previews can construct an alternative bundle without re-implementing the live graph. The factory is \`@MainActor\` because every constructed type (\`NetworkMonitor\`, \`JournalClient\`, \`JournalSyncService\`, \`FlowCoordinator\`, \`SyncSettingsViewModel\`, \`JournalQueue\`) is main-actor isolated under Swift 6.

Also moves \`makeJournalQueue\`'s progressive-fallback helper to live alongside its caller, and introduces \`makeJournalRepository\` for the analogous SQLite-open fallback path that previously inlined inside \`ContentView.init\`.

## Impact

| File | Before | After |
|---|---|---|
| \`ContentView.swift\` | 313 | **252** |
| \`ContentViewDependencies.swift\` | — | 117 |

\`ContentView\` is now within ~50 lines of the Phase 2a \`≤200\` target. Remaining candidates: the \`contentZStack\` block (~25 lines, the loading / empty / loaded ZStack) and the rest of \`contentWithDialogs\` (sheets + remaining \`onChange\` + onboarding task).

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: app launches, catalog loads from cache, journal queue initializes (try once without simulator reset to exercise documents-dir path).