### PR TITLE
fix(flow): bound FlowReviewSheet submission with timeout + cancellation (#341)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -6,6 +6,7 @@ struct FlowReviewSheet: View {
   @State private var showingSuccess = false
   @State private var showingError = false
   @State private var errorMessage = ""
+  @State private var submitTask: Task<Void, Never>?
 
   var body: some View {
     NavigationStack {
@@ -92,6 +93,14 @@ struct FlowReviewSheet: View {
       }
       // Prevent cancel() racing a still-pending submit Task writing @State after dismiss.
       .interactiveDismissDisabled(isSubmitting)
+      // Any transition off .review (toolbar Cancel, success-alert OK, or
+      // the system swipe-dismiss binding) means the user backed out — drop
+      // the in-flight submit so a hung request can't strand isSubmitting.
+      .onChange(of: flowCoordinator.currentStep) { _, newStep in
+        if newStep != .review {
+          submitTask?.cancel()
+        }
+      }
     }
   }
 
@@ -155,11 +164,14 @@ struct FlowReviewSheet: View {
     .cornerRadius(10)
   }
 
+  @MainActor
   private func submitEntry() {
     isSubmitting = true
-    Task {
+    submitTask = Task {
       do {
-        try await flowCoordinator.submit()
+        try await SubmitTimeout.run(seconds: 30) {
+          try await flowCoordinator.submit()
+        }
         isSubmitting = false
         showingSuccess = true
       } catch JournalError.queuedForRetry {
@@ -167,6 +179,14 @@ struct FlowReviewSheet: View {
         // is restored. Treat this as a successful submission for UX purposes.
         isSubmitting = false
         showingSuccess = true
+      } catch is CancellationError {
+        // The flow was cancelled out from under the submit; the sheet is
+        // already going away, so reset state without surfacing an error.
+        isSubmitting = false
+      } catch is SubmitTimeoutError {
+        isSubmitting = false
+        errorMessage = "Submission timed out. Check your connection and try again."
+        showingError = true
       } catch {
         isSubmitting = false
         errorMessage = "Failed to submit: \(error.localizedDescription)"

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -169,7 +169,7 @@ struct FlowReviewSheet: View {
     isSubmitting = true
     submitTask = Task {
       do {
-        try await SubmitTimeout.run(seconds: 30) {
+        try await SubmitTimeout.run(seconds: SubmitTimeout.journalSubmitDeadlineSeconds) {
           try await flowCoordinator.submit()
         }
         isSubmitting = false

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/SubmitTimeout.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/SubmitTimeout.swift
@@ -6,6 +6,10 @@ struct SubmitTimeoutError: Error, Equatable {}
 
 /// Races an async operation against a wall-clock deadline.
 enum SubmitTimeout {
+  /// Deadline applied to a journal submission, co-located with the
+  /// mechanism that enforces it.
+  static let journalSubmitDeadlineSeconds: Double = 30
+
   /// Runs `operation`, throwing `SubmitTimeoutError` if it does not finish
   /// within `seconds`. The losing branch is always cancelled, and a real
   /// error from `operation` propagates unchanged rather than being masked

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/SubmitTimeout.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/SubmitTimeout.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Thrown by `SubmitTimeout.run` when the wrapped operation misses its
+/// deadline.
+struct SubmitTimeoutError: Error, Equatable {}
+
+/// Races an async operation against a wall-clock deadline.
+///
+/// `FlowReviewSheet` disables interactive dismissal while a submission is
+/// in flight, so an indefinitely-hung `submit()` would leave the sheet
+/// permanently stuck. Wrapping the submission here guarantees it either
+/// resolves or throws `SubmitTimeoutError` within `seconds`.
+enum SubmitTimeout {
+  /// Runs `operation`, throwing `SubmitTimeoutError` if it does not finish
+  /// within `seconds`. The operation is cancelled when either branch wins,
+  /// and any error it throws propagates unchanged (the timeout never masks
+  /// a real failure).
+  static func run(
+    seconds: Double,
+    operation: @escaping @Sendable () async throws -> Void
+  ) async throws {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask { try await operation() }
+      group.addTask {
+        try await Task.sleep(for: .seconds(seconds))
+        throw SubmitTimeoutError()
+      }
+      defer { group.cancelAll() }
+      try await group.next()
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/SubmitTimeout.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/SubmitTimeout.swift
@@ -5,16 +5,15 @@ import Foundation
 struct SubmitTimeoutError: Error, Equatable {}
 
 /// Races an async operation against a wall-clock deadline.
-///
-/// `FlowReviewSheet` disables interactive dismissal while a submission is
-/// in flight, so an indefinitely-hung `submit()` would leave the sheet
-/// permanently stuck. Wrapping the submission here guarantees it either
-/// resolves or throws `SubmitTimeoutError` within `seconds`.
 enum SubmitTimeout {
   /// Runs `operation`, throwing `SubmitTimeoutError` if it does not finish
-  /// within `seconds`. The operation is cancelled when either branch wins,
-  /// and any error it throws propagates unchanged (the timeout never masks
-  /// a real failure).
+  /// within `seconds`. The losing branch is always cancelled, and a real
+  /// error from `operation` propagates unchanged rather than being masked
+  /// as a timeout.
+  ///
+  /// `FlowReviewSheet` disables interactive dismissal while a submission is
+  /// in flight, so without this an indefinitely-hung `submit()` would leave
+  /// the sheet permanently stuck.
   static func run(
     seconds: Double,
     operation: @escaping @Sendable () async throws -> Void

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/SubmitTimeoutTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/SubmitTimeoutTests.swift
@@ -14,7 +14,7 @@ struct SubmitTimeoutTests {
   @Test("an operation exceeding the deadline throws SubmitTimeoutError")
   func slowOperation_timesOut() async {
     await #expect(throws: SubmitTimeoutError.self) {
-      try await SubmitTimeout.run(seconds: 0.05) {
+      try await SubmitTimeout.run(seconds: 0.2) {
         try await Task.sleep(for: .seconds(10))
       }
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/SubmitTimeoutTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/SubmitTimeoutTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Coverage for `SubmitTimeout.run` — the deadline race that keeps a hung
+/// journal submission from stranding `FlowReviewSheet` (#341).
+struct SubmitTimeoutTests {
+  private struct ProbeError: Error, Equatable {}
+
+  @Test("an operation finishing before the deadline does not throw")
+  func fastOperation_completes() async throws {
+    try await SubmitTimeout.run(seconds: 5) {}
+  }
+
+  @Test("an operation exceeding the deadline throws SubmitTimeoutError")
+  func slowOperation_timesOut() async {
+    await #expect(throws: SubmitTimeoutError.self) {
+      try await SubmitTimeout.run(seconds: 0.05) {
+        try await Task.sleep(for: .seconds(10))
+      }
+    }
+  }
+
+  @Test("an operation error propagates instead of being masked as a timeout")
+  func operationError_propagates() async {
+    await #expect(throws: ProbeError.self) {
+      try await SubmitTimeout.run(seconds: 5) {
+        throw ProbeError()
+      }
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/SubmitTimeoutTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/SubmitTimeoutTests.swift
@@ -28,4 +28,17 @@ struct SubmitTimeoutTests {
       }
     }
   }
+
+  @Test("cancelling the enclosing task propagates CancellationError")
+  func externalCancellation_propagates() async {
+    let task = Task {
+      try await SubmitTimeout.run(seconds: 30) {
+        try await Task.sleep(for: .seconds(30))
+      }
+    }
+    task.cancel()
+    await #expect(throws: CancellationError.self) {
+      try await task.value
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Closes #341. Hardens the journal submission path in `FlowReviewSheet` per the #340 review's deferred concerns.
- **`SubmitTimeout.run`** — a new deadline-race helper that throws `SubmitTimeoutError` if the wrapped operation misses its window, while letting a genuine operation error propagate unchanged (the timeout never masks a real failure).
- **30s timeout** — `flowCoordinator.submit()` now runs inside `SubmitTimeout.run(seconds: 30)`, so an indefinitely-hung request can no longer permanently strand the sheet (which disables interactive dismissal while `isSubmitting`).
- **Lifecycle-bound submit task** — the submit `Task` is stored and cancelled on any transition off `.review` (toolbar Cancel, success-alert OK, or the #336 system-dismiss binding), so a hung submit resets instead of leaking.
- **Explicit isolation** — `submitEntry()` is `@MainActor`-annotated, and `CancellationError` is treated as a quiet state reset rather than a surfaced error.

## Test plan
- [x] `run-tests-individually.sh SubmitTimeoutTests` — 1/1 passed (completion, timeout, error-propagation cases)
- [x] Full suite (`run-tests-individually.sh`) — all 44 suites pass, no regressions
- [x] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)