### PR TITLE
test: add WLNavigationBarModifierTests structural coverage (#322)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLNavigationBarModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLNavigationBarModifierTests.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Structural smoke tests for the design-system nav-bar modifier.
+/// The runtime branching (`#available(watchOS 26, *)`) selects between a
+/// no-op on 26+ and `.toolbarBackground(.hidden, for: .navigationBar)`
+/// on older runtimes — neither is unit-testable without snapshot or
+/// ViewInspector infrastructure. These tests pin the construction and
+/// extension surface so future refactors don't accidentally remove or
+/// break the entry point.
+struct WLNavigationBarModifierTests {
+  @Test func modifier_canBeInstantiated() {
+    _ = WLNavigationBarModifier()
+  }
+
+  @Test func viewExtension_isCallable() {
+    // Compile-time smoke: applying the modifier through the View extension
+    // succeeds. If `wlNavigationBar()` is renamed or removed, this fails
+    // to compile. We deliberately don't evaluate `.body` here — outside a
+    // real SwiftUI render pipeline that would crash on DynamicProperty
+    // initialization rather than testing anything meaningful.
+    _ = Text("nav").wlNavigationBar()
+  }
+}


### PR DESCRIPTION
Closes #322.

## Summary

Adds the missing test file for \`WLNavigationBarModifier\` that #321's review flagged as a consistency gap with the rest of the design-system test suite (\`WLGlassModifierTests\`, \`WLCardModifierTests\`, etc.).

Two structural smoke tests:

- **\`modifier_canBeInstantiated()\`** — confirms the modifier constructs successfully. Compile-time guard against rename or signature changes.
- **\`viewExtension_isCallable()\`** — confirms \`.wlNavigationBar()\` resolves from the View extension. Compile-time guard against the extension being renamed or removed.

## Why not more?

The runtime branching (\`if #available(watchOS 26, *)\`: no-op vs \`.toolbarBackground(.hidden, for: .navigationBar)\`) is not unit-testable without snapshot or ViewInspector infrastructure — accessing \`.body\` outside a real SwiftUI render pipeline trips \`DynamicProperty\` init and crashes (verified locally). The structural smoke is the realistic ceiling here; the runtime behavior is exercised whenever \`ContentView\` is rendered.

## Test plan

- [x] \`frontend/WavelengthWatch/run-tests-individually.sh WLNavigationBarModifierTests\` — 1/1 passing.
- [x] \`pre-commit run --all-files\` clean.