### PR TITLE
fix(flow): honor system-dismiss on flow review sheet (#335)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
@@ -47,7 +47,7 @@ struct MainContentDialogsModifier: ViewModifier {
       }
       .sheet(isPresented: $showingMenu) { menuSheet }
       .sheet(isPresented: $showingOnboarding) { onboardingSheet }
-      .sheet(isPresented: .constant(flowCoordinator.currentStep == .review)) {
+      .sheet(isPresented: flowReviewPresenter) {
         FlowReviewSheet(flowCoordinator: flowCoordinator)
       }
       .task {
@@ -83,6 +83,27 @@ struct MainContentDialogsModifier: ViewModifier {
       isPresented: $showingOnboarding
     )
     .interactiveDismissDisabled()
+  }
+
+  // MARK: - Bindings
+
+  /// Read-write binding for the flow-review sheet. Like
+  /// `FlowConfirmationAlertsModifier.presenter(for:)`, the write side
+  /// treats `isPresented = false` (system swipe-dismiss) as an
+  /// implicit cancel — the buttons inside `FlowReviewSheet` already
+  /// transition the coordinator off `.review` explicitly, so this only
+  /// fires when neither button was tapped and the user closed via the
+  /// swipe gesture. The step guard prevents a spurious cancel if the
+  /// coordinator has already moved on by the time SwiftUI writes false.
+  private var flowReviewPresenter: Binding<Bool> {
+    Binding(
+      get: { flowCoordinator.currentStep == .review },
+      set: { isPresented in
+        if !isPresented, flowCoordinator.currentStep == .review {
+          flowCoordinator.cancel()
+        }
+      }
+    )
   }
 
   // MARK: - Navigation


### PR DESCRIPTION
Closes #335.

## Summary

Same class of bug as #326 fixed for the flow confirmation alerts, but for the flow review sheet. Pattern was inherited from the original \`ContentView\` code:

\`\`\`swift
.sheet(isPresented: .constant(flowCoordinator.currentStep == .review)) {
  FlowReviewSheet(flowCoordinator: flowCoordinator)
}
\`\`\`

\`.constant(...)\` is read-only — SwiftUI's attempt to write \`false\` on a swipe-dismiss is silently dropped. The sheet stays "presented" in SwiftUI's view of the world until the coordinator transitions off \`.review\` through some other path. Today the inner buttons handle that transition, but a user-initiated swipe-dismiss leaves the sheet stuck in a half-state.

## Fix

Replaces \`.constant(...)\` with a derived read-write \`Binding\`: the read side still tracks the coordinator step, and the write side treats \`isPresented = false\` as an implicit cancel by calling \`flowCoordinator.cancel()\`. The step guard prevents a spurious cancel if the coordinator has already moved on by the time SwiftUI writes false. Matches the pattern established in \`FlowConfirmationAlertsModifier.presenter(for:)\`.

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: open the flow review (complete primary → confirm → review), swipe-dismiss — confirm the flow returns to idle instead of getting stuck.