### PR TITLE
refactor(deps): harden ContentViewDependencies factories (#333)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -59,6 +59,7 @@ struct ContentViewDependencies {
 
   /// Builds the live dependency graph: real API, on-disk SQLite,
   /// real network monitor. Used by the app's runtime entry point.
+  @MainActor
   static func live() -> ContentViewDependencies {
     let configuration = AppConfiguration()
     let apiClient = APIClient(baseURL: configuration.apiBaseURL)
@@ -120,6 +121,7 @@ struct ContentViewDependencies {
   ///
   /// `openPersistent` is injectable so the fallback branch can be tested
   /// without a genuinely corrupt database file.
+  @MainActor
   static func makeJournalRepository(
     openPersistent: () throws -> JournalRepositoryProtocol = {
       let repository = JournalRepository()
@@ -149,7 +151,9 @@ struct ContentViewDependencies {
   ///
   /// The closure parameters are `@MainActor` because their default values
   /// construct the main-actor-isolated `JournalQueue`, and default-argument
-  /// expressions evaluate outside the enclosing type's actor isolation.
+  /// expressions evaluate outside the enclosing type's actor isolation —
+  /// the annotation on the function alone does not reach them.
+  @MainActor
   static func makeJournalQueue(
     documentsQueue: @MainActor () throws -> JournalQueue = { try JournalQueue() },
     tempQueue: @MainActor () throws -> JournalQueue = {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Bundle of everything `ContentView` needs to wire up its root view
 /// hierarchy: the live API client, repositories, queue, journal client,
@@ -22,6 +23,10 @@ struct ContentViewDependencies {
   let viewModel: ContentViewModel
   let flowCoordinator: FlowCoordinator
   let syncSettingsViewModel: SyncSettingsViewModel
+  /// Shared sync-preferences store backing both `journalClient` and
+  /// `syncSettingsViewModel`. Exposed on the bundle so a test config can
+  /// inject a known state without reconstructing the whole graph.
+  let syncSettings: SyncSettings
   let networkMonitor: NetworkMonitor
   let journalQueue: JournalQueue
   let syncService: JournalSyncService
@@ -36,6 +41,21 @@ struct ContentViewDependencies {
   /// includes the +1 offset that the infinite-scroll TabView expects;
   /// `init(dependencies:)` unpacks this directly with no arithmetic.
   let initialPhaseSelection: Int
+
+  private static let logger = Logger(
+    subsystem: "com.wavelengthwatch.watch",
+    category: "ContentViewDependencies"
+  )
+
+  /// Filesystem path for the temp-directory journal-queue fallback,
+  /// composed via `URL` so it stays correct even if `NSTemporaryDirectory`
+  /// ever stops returning a trailing-slash path.
+  static let tempJournalQueueFallbackPath = URL(
+    fileURLWithPath: NSTemporaryDirectory(),
+    isDirectory: true
+  )
+  .appendingPathComponent("journal_queue_fallback.sqlite")
+  .path
 
   /// Builds the live dependency graph: real API, on-disk SQLite,
   /// real network monitor. Used by the app's runtime entry point.
@@ -76,6 +96,7 @@ struct ContentViewDependencies {
       viewModel: viewModel,
       flowCoordinator: flowCoordinator,
       syncSettingsViewModel: syncSettingsViewModel,
+      syncSettings: syncSettings,
       networkMonitor: networkMonitor,
       journalQueue: journalQueue,
       syncService: syncService,
@@ -96,13 +117,22 @@ struct ContentViewDependencies {
   /// in-memory storage if open fails (SwiftUI previews, test harness,
   /// or a corrupted database file). The fallback keeps the app
   /// functional but entries logged in the session don't persist.
-  private static func makeJournalRepository() -> JournalRepositoryProtocol {
-    let persistentRepo = JournalRepository()
+  ///
+  /// `openPersistent` is injectable so the fallback branch can be tested
+  /// without a genuinely corrupt database file.
+  static func makeJournalRepository(
+    openPersistent: () throws -> JournalRepositoryProtocol = {
+      let repository = JournalRepository()
+      try repository.open()
+      return repository
+    }
+  ) -> JournalRepositoryProtocol {
     do {
-      try persistentRepo.open()
-      return persistentRepo
+      return try openPersistent()
     } catch {
-      print("⚠️ Failed to open journal database: \(error). Falling back to in-memory storage.")
+      logger.warning(
+        "Journal database open failed: \(error.localizedDescription, privacy: .public). Falling back to in-memory storage."
+      )
       return InMemoryJournalRepository()
     }
   }
@@ -113,20 +143,34 @@ struct ContentViewDependencies {
   /// normal operation; if even that throws, the device is in a state
   /// where no offline persistence is possible and crashing surfaces
   /// the problem rather than silently dropping entries.
-  private static func makeJournalQueue() -> JournalQueue {
-    do {
-      return try JournalQueue()
-    } catch {
-      print("⚠️ Documents-dir journal queue init failed: \(error). Trying temp dir.")
+  ///
+  /// The three legs are injectable so the fallthrough order can be
+  /// tested without genuinely unwritable directories.
+  static func makeJournalQueue(
+    documentsQueue: @MainActor () throws -> JournalQueue = { try JournalQueue() },
+    tempQueue: @MainActor () throws -> JournalQueue = {
+      try JournalQueue(databasePath: tempJournalQueueFallbackPath)
+    },
+    inMemoryQueue: @MainActor () throws -> JournalQueue = {
+      try JournalQueue(databasePath: ":memory:")
     }
-    let fallbackPath = NSTemporaryDirectory() + "journal_queue_fallback.sqlite"
+  ) -> JournalQueue {
     do {
-      return try JournalQueue(databasePath: fallbackPath)
+      return try documentsQueue()
     } catch {
-      print("⚠️ Temp-dir journal queue init failed: \(error). Falling back to in-memory.")
+      logger.warning(
+        "Documents-dir journal queue init failed: \(error.localizedDescription, privacy: .public). Trying temp dir."
+      )
     }
     do {
-      return try JournalQueue(databasePath: ":memory:")
+      return try tempQueue()
+    } catch {
+      logger.warning(
+        "Temp-dir journal queue init failed: \(error.localizedDescription, privacy: .public). Falling back to in-memory."
+      )
+    }
+    do {
+      return try inMemoryQueue()
     } catch {
       fatalError("In-memory journal queue init failed unexpectedly: \(error)")
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -146,6 +146,10 @@ struct ContentViewDependencies {
   ///
   /// The three legs are injectable so the fallthrough order can be
   /// tested without genuinely unwritable directories.
+  ///
+  /// The closure parameters are `@MainActor` because their default values
+  /// construct the main-actor-isolated `JournalQueue`, and default-argument
+  /// expressions evaluate outside the enclosing type's actor isolation.
   static func makeJournalQueue(
     documentsQueue: @MainActor () throws -> JournalQueue = { try JournalQueue() },
     tempQueue: @MainActor () throws -> JournalQueue = {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/SyncSettingsViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/SyncSettingsViewModel.swift
@@ -25,7 +25,9 @@ final class SyncSettingsViewModel: ObservableObject {
   /// Private setter ensures only the view model can mark onboarding complete.
   @Published private(set) var hasCompletedOnboarding: Bool
 
-  private let syncSettings: SyncSettings
+  /// Shared sync-preferences store. Not `private` so tests can verify the
+  /// dependency graph wires a single `SyncSettings` instance everywhere.
+  let syncSettings: SyncSettings
 
   /// Creates a view model with the specified sync settings.
   ///

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
@@ -60,11 +60,21 @@ struct ContentViewDependenciesTests {
 
   // MARK: - live()
 
-  @Test("live composes the full dependency graph without crashing")
+  @Test("live composes the dependency graph with shared instances wired through")
   func live_composesGraph() {
     let deps = ContentViewDependencies.live()
-    // initialPhaseSelection carries the +1 infinite-scroll offset, so it is
-    // always >= 1; reaching this assertion proves every field was built.
-    #expect(deps.initialPhaseSelection >= 1)
+    // The flow coordinator must be built against the same view-model the
+    // bundle hands to ContentView — a real wiring invariant, not just
+    // "live() didn't crash".
+    #expect(deps.flowCoordinator.contentViewModel === deps.viewModel)
+  }
+
+  @Test("live exposes a usable syncSettings handle for test injection")
+  func live_exposesSyncSettings() {
+    let deps = ContentViewDependencies.live()
+    let original = deps.syncSettings.cloudSyncEnabled
+    deps.syncSettings.cloudSyncEnabled = !original
+    #expect(deps.syncSettings.cloudSyncEnabled == !original)
+    deps.syncSettings.cloudSyncEnabled = original
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
@@ -69,12 +69,9 @@ struct ContentViewDependenciesTests {
     #expect(deps.flowCoordinator.contentViewModel === deps.viewModel)
   }
 
-  @Test("live exposes a usable syncSettings handle for test injection")
-  func live_exposesSyncSettings() {
+  @Test("live wires a single shared syncSettings instance through the graph")
+  func live_exposesSharedSyncSettings() {
     let deps = ContentViewDependencies.live()
-    let original = deps.syncSettings.cloudSyncEnabled
-    deps.syncSettings.cloudSyncEnabled = !original
-    #expect(deps.syncSettings.cloudSyncEnabled == !original)
-    deps.syncSettings.cloudSyncEnabled = original
+    #expect(deps.syncSettings === deps.syncSettingsViewModel.syncSettings)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
@@ -1,0 +1,70 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Coverage for `ContentViewDependencies`' progressive fallback factories (#333).
+@MainActor
+struct ContentViewDependenciesTests {
+  private struct FactoryFailure: Error {}
+
+  // MARK: - makeJournalRepository
+
+  @Test("makeJournalRepository returns the persistent repo when the open succeeds")
+  func makeJournalRepository_returnsPersistentOnSuccess() {
+    let persistent = InMemoryJournalRepository()
+    let repo = ContentViewDependencies.makeJournalRepository(openPersistent: { persistent })
+    #expect(repo as AnyObject === persistent)
+  }
+
+  @Test("makeJournalRepository falls back to in-memory when the open fails")
+  func makeJournalRepository_fallsBackOnOpenFailure() {
+    let repo = ContentViewDependencies.makeJournalRepository(openPersistent: {
+      throw FactoryFailure()
+    })
+    #expect(repo is InMemoryJournalRepository)
+  }
+
+  // MARK: - makeJournalQueue
+
+  @Test("makeJournalQueue uses the documents queue when it opens")
+  func makeJournalQueue_usesDocumentsWhenAvailable() throws {
+    let documents = try JournalQueue(databasePath: ":memory:")
+    let queue = ContentViewDependencies.makeJournalQueue(
+      documentsQueue: { documents },
+      tempQueue: { throw FactoryFailure() },
+      inMemoryQueue: { throw FactoryFailure() }
+    )
+    #expect(queue === documents)
+  }
+
+  @Test("makeJournalQueue falls through to the temp queue when documents fails")
+  func makeJournalQueue_fallsThroughToTemp() throws {
+    let temp = try JournalQueue(databasePath: ":memory:")
+    let queue = ContentViewDependencies.makeJournalQueue(
+      documentsQueue: { throw FactoryFailure() },
+      tempQueue: { temp },
+      inMemoryQueue: { throw FactoryFailure() }
+    )
+    #expect(queue === temp)
+  }
+
+  @Test("makeJournalQueue falls through to in-memory when documents and temp fail")
+  func makeJournalQueue_fallsThroughToInMemory() throws {
+    let inMemory = try JournalQueue(databasePath: ":memory:")
+    let queue = ContentViewDependencies.makeJournalQueue(
+      documentsQueue: { throw FactoryFailure() },
+      tempQueue: { throw FactoryFailure() },
+      inMemoryQueue: { inMemory }
+    )
+    #expect(queue === inMemory)
+  }
+
+  // MARK: - live()
+
+  @Test("live composes the full dependency graph without crashing")
+  func live_composesGraph() {
+    let deps = ContentViewDependencies.live()
+    // initialPhaseSelection carries the +1 infinite-scroll offset, so it is
+    // always >= 1; reaching this assertion proves every field was built.
+    #expect(deps.initialPhaseSelection >= 1)
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #333. Addresses the four deferred review items from #332, all in `ContentViewDependencies`.
- **Injectable factories** — `makeJournalRepository` and `makeJournalQueue` now accept factory closures (defaulting to the real constructors), so the SQLite-open fallback and the documents → temp → in-memory fallthrough are unit-testable without genuinely unwritable directories. Both were also un-`private`d for `@testable` access.
- **`os.Logger` over `print()`** — fallback events now log via `Logger` (subsystem `com.wavelengthwatch.watch`, matching the existing `AppConfiguration` / `CatalogRepository` convention), so a silent degradation to in-memory storage is visible in production.
- **URL path composition** — the temp-dir fallback path is built with `URL(fileURLWithPath:isDirectory:).appendingPathComponent(_:)` instead of string concatenation, dropping the `NSTemporaryDirectory` trailing-slash assumption.
- **`syncSettings` on the bundle** — exposed as a field so a test config can inject a known sync state without rebuilding the graph.

## Test plan
- [x] `run-tests-individually.sh ContentViewDependenciesTests` — 1/1 passed (repository fallback, queue fallthrough x3, `live()` composition)
- [x] Full suite (`run-tests-individually.sh`) — all suites pass, no regressions
- [x] `pre-commit run --all-files` — all hooks pass

Note: the `os.Logger` migration is scoped to this file; the issue flags the repo-wide `print()` sweep as separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)