### PR TITLE
test(flow): harden FlowConfirmationAlertsModifier (#327)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowConfirmationAlertsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowConfirmationAlertsModifier.swift
@@ -10,17 +10,20 @@ import SwiftUI
 /// know about journal persistence, queueing, or feedback rendering.
 struct FlowConfirmationAlertsModifier: ViewModifier {
   @ObservedObject var flowCoordinator: FlowCoordinator
-  let onPrimarySubmit: () async -> Void
-  let onSecondarySubmit: () async -> Void
+  let onPrimarySubmit: @MainActor () async -> Void
+  let onSecondarySubmit: @MainActor () async -> Void
 
   func body(content: Content) -> some View {
     content
       .alert(
         "Primary emotion selected",
-        isPresented: presenter(for: .confirmingPrimary)
+        isPresented: Self.presenter(for: .confirmingPrimary, coordinator: flowCoordinator)
       ) {
         Button("Add Secondary Emotion") { flowCoordinator.promptForSecondary() }
         Button("Add Strategy") { flowCoordinator.promptForStrategy() }
+        // Known race deferred to the Phase 2b coordinator-owned submit: a
+        // swipe-dismiss right after Done lets the presenter binding fire
+        // cancel() alongside the still-running submit Task.
         Button("Done") { Task { await onPrimarySubmit() } }
         Button("Cancel", role: .cancel) { flowCoordinator.cancel() }
       } message: {
@@ -30,12 +33,13 @@ struct FlowConfirmationAlertsModifier: ViewModifier {
       }
       .alert(
         "Secondary emotion selected",
-        isPresented: presenter(for: .confirmingSecondary)
+        isPresented: Self.presenter(for: .confirmingSecondary, coordinator: flowCoordinator)
       ) {
         Button("Add Strategy") { flowCoordinator.promptForStrategy() }
         Button("Done") { Task { await onSecondarySubmit() } }
         Button("Cancel", role: .cancel) { flowCoordinator.cancel() }
       } message: {
+        // A nil secondary is the legitimate "user skipped it" path, not a bug.
         if let secondary = flowCoordinator.selections.secondary {
           Text("You selected \"\(secondary.expression)\". What would you like to do next?")
         } else {
@@ -44,11 +48,12 @@ struct FlowConfirmationAlertsModifier: ViewModifier {
       }
       .alert(
         "Strategy selected",
-        isPresented: presenter(for: .confirmingStrategy)
+        isPresented: Self.presenter(for: .confirmingStrategy, coordinator: flowCoordinator)
       ) {
         Button("Continue to Review") { flowCoordinator.showReview() }
         Button("Cancel", role: .cancel) { flowCoordinator.cancel() }
       } message: {
+        // A nil strategy is the legitimate "user skipped it" path, not a bug.
         if let strategy = flowCoordinator.selections.strategy {
           Text("You selected \"\(strategy.strategy)\". Continue to review?")
         } else {
@@ -64,12 +69,18 @@ struct FlowConfirmationAlertsModifier: ViewModifier {
   /// implicit cancel — without this, `.constant()` would silently ignore
   /// the system dismissal and the alert would immediately re-present
   /// because `currentStep == step` is still true.
-  private func presenter(for step: FlowCoordinator.FlowStep) -> Binding<Bool> {
+  ///
+  /// `static` taking an explicit `coordinator` so the binding's get/set
+  /// contract is unit-testable without rendering the modifier.
+  static func presenter(
+    for step: FlowCoordinator.FlowStep,
+    coordinator: FlowCoordinator
+  ) -> Binding<Bool> {
     Binding(
-      get: { flowCoordinator.currentStep == step },
+      get: { coordinator.currentStep == step },
       set: { isPresented in
-        if !isPresented, flowCoordinator.currentStep == step {
-          flowCoordinator.cancel()
+        if !isPresented, coordinator.currentStep == step {
+          coordinator.cancel()
         }
       }
     )
@@ -81,8 +92,8 @@ extension View {
   /// See `FlowConfirmationAlertsModifier` for the per-alert contract.
   func flowConfirmationAlerts(
     flowCoordinator: FlowCoordinator,
-    onPrimarySubmit: @escaping () async -> Void,
-    onSecondarySubmit: @escaping () async -> Void
+    onPrimarySubmit: @escaping @MainActor () async -> Void,
+    onSecondarySubmit: @escaping @MainActor () async -> Void
   ) -> some View {
     modifier(FlowConfirmationAlertsModifier(
       flowCoordinator: flowCoordinator,

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowConfirmationAlertsModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowConfirmationAlertsModifierTests.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Coverage for `FlowConfirmationAlertsModifier.presenter(for:coordinator:)`
+/// — the per-step binding whose write side maps a system dismissal of a
+/// confirmation alert onto `FlowCoordinator.cancel()` (filed as #327).
+@MainActor
+struct FlowConfirmationAlertsModifierTests {
+  private func makeCoordinator() async -> (FlowCoordinator, CatalogResponseModel) {
+    let catalog = CatalogTestHelper.createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let viewModel = ContentViewModel(
+      catalogRepository: repository,
+      journalRepository: InMemoryJournalRepository(),
+      journalClient: JournalClientMock()
+    )
+    await viewModel.loadCatalog()
+    return (FlowCoordinator(contentViewModel: viewModel), catalog)
+  }
+
+  // MARK: - Getter
+
+  @Test("getter is true only while the coordinator is in the matching step")
+  func getter_matchesStep() async {
+    let (coordinator, catalog) = await makeCoordinator()
+    let binding = FlowConfirmationAlertsModifier.presenter(
+      for: .confirmingPrimary,
+      coordinator: coordinator
+    )
+
+    #expect(binding.wrappedValue == false)
+
+    coordinator.capturePrimary(catalog.layers[1].phases[0].medicinal[0])
+    #expect(binding.wrappedValue == true)
+
+    coordinator.promptForStrategy()
+    #expect(binding.wrappedValue == false)
+  }
+
+  // MARK: - Setter — implicit cancel
+
+  @Test("writing false while in the step cancels the flow")
+  func setterFalse_inStep_cancelsFlow() async {
+    let (coordinator, catalog) = await makeCoordinator()
+    coordinator.capturePrimary(catalog.layers[1].phases[0].medicinal[0])
+    let binding = FlowConfirmationAlertsModifier.presenter(
+      for: .confirmingPrimary,
+      coordinator: coordinator
+    )
+
+    binding.wrappedValue = false
+
+    #expect(coordinator.currentStep == .idle)
+    #expect(coordinator.selections.primary == nil)
+  }
+
+  // MARK: - Setter — step guard
+
+  @Test("writing false for a step the coordinator is not in does not cancel")
+  func setterFalse_otherStep_doesNotCancel() async {
+    let (coordinator, catalog) = await makeCoordinator()
+    let primary = catalog.layers[1].phases[0].medicinal[0]
+    coordinator.capturePrimary(primary)
+    // Binding for a step the coordinator is NOT currently in.
+    let binding = FlowConfirmationAlertsModifier.presenter(
+      for: .confirmingStrategy,
+      coordinator: coordinator
+    )
+
+    binding.wrappedValue = false
+
+    #expect(coordinator.currentStep == .confirmingPrimary)
+    #expect(coordinator.selections.primary == primary)
+  }
+}


### PR DESCRIPTION
## Summary
Addresses the four deferred review items from #326. Items 1, 2, and 4 are done; **item 3's premise is incorrect** and is intentionally not implemented (details below).

- **Item 1 — tests.** `presenter(for:)` is extracted into a testable `static func presenter(for:coordinator:)` (same pattern as `MainContentDialogsModifier.flowReviewPresenter`). New `FlowConfirmationAlertsModifierTests` covers the getter↔step match and the set-path cancel guard (cancel only fires while the coordinator is still in the target step).
- **Item 2 — `@MainActor` closures.** `onPrimarySubmit` / `onSecondarySubmit` and the `flowConfirmationAlerts` View-extension parameters are now `@MainActor`, so a caller can't route them off-actor.
- **Item 4 — concurrent cancel()/submit race.** Intentionally deferred to the Phase 2b coordinator-owned submit, with an inline code note at the primary `Done` button as the issue requested.

## Item 3 — not implemented (premise is wrong)
The issue calls the `else` branches in the `.confirmingSecondary` / `.confirmingStrategy` alert messages "invariant violations" and suggests `assertionFailure`. They are **not** invariant violations: `FlowCoordinator.captureSecondary(_:)` and `captureStrategy(_:)` both accept `nil` — that is the supported "user skipped this optional selection" path, which legitimately lands on `.confirmingSecondary` / `.confirmingStrategy` with no selection set. Adding `assertionFailure` there would crash a normal user flow. Instead I added one-line comments documenting that the `nil` fallback is the skip path, so a future reader doesn't repeat the misdiagnosis.

## What's not unit-testable
The "button → coordinator method" and "submit button → closure" bullets under item 1 require tapping SwiftUI alert buttons, which isn't possible without ViewInspector/snapshot infrastructure the repo doesn't have (see the same note on `WLNavigationBarModifierTests`). The substantive logic — the `presenter` binding — is fully covered; the button actions are one-liners over already-tested `FlowCoordinator` methods.

## Test plan
- [x] `run-tests-individually.sh FlowConfirmationAlertsModifierTests` — 1/1 passed
- [x] Full suite (`run-tests-individually.sh`) — all suites pass, no regressions
- [x] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)