### PR TITLE
fix(flow): block swipe-dismiss on review sheet during submission (#338)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -90,10 +90,7 @@ struct FlowReviewSheet: View {
       } message: {
         Text(errorMessage)
       }
-      // Block swipe-dismiss while a submission is in flight: after the
-      // #336 binding fix, swipe → `flowCoordinator.cancel()` fires
-      // immediately, but the still-pending submit Task can later
-      // resolve and write to `@State` on a dismissed view.
+      // Prevent cancel() racing a still-pending submit Task writing @State after dismiss.
       .interactiveDismissDisabled(isSubmitting)
     }
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -90,6 +90,11 @@ struct FlowReviewSheet: View {
       } message: {
         Text(errorMessage)
       }
+      // Block swipe-dismiss while a submission is in flight: after the
+      // #336 binding fix, swipe → `flowCoordinator.cancel()` fires
+      // immediately, but the still-pending submit Task can later
+      // resolve and write to `@State` on a dismissed view.
+      .interactiveDismissDisabled(isSubmitting)
     }
   }
 


### PR DESCRIPTION
Closes #338.

## Summary

After #336's binding fix, swipe-dismissing the flow review sheet maps to \`flowCoordinator.cancel()\` — which is the right behavior when the user is just changing their mind. But if the submission \`Task\` is already in flight, \`cancel()\` fires immediately while the \`Task\` can later resolve and write to \`@State\` on a dismissed view (\`showingSuccess\` toggles on a phantom view, the alert never appears).

The Cancel toolbar button is already gated on \`isSubmitting\`. Mirrors that with \`.interactiveDismissDisabled(isSubmitting)\` so the swipe gesture is blocked while the submit is in flight. Once the \`Task\` resolves, \`isSubmitting\` flips back to false and the user can dismiss normally.

This race existed before #336 too in principle, but pre-#336 the swipe was silently dropped by the \`.constant()\` binding so the race wasn't reachable.

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual smoke: tap submit, then try to swipe-dismiss while the spinner is up — sheet stays put until the submit resolves.