### PR TITLE
refactor(navigation): extract MainContentDialogsModifier; ContentView hits ≤200 (#295)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -62,20 +62,6 @@ struct ContentView: View {
     }
   }
 
-  /// Clamped layer selection that's always valid for the current filteredLayers
-  ///
-  /// This fixes #183: scroll position and digital crown bindings must return valid indices
-  /// even when layerSelection is stale (e.g., after filter mode change).
-  ///
-  /// **Timing note:** `layerSelection` itself gets updated to the clamped value in
-  /// `onChange(of: viewModel.layerFilterMode)`, but that handler fires AFTER the initial
-  /// render. This computed property ensures bindings always return valid values even
-  /// during that timing window, preventing SwiftUI from rendering with invalid state.
-  private var clampedLayerSelection: Int {
-    guard viewModel.filteredLayers.count > 0 else { return 0 }
-    return min(layerSelection, viewModel.filteredLayers.count - 1)
-  }
-
   var body: some View {
     NavigationStack(path: $navigationPath) {
       contentWithDialogs
@@ -167,65 +153,19 @@ struct ContentView: View {
         onPrimarySubmit: { await submitFlowEntry(failurePrefix: "Failed to log emotion") },
         onSecondarySubmit: { await submitFlowEntry(failurePrefix: "Failed to log emotions") }
       )
-      .onChange(of: notificationDelegate.scheduledNotificationReceived) { _, newValue in
-        if let notification = newValue {
-          viewModel.setInitiatedBy(notification.initiatedBy)
-          notificationDelegate.clearNotificationState()
-        }
-      }
-      .onChange(of: flowCoordinator.currentStep) { _, newStep in
-        // Pop navigation to root when flow state transitions
-        // This fixes #157, #162, #164: prevents user from being stuck in detail views
-        switch newStep {
-        case .selectingPrimary, .selectingSecondary, .selectingStrategy:
-          // When transitioning to selection steps, pop to root so user can navigate freely
-          if !navigationPath.isEmpty {
-            navigationPath.removeLast(navigationPath.count)
-          }
-        case .idle:
-          // When flow completes or is canceled, pop to root
-          if !navigationPath.isEmpty {
-            navigationPath.removeLast(navigationPath.count)
-          }
-        default:
-          break
-        }
-      }
-      .sheet(isPresented: $showingMenu) {
-        NavigationStack {
-          MenuView(
-            journalClient: journalClient,
-            syncSettingsViewModel: syncSettingsViewModel,
-            journalQueue: journalQueue,
-            syncService: syncService,
-            networkMonitor: networkMonitor,
-            isPresented: $showingMenu
-          )
-          .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-              Button("Done") {
-                showingMenu = false
-              }
-            }
-          }
-        }
-      }
-      .sheet(isPresented: $showingOnboarding) {
-        OnboardingView(
-          viewModel: syncSettingsViewModel,
-          isPresented: $showingOnboarding
-        )
-        .interactiveDismissDisabled()
-      }
-      .sheet(isPresented: .constant(flowCoordinator.currentStep == .review)) {
-        FlowReviewSheet(flowCoordinator: flowCoordinator)
-      }
-      .task {
-        // Check onboarding completion once when view appears
-        if !syncSettingsViewModel.hasCompletedOnboarding {
-          showingOnboarding = true
-        }
-      }
+      .mainContentDialogs(
+        viewModel: viewModel,
+        flowCoordinator: flowCoordinator,
+        syncSettingsViewModel: syncSettingsViewModel,
+        notificationDelegate: notificationDelegate,
+        journalClient: journalClient,
+        journalQueue: journalQueue,
+        syncService: syncService,
+        networkMonitor: networkMonitor,
+        showingMenu: $showingMenu,
+        showingOnboarding: $showingOnboarding,
+        navigationPath: $navigationPath
+      )
   }
 
   /// Top-bar toolbar: back chevron when in flow mode, menu button otherwise.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+/// Bundles the dialog stack and lifecycle handlers attached to the
+/// main shell content:
+///
+/// - **Notification-driven `initiatedBy`** — when a scheduled
+///   notification fires while the app is foregrounded, the delegate's
+///   `scheduledNotificationReceived` carries the `InitiatedBy` to
+///   apply to the next entry.
+/// - **Flow-step navigation pop** — any transition into a flow
+///   selection step or back to idle pops the NavigationStack to root
+///   so the user isn't stuck in a detail view (fixes #157 / #162 / #164).
+/// - **Menu sheet** — wrapped in its own `NavigationStack` with a
+///   "Done" cancellation button so it can present nested sheets.
+/// - **Onboarding sheet** — gated by `SyncSettingsViewModel`, modal,
+///   non-interactive-dismiss.
+/// - **Flow review sheet** — presented while `flowCoordinator.currentStep
+///   == .review`.
+/// - **Onboarding-check `.task`** — runs once on appear; flips
+///   `showingOnboarding = true` if the user hasn't completed
+///   onboarding yet.
+struct MainContentDialogsModifier: ViewModifier {
+  @ObservedObject var viewModel: ContentViewModel
+  @ObservedObject var flowCoordinator: FlowCoordinator
+  @ObservedObject var syncSettingsViewModel: SyncSettingsViewModel
+  @ObservedObject var notificationDelegate: NotificationDelegate
+
+  let journalClient: JournalClientProtocol
+  @ObservedObject var journalQueue: JournalQueue
+  @ObservedObject var syncService: JournalSyncService
+  @ObservedObject var networkMonitor: NetworkMonitor
+
+  @Binding var showingMenu: Bool
+  @Binding var showingOnboarding: Bool
+  @Binding var navigationPath: NavigationPath
+
+  func body(content: Content) -> some View {
+    content
+      .onChange(of: notificationDelegate.scheduledNotificationReceived) { _, newValue in
+        if let notification = newValue {
+          viewModel.setInitiatedBy(notification.initiatedBy)
+          notificationDelegate.clearNotificationState()
+        }
+      }
+      .onChange(of: flowCoordinator.currentStep) { _, newStep in
+        popNavigationPath(for: newStep)
+      }
+      .sheet(isPresented: $showingMenu) { menuSheet }
+      .sheet(isPresented: $showingOnboarding) { onboardingSheet }
+      .sheet(isPresented: .constant(flowCoordinator.currentStep == .review)) {
+        FlowReviewSheet(flowCoordinator: flowCoordinator)
+      }
+      .task {
+        if !syncSettingsViewModel.hasCompletedOnboarding {
+          showingOnboarding = true
+        }
+      }
+  }
+
+  // MARK: - Sheets
+
+  private var menuSheet: some View {
+    NavigationStack {
+      MenuView(
+        journalClient: journalClient,
+        syncSettingsViewModel: syncSettingsViewModel,
+        journalQueue: journalQueue,
+        syncService: syncService,
+        networkMonitor: networkMonitor,
+        isPresented: $showingMenu
+      )
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Done") { showingMenu = false }
+        }
+      }
+    }
+  }
+
+  private var onboardingSheet: some View {
+    OnboardingView(
+      viewModel: syncSettingsViewModel,
+      isPresented: $showingOnboarding
+    )
+    .interactiveDismissDisabled()
+  }
+
+  // MARK: - Navigation
+
+  /// Pops the navigation stack to root on flow-step transitions that
+  /// should leave the user free to navigate again (fixes #157 / #162 / #164:
+  /// prevents being stuck in a detail view across flow boundaries).
+  private func popNavigationPath(for step: FlowCoordinator.FlowStep) {
+    switch step {
+    case .selectingPrimary, .selectingSecondary, .selectingStrategy, .idle:
+      if !navigationPath.isEmpty {
+        navigationPath.removeLast(navigationPath.count)
+      }
+    default:
+      break
+    }
+  }
+}
+
+extension View {
+  /// Attaches the main shell's dialog stack and lifecycle handlers.
+  /// See `MainContentDialogsModifier` for the per-handler contract.
+  func mainContentDialogs(
+    viewModel: ContentViewModel,
+    flowCoordinator: FlowCoordinator,
+    syncSettingsViewModel: SyncSettingsViewModel,
+    notificationDelegate: NotificationDelegate,
+    journalClient: JournalClientProtocol,
+    journalQueue: JournalQueue,
+    syncService: JournalSyncService,
+    networkMonitor: NetworkMonitor,
+    showingMenu: Binding<Bool>,
+    showingOnboarding: Binding<Bool>,
+    navigationPath: Binding<NavigationPath>
+  ) -> some View {
+    modifier(MainContentDialogsModifier(
+      viewModel: viewModel,
+      flowCoordinator: flowCoordinator,
+      syncSettingsViewModel: syncSettingsViewModel,
+      notificationDelegate: notificationDelegate,
+      journalClient: journalClient,
+      journalQueue: journalQueue,
+      syncService: syncService,
+      networkMonitor: networkMonitor,
+      showingMenu: showingMenu,
+      showingOnboarding: showingOnboarding,
+      navigationPath: navigationPath
+    ))
+  }
+}


### PR DESCRIPTION
Part of #295 (Phase 2a — eighth slice; ContentView meets the file-size acceptance criterion).

## Summary

\`ContentView\`'s remaining mass lived in \`contentWithDialogs\` after the alerts had been extracted: two \`onChange\` handlers (notification-driven \`initiatedBy\` + flow-step navigation pop), three sheets (menu, onboarding, flow review), and the onboarding-check \`.task\`. Plus a dead \`clampedLayerSelection\` property carried over from before \`LayerScrollView\` absorbed the clamping internally.

Two moves:

1. **Delete the orphaned \`clampedLayerSelection\` property** (14 lines incl. the #183 doc-comment). \`LayerScrollView\` has its own \`clampedSelection\` for the same purpose; \`ContentView\` no longer reads from it.

2. **Bundle the remaining \`contentWithDialogs\` body** into a \`MainContentDialogsModifier\` + \`.mainContentDialogs(...)\` View extension. Each handler keeps its identity via dedicated private properties (\`menuSheet\`, \`onboardingSheet\`, \`popNavigationPath\`). The fixes-#157/#162/#164 navigation-pop logic gets a name and a single switch case (\`selectingPrimary/Secondary/Strategy/idle\` all pop to root identically — previously two separate cases that did the same thing).

## Impact

| File | Before | After |
|---|---|---|
| \`ContentView.swift\` | 252 | **192** ✅ |
| \`MainContentDialogsModifier.swift\` | — | 135 |

🎯 **ContentView is now under the Phase 2a ≤200 line target.** Every view file in the project is under target:

- \`ContentView.swift\`: 192
- \`MainContentDialogsModifier.swift\`: 135
- \`LayerScrollView.swift\`: 160
- \`PhaseCrystalCard.swift\`: 150
- \`NavigationSyncModifier.swift\`: 119
- \`ContentViewDependencies.swift\`: 117
- \`PhasePageView.swift\`: 85 (was 203 before this Phase 2a effort)
- Others all under 100

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: menu sheet opens / dismisses; onboarding sheet gates on \`hasCompletedOnboarding\`; flow review sheet appears during \`.review\` step; navigation pops correctly when transitioning into a flow selection step from a detail view.