### PR TITLE
docs(navigation): add PhaseCrystalCard #Preview + scale rationale (#331)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -167,7 +167,7 @@ struct PhaseCrystalCard: View {
     subtitle: "Power",
     phases: [phase]
   )
-  return PhaseCrystalCard(layer: layer, phase: phase, color: .red, scale: 1.0)
+  PhaseCrystalCard(layer: layer, phase: phase, color: .red, scale: 1.0)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.black)
 }
@@ -187,7 +187,7 @@ struct PhaseCrystalCard: View {
     subtitle: "Magic",
     phases: [phase]
   )
-  return PhaseCrystalCard(layer: layer, phase: phase, color: .purple, scale: 1.0)
+  PhaseCrystalCard(layer: layer, phase: phase, color: .purple, scale: 1.0)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.black)
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -50,6 +50,9 @@ struct PhaseCrystalCard: View {
       crystalAccent
     }
     .padding(.horizontal, 20 * scale)
+    // Vertical rhythm stays fixed: the card's content (caption + title3 + accent) is
+    // already a fixed visual height, so scaling the pad only pushes the orb out without
+    // improving readability on larger watches.
     .padding(.vertical, 16)
     .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
     .background(cardBackground)
@@ -147,4 +150,44 @@ struct PhaseCrystalCard: View {
       .shadow(color: color.opacity(0.2), radius: 8)
       .shadow(color: .black.opacity(0.3), radius: 4)
   }
+}
+
+#Preview("Red layer, Peaking phase") {
+  let phase = CatalogPhaseModel(
+    id: 2,
+    name: "Peaking",
+    medicinal: [],
+    toxic: [],
+    strategies: []
+  )
+  let layer = CatalogLayerModel(
+    id: 4,
+    color: "Red",
+    title: "Red",
+    subtitle: "Power",
+    phases: [phase]
+  )
+  return PhaseCrystalCard(layer: layer, phase: phase, color: .red, scale: 1.0)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
+}
+
+#Preview("Edge case — Bottoming Out") {
+  let phase = CatalogPhaseModel(
+    id: 5,
+    name: "Bottoming Out",
+    medicinal: [],
+    toxic: [],
+    strategies: []
+  )
+  let layer = CatalogLayerModel(
+    id: 2,
+    color: "Purple",
+    title: "Purple",
+    subtitle: "Magic",
+    phases: [phase]
+  )
+  return PhaseCrystalCard(layer: layer, phase: phase, color: .purple, scale: 1.0)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -50,9 +50,7 @@ struct PhaseCrystalCard: View {
       crystalAccent
     }
     .padding(.horizontal, 20 * scale)
-    // Vertical rhythm stays fixed: the card's content (caption + title3 + accent) is
-    // already a fixed visual height, so scaling the pad only pushes the orb out without
-    // improving readability on larger watches.
+    // Fixed: content is a fixed visual height; scaling this pad only pushes the orb out.
     .padding(.vertical, 16)
     .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
     .background(cardBackground)
@@ -161,10 +159,10 @@ struct PhaseCrystalCard: View {
     strategies: []
   )
   let layer = CatalogLayerModel(
-    id: 4,
+    id: 3,
     color: "Red",
-    title: "Red",
-    subtitle: "Power",
+    title: "RED",
+    subtitle: "(Power)",
     phases: [phase]
   )
   PhaseCrystalCard(layer: layer, phase: phase, color: .red, scale: 1.0)
@@ -183,8 +181,8 @@ struct PhaseCrystalCard: View {
   let layer = CatalogLayerModel(
     id: 2,
     color: "Purple",
-    title: "Purple",
-    subtitle: "Magic",
+    title: "PURPLE",
+    subtitle: "(Tribal)",
     phases: [phase]
   )
   PhaseCrystalCard(layer: layer, phase: phase, color: .purple, scale: 1.0)


### PR DESCRIPTION
Closes #331.

## Summary

Two polish items the reviewer on #330 flagged:

1. **Document the fixed \`.padding(.vertical, 16)\`**. The card's content (caption + title3 + accent) is a fixed-height visual block, so scaling the vertical pad only pushes the orb out without improving readability on larger watches. Inline comment makes the intent explicit so a future contributor doesn't "fix" the apparent inconsistency between horizontal-scaled and vertical-fixed padding.

2. **Add two \`#Preview\` blocks** that render the card with concrete \`CatalogLayerModel\` / \`CatalogPhaseModel\` instances (no \`.preview\` fixtures exist on these models yet — using inline construction):
   - Normal case: Red layer, "Peaking" phase, scale 1.0.
   - Edge case: Purple layer, "Bottoming Out" phase — the longest phase name the design has to fit.

   Both background the card on black so the orb glow and shadows read correctly. Lets design iteration happen in Xcode's canvas without launching the full app.

## Test plan

- [x] All 43 watchOS suites pass under Xcode 26.3 / watchOS 26.2 simulator.
- [x] \`pre-commit run --all-files\` clean.
- [ ] Manual: open \`PhaseCrystalCard.swift\` in Xcode canvas, confirm both previews render without truncation.