### PR TITLE
test(navigation): cover flow-review presenter dismiss-cancel mapping (#337)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
@@ -47,7 +47,7 @@ struct MainContentDialogsModifier: ViewModifier {
       }
       .sheet(isPresented: $showingMenu) { menuSheet }
       .sheet(isPresented: $showingOnboarding) { onboardingSheet }
-      .sheet(isPresented: flowReviewPresenter) {
+      .sheet(isPresented: Self.flowReviewPresenter(for: flowCoordinator)) {
         FlowReviewSheet(flowCoordinator: flowCoordinator)
       }
       .task {
@@ -95,7 +95,7 @@ struct MainContentDialogsModifier: ViewModifier {
   /// fires when neither button was tapped and the user closed via the
   /// swipe gesture. The step guard prevents a spurious cancel if the
   /// coordinator has already moved on by the time SwiftUI writes false.
-  private var flowReviewPresenter: Binding<Bool> {
+  static func flowReviewPresenter(for flowCoordinator: FlowCoordinator) -> Binding<Bool> {
     Binding(
       get: { flowCoordinator.currentStep == .review },
       set: { isPresented in

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/MainContentDialogsModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/MainContentDialogsModifierTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Regression coverage for `MainContentDialogsModifier.flowReviewPresenter(for:)`
+/// — the derived `Binding<Bool>` that maps a system swipe-dismiss of the
+/// flow-review sheet onto `FlowCoordinator.cancel()` (filed from #336 review).
+@MainActor
+struct MainContentDialogsModifierTests {
+  private func makeCoordinator() async -> (FlowCoordinator, CatalogResponseModel) {
+    let catalog = CatalogTestHelper.createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let viewModel = ContentViewModel(
+      catalogRepository: repository,
+      journalRepository: InMemoryJournalRepository(),
+      journalClient: JournalClientMock()
+    )
+    await viewModel.loadCatalog()
+    return (FlowCoordinator(contentViewModel: viewModel), catalog)
+  }
+
+  // MARK: - Getter
+
+  @Test("getter is true only while the coordinator is in .review")
+  func getter_isTrueOnlyInReview() async {
+    let (coordinator, _) = await makeCoordinator()
+    let binding = MainContentDialogsModifier.flowReviewPresenter(for: coordinator)
+
+    #expect(binding.wrappedValue == false)
+
+    coordinator.startPrimarySelection()
+    #expect(binding.wrappedValue == false)
+
+    coordinator.showReview()
+    #expect(binding.wrappedValue == true)
+  }
+
+  // MARK: - Setter — implicit cancel
+
+  @Test("writing false while in .review cancels the flow")
+  func setterFalse_inReview_cancelsFlow() async {
+    let (coordinator, catalog) = await makeCoordinator()
+    coordinator.capturePrimary(catalog.layers[1].phases[0].medicinal[0])
+    coordinator.showReview()
+    let binding = MainContentDialogsModifier.flowReviewPresenter(for: coordinator)
+
+    binding.wrappedValue = false
+
+    #expect(coordinator.currentStep == .idle)
+    #expect(coordinator.selections.primary == nil)
+    #expect(coordinator.contentViewModel.layerFilterMode == .all)
+  }
+
+  // MARK: - Setter — step guard
+
+  @Test("writing false outside .review does not cancel the flow")
+  func setterFalse_outsideReview_doesNotCancel() async {
+    let (coordinator, catalog) = await makeCoordinator()
+    let primary = catalog.layers[1].phases[0].medicinal[0]
+    coordinator.capturePrimary(primary)
+    let binding = MainContentDialogsModifier.flowReviewPresenter(for: coordinator)
+
+    binding.wrappedValue = false
+
+    #expect(coordinator.currentStep == .confirmingPrimary)
+    #expect(coordinator.selections.primary == primary)
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #337. Adds the regression coverage requested in the #336 review for the flow-review sheet's system-dismiss → `FlowCoordinator.cancel()` mapping.
- Extracts `MainContentDialogsModifier.flowReviewPresenter` from a `private` computed property into a testable `static func flowReviewPresenter(for:)` — the binding only ever depended on the `FlowCoordinator`, so making that dependency explicit lets the test exercise it without constructing the full modifier and its 11 dependencies.
- New `MainContentDialogsModifierTests` covers the three cases from the issue: getter is `true` only while in `.review`, writing `false` while in `.review` cancels the flow (step → `.idle`, selections cleared, filter restored), and writing `false` outside `.review` is a no-op (step guard).

## Test plan
- [x] `run-tests-individually.sh MainContentDialogsModifierTests` — 1/1 passed
- [x] Full suite (`run-tests-individually.sh`) — all 44 suites pass, no regressions from the production change
- [x] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)