### PR TITLE
test(navigation): expand PhaseNavigator edge-case coverage (#296)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/PhaseNavigator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/PhaseNavigator.swift
@@ -7,6 +7,10 @@ import Foundation
 /// extra page on either end so the user can move from the first phase
 /// to the last (and vice‑versa) without interruption. These helpers
 /// manage the bookkeeping for that behaviour.
+///
+/// - Precondition: `phaseCount >= 1`. The modulo math in
+///   `normalizedIndex(_:phaseCount:)` traps on `% 0`; callers (today
+///   `NavigationViewModel`) are responsible for the empty-order guard.
 enum PhaseNavigator {
   /// Returns a selection value confined to the valid range of pages.
   ///

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PhaseNavigatorTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PhaseNavigatorTests.swift
@@ -28,17 +28,20 @@ struct PhaseNavigatorTests {
 
   @Test("a single-phase order wraps both sentinels back to the only page")
   func adjustedSelection_phaseCount1_collapsesToSinglePage() {
+    // Real-page pass-through at phaseCount: 1 is covered by the contract
+    // pinned in adjustedSelection_realPages_passThrough; this test focuses
+    // strictly on the sentinel wrap.
     #expect(PhaseNavigator.adjustedSelection(0, phaseCount: 1) == 1)
     #expect(PhaseNavigator.adjustedSelection(2, phaseCount: 1) == 1)
-    #expect(PhaseNavigator.adjustedSelection(1, phaseCount: 1) == 1)
   }
 
   // MARK: - normalizedIndex: sentinel and real-page mapping
 
   @Test("real pages 1...phaseCount map to indices 0...phaseCount - 1")
   func normalizedIndex_realPages_mapZeroBased() {
-    #expect(PhaseNavigator.normalizedIndex(1, phaseCount: 6) == 0)
-    #expect(PhaseNavigator.normalizedIndex(6, phaseCount: 6) == 5)
+    for page in 1 ... 6 {
+      #expect(PhaseNavigator.normalizedIndex(page, phaseCount: 6) == page - 1)
+    }
   }
 
   @Test("leading sentinel (0) normalizes directly to the last index")

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PhaseNavigatorTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PhaseNavigatorTests.swift
@@ -1,21 +1,64 @@
 import Testing
 @testable import WavelengthWatch_Watch_App
 
+/// Coverage for the circular-navigation utilities `PhaseNavigator`
+/// exposes. The sentinel pages at `0` and `phaseCount + 1` are the
+/// trickiest part; tests below pin each boundary plus the degenerate
+/// `phaseCount` values that the caller (`NavigationViewModel`) guards
+/// against but the utility itself must also tolerate.
 struct PhaseNavigatorTests {
-  @Test func wrapsFromFirstToLast() {
-    let adjusted = PhaseNavigator.adjustedSelection(0, phaseCount: 6)
-    #expect(adjusted == 6)
+  // MARK: - adjustedSelection: sentinel wrapping
+
+  @Test("leading sentinel (0) wraps to the last real page")
+  func adjustedSelection_leadingSentinel_wrapsToLast() {
+    #expect(PhaseNavigator.adjustedSelection(0, phaseCount: 6) == 6)
   }
 
-  @Test func wrapsFromLastToFirst() {
-    let adjusted = PhaseNavigator.adjustedSelection(7, phaseCount: 6)
-    #expect(adjusted == 1)
+  @Test("trailing sentinel (phaseCount + 1) wraps to the first real page")
+  func adjustedSelection_trailingSentinel_wrapsToFirst() {
+    #expect(PhaseNavigator.adjustedSelection(7, phaseCount: 6) == 1)
   }
 
-  @Test func normalizesSelection() {
-    let index = PhaseNavigator.normalizedIndex(1, phaseCount: 6)
-    #expect(index == 0)
-    let last = PhaseNavigator.normalizedIndex(6, phaseCount: 6)
-    #expect(last == 5)
+  @Test("a real-page selection passes through unchanged")
+  func adjustedSelection_realPages_passThrough() {
+    for page in 1 ... 6 {
+      #expect(PhaseNavigator.adjustedSelection(page, phaseCount: 6) == page)
+    }
+  }
+
+  @Test("a single-phase order wraps both sentinels back to the only page")
+  func adjustedSelection_phaseCount1_collapsesToSinglePage() {
+    #expect(PhaseNavigator.adjustedSelection(0, phaseCount: 1) == 1)
+    #expect(PhaseNavigator.adjustedSelection(2, phaseCount: 1) == 1)
+    #expect(PhaseNavigator.adjustedSelection(1, phaseCount: 1) == 1)
+  }
+
+  // MARK: - normalizedIndex: sentinel and real-page mapping
+
+  @Test("real pages 1...phaseCount map to indices 0...phaseCount - 1")
+  func normalizedIndex_realPages_mapZeroBased() {
+    #expect(PhaseNavigator.normalizedIndex(1, phaseCount: 6) == 0)
+    #expect(PhaseNavigator.normalizedIndex(6, phaseCount: 6) == 5)
+  }
+
+  @Test("leading sentinel (0) normalizes directly to the last index")
+  func normalizedIndex_leadingSentinel_mapsToLastIndex() {
+    // Equivalent to `normalizedIndex(adjustedSelection(0, 6), 6)` — the
+    // modulo math wraps in a single step, so adjustedSelection is not a
+    // prerequisite for normalizedIndex to handle a sentinel.
+    #expect(PhaseNavigator.normalizedIndex(0, phaseCount: 6) == 5)
+  }
+
+  @Test("trailing sentinel (phaseCount + 1) normalizes directly to the first index")
+  func normalizedIndex_trailingSentinel_mapsToFirstIndex() {
+    #expect(PhaseNavigator.normalizedIndex(7, phaseCount: 6) == 0)
+  }
+
+  @Test("a single-phase order normalizes every real page to index 0")
+  func normalizedIndex_phaseCount1_alwaysReturnsZero() {
+    #expect(PhaseNavigator.normalizedIndex(1, phaseCount: 1) == 0)
+    // And the sentinels too — both wrap to the only index.
+    #expect(PhaseNavigator.normalizedIndex(0, phaseCount: 1) == 0)
+    #expect(PhaseNavigator.normalizedIndex(2, phaseCount: 1) == 0)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PhaseNavigatorTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PhaseNavigatorTests.swift
@@ -26,12 +26,12 @@ struct PhaseNavigatorTests {
     }
   }
 
-  @Test("a single-phase order wraps both sentinels back to the only page")
+  @Test("a single-phase order maps both sentinels and the only page to 1")
   func adjustedSelection_phaseCount1_collapsesToSinglePage() {
-    // Real-page pass-through at phaseCount: 1 is covered by the contract
-    // pinned in adjustedSelection_realPages_passThrough; this test focuses
-    // strictly on the sentinel wrap.
+    // The pass-through test only iterates phaseCount: 6, so the real-page
+    // case at phaseCount: 1 lives here alongside the sentinel wrap.
     #expect(PhaseNavigator.adjustedSelection(0, phaseCount: 1) == 1)
+    #expect(PhaseNavigator.adjustedSelection(1, phaseCount: 1) == 1)
     #expect(PhaseNavigator.adjustedSelection(2, phaseCount: 1) == 1)
   }
 
@@ -46,9 +46,7 @@ struct PhaseNavigatorTests {
 
   @Test("leading sentinel (0) normalizes directly to the last index")
   func normalizedIndex_leadingSentinel_mapsToLastIndex() {
-    // Equivalent to `normalizedIndex(adjustedSelection(0, 6), 6)` — the
-    // modulo math wraps in a single step, so adjustedSelection is not a
-    // prerequisite for normalizedIndex to handle a sentinel.
+    // Modulo wraps in one step — adjustedSelection is not required first.
     #expect(PhaseNavigator.normalizedIndex(0, phaseCount: 6) == 5)
   }
 
@@ -57,10 +55,13 @@ struct PhaseNavigatorTests {
     #expect(PhaseNavigator.normalizedIndex(7, phaseCount: 6) == 0)
   }
 
-  @Test("a single-phase order normalizes every real page to index 0")
-  func normalizedIndex_phaseCount1_alwaysReturnsZero() {
+  @Test("a single-phase order normalizes the only real page to index 0")
+  func normalizedIndex_phaseCount1_realPage_returnsZero() {
     #expect(PhaseNavigator.normalizedIndex(1, phaseCount: 1) == 0)
-    // And the sentinels too — both wrap to the only index.
+  }
+
+  @Test("a single-phase order normalizes both sentinels to index 0")
+  func normalizedIndex_phaseCount1_sentinels_returnZero() {
     #expect(PhaseNavigator.normalizedIndex(0, phaseCount: 1) == 0)
     #expect(PhaseNavigator.normalizedIndex(2, phaseCount: 1) == 0)
   }


### PR DESCRIPTION
## Summary
- Phase 2b acceptance bullet "Unit tests cover circular navigation edge cases" was only met by three happy-path tests. This expands `PhaseNavigatorTests` to pin each boundary the utility actually handles, with no implementation change.
- Adds coverage for `adjustedSelection`: real-page pass-through across the full `1...phaseCount` range, and the single-phase collapse where every input maps back to page 1.
- Adds coverage for `normalizedIndex`: both sentinels mapping directly to the wrapped index in one step (documenting that the modulo math wraps without `adjustedSelection` as a prerequisite), and the single-phase case where every input collapses to index 0.

Tests-only change; no production code touched.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh PhaseNavigatorTests` — 1/1 suite passes
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

Closes a portion of #296 (Phase 2b — Refactor PhaseNavigator and layer filtering system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)