### PR TITLE
refactor(curriculum): adopt WLColorTokens.pageBackground() (#297)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumDetailView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumDetailView.swift
@@ -159,13 +159,7 @@ struct CurriculumDetailView: View {
       }
       .padding(.vertical, 16)
     }
-    .background(
-      LinearGradient(
-        gradient: Gradient(colors: [Color.black, Color.black.opacity(0.8)]),
-        startPoint: .top,
-        endPoint: .bottom
-      )
-    )
+    .background(WLColorTokens.pageBackground())
     .onAppear {
       isShowingDetailView.wrappedValue = true
       // Cache aggregated emotions once for Clear Light (avoids re-computation on every render)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
@@ -84,13 +84,7 @@ struct StrategyListView: View {
       }
       .padding(.vertical, 16)
     }
-    .background(
-      LinearGradient(
-        gradient: Gradient(colors: [Color.black, Color.black.opacity(0.8)]),
-        startPoint: .top,
-        endPoint: .bottom
-      )
-    )
+    .background(WLColorTokens.pageBackground())
     .alert("Log Strategy", isPresented: $showingJournalConfirmation) {
       Button("Yes") {
         handleLogAction()


### PR DESCRIPTION
## Summary
- `CurriculumDetailView` and `StrategyListView` each inlined the identical six-line `LinearGradient(colors: [Color.black, Color.black.opacity(0.8)], startPoint: .top, endPoint: .bottom)` for their page background, duplicating `WLColorTokens.pageBackground()` from the design system.
- Replaces both inline gradients with the token call. Identical visual output, single source of truth for future tweaks.
- First Phase 3a (#297) adoption of the WL design system in content views.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)