### PR TITLE
test(journal): cover JournalFeedbackAlert copy and pluralization (#325)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalFeedbackAlert.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalFeedbackAlert.swift
@@ -13,39 +13,46 @@ enum JournalFeedbackAlert {
     _ feedback: ContentViewModel.JournalFeedback,
     dismiss: @escaping () -> Void
   ) -> Alert {
-    switch feedback.kind {
-    case .success:
-      return Alert(
-        title: Text("Entry Logged"),
-        message: Text("Thanks for checking in."),
-        dismissButton: .default(Text("OK"), action: dismiss)
-      )
-    case let .queued(message):
-      return Alert(
-        title: Text("Saved Offline"),
-        message: Text(message),
-        dismissButton: .default(Text("OK"), action: dismiss)
-      )
-    case let .syncing(current, total):
-      let suffix = total == 1 ? "y" : "ies"
-      return Alert(
-        title: Text("Syncing"),
-        message: Text("Syncing \(current) of \(total) entr\(suffix)…"),
-        dismissButton: .default(Text("OK"), action: dismiss)
-      )
-    case let .syncSuccess(count):
-      let suffix = count == 1 ? "y" : "ies"
-      return Alert(
-        title: Text("Synced"),
-        message: Text("\(count) entr\(suffix) synced successfully."),
-        dismissButton: .default(Text("OK"), action: dismiss)
-      )
-    case let .failure(message):
-      return Alert(
-        title: Text("Something went wrong"),
-        message: Text(message),
-        dismissButton: .default(Text("OK"), action: dismiss)
-      )
+    Alert(
+      title: Text(title(for: feedback.kind)),
+      message: Text(message(for: feedback.kind)),
+      dismissButton: .default(Text("OK"), action: dismiss)
+    )
+  }
+
+  /// The alert title copy for a feedback `Kind`. Extracted so the copy
+  /// contract is unit-testable without introspecting an opaque `Alert`.
+  static func title(for kind: ContentViewModel.JournalFeedback.Kind) -> String {
+    switch kind {
+    case .success: "Entry Logged"
+    case .queued: "Saved Offline"
+    case .syncing: "Syncing"
+    case .syncSuccess: "Synced"
+    case .failure: "Something went wrong"
     }
+  }
+
+  /// The alert message copy for a feedback `Kind`, including the
+  /// entry-count pluralization for the `.syncing` and `.syncSuccess`
+  /// cases. Extracted alongside `title(for:)` for unit testability.
+  static func message(for kind: ContentViewModel.JournalFeedback.Kind) -> String {
+    switch kind {
+    case .success:
+      "Thanks for checking in."
+    case let .queued(message):
+      message
+    case let .syncing(current, total):
+      "Syncing \(current) of \(total) entr\(pluralSuffix(for: total))…"
+    case let .syncSuccess(count):
+      "\(count) entr\(pluralSuffix(for: count)) synced successfully."
+    case let .failure(message):
+      message
+    }
+  }
+
+  /// The "entr-" suffix: singular `y` for a count of 1, plural `ies`
+  /// otherwise.
+  private static func pluralSuffix(for count: Int) -> String {
+    count == 1 ? "y" : "ies"
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalFeedbackAlertTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalFeedbackAlertTests.swift
@@ -1,13 +1,7 @@
 import Testing
 @testable import WavelengthWatch_Watch_App
 
-/// Coverage for `JournalFeedbackAlert`'s copy contract — one assertion
-/// per `JournalFeedback.Kind` branch plus the entry-count pluralization
-/// boundaries for `.syncing` and `.syncSuccess` (filed as #325).
-///
-/// `Alert` itself is opaque to Swift Testing, so these exercise the
-/// extracted `title(for:)` / `message(for:)` factories that `make`
-/// composes into the alert.
+/// Copy and pluralization coverage for `JournalFeedbackAlert` (#325).
 struct JournalFeedbackAlertTests {
   // MARK: - Titles
 
@@ -45,6 +39,10 @@ struct JournalFeedbackAlertTests {
 
   @Test("syncSuccess message pluralizes on count")
   func message_syncSuccessPluralization() {
+    #expect(
+      JournalFeedbackAlert.message(for: .syncSuccess(count: 0))
+        == "0 entries synced successfully."
+    )
     #expect(
       JournalFeedbackAlert.message(for: .syncSuccess(count: 1))
         == "1 entry synced successfully."

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalFeedbackAlertTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalFeedbackAlertTests.swift
@@ -1,0 +1,57 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Coverage for `JournalFeedbackAlert`'s copy contract — one assertion
+/// per `JournalFeedback.Kind` branch plus the entry-count pluralization
+/// boundaries for `.syncing` and `.syncSuccess` (filed as #325).
+///
+/// `Alert` itself is opaque to Swift Testing, so these exercise the
+/// extracted `title(for:)` / `message(for:)` factories that `make`
+/// composes into the alert.
+struct JournalFeedbackAlertTests {
+  // MARK: - Titles
+
+  @Test("each Kind maps to its design title")
+  func title_perBranch() {
+    #expect(JournalFeedbackAlert.title(for: .success) == "Entry Logged")
+    #expect(JournalFeedbackAlert.title(for: .queued("x")) == "Saved Offline")
+    #expect(JournalFeedbackAlert.title(for: .syncing(current: 1, total: 3)) == "Syncing")
+    #expect(JournalFeedbackAlert.title(for: .syncSuccess(count: 2)) == "Synced")
+    #expect(JournalFeedbackAlert.title(for: .failure("x")) == "Something went wrong")
+  }
+
+  // MARK: - Messages
+
+  @Test("success and failure messages match design copy / pass through")
+  func message_staticAndPassThrough() {
+    #expect(JournalFeedbackAlert.message(for: .success) == "Thanks for checking in.")
+    #expect(JournalFeedbackAlert.message(for: .queued("Saved for later")) == "Saved for later")
+    #expect(JournalFeedbackAlert.message(for: .failure("Network unavailable")) == "Network unavailable")
+  }
+
+  // MARK: - Pluralization boundaries
+
+  @Test("syncing message pluralizes on total")
+  func message_syncingPluralization() {
+    #expect(
+      JournalFeedbackAlert.message(for: .syncing(current: 1, total: 1))
+        == "Syncing 1 of 1 entry…"
+    )
+    #expect(
+      JournalFeedbackAlert.message(for: .syncing(current: 1, total: 2))
+        == "Syncing 1 of 2 entries…"
+    )
+  }
+
+  @Test("syncSuccess message pluralizes on count")
+  func message_syncSuccessPluralization() {
+    #expect(
+      JournalFeedbackAlert.message(for: .syncSuccess(count: 1))
+        == "1 entry synced successfully."
+    )
+    #expect(
+      JournalFeedbackAlert.message(for: .syncSuccess(count: 2))
+        == "2 entries synced successfully."
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #325. Adds the regression coverage requested in the #324 review for the `JournalFeedbackAlert` factory.
- `Alert` is opaque to Swift Testing, so the per-`Kind` title and message copy is extracted into pure `title(for:)` / `message(for:)` static functions that `make` now composes — making the copy contract directly unit-testable. The `.syncing` / `.syncSuccess` pluralization moves into a small private `pluralSuffix(for:)` helper.
- New `JournalFeedbackAlertTests` covers one assertion per `JournalFeedback.Kind` branch (`.success`, `.queued`, `.syncing`, `.syncSuccess`, `.failure`) plus the entry-count pluralization boundaries (1 vs 2 entries) for `.syncing` and `.syncSuccess`. Copy strings are unchanged from the original factory.

## Test plan
- [x] `run-tests-individually.sh JournalFeedbackAlertTests` — 1/1 passed
- [x] Full suite (`run-tests-individually.sh`) — all suites pass, no regressions from the `make` refactor
- [x] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)