### PR TITLE
refactor(journal): adopt WLColorTokens.cardFill/elevatedCardFill (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -135,7 +135,7 @@ struct FlowReviewSheet: View {
     .padding(12)
     .background(
       RoundedRectangle(cornerRadius: 8)
-        .fill(Color.secondary.opacity(0.15))
+        .fill(WLColorTokens.cardFill)
     )
   }
 
@@ -160,7 +160,7 @@ struct FlowReviewSheet: View {
     }
     .padding(.vertical, 12)
     .padding(.horizontal, 16)
-    .background(Color.secondary.opacity(0.1))
+    .background(WLColorTokens.elevatedCardFill)
     .cornerRadius(10)
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
@@ -62,7 +62,7 @@ struct JournalReviewView: View {
         .padding(.vertical, 8)
         .padding(.horizontal, 12)
         .frame(maxWidth: .infinity)
-        .background(Color.secondary.opacity(0.1))
+        .background(WLColorTokens.elevatedCardFill)
         .cornerRadius(8)
 
         Divider()
@@ -186,7 +186,7 @@ struct JournalReviewView: View {
     }
     .padding(.vertical, 12)
     .padding(.horizontal, 16)
-    .background(Color.secondary.opacity(0.1))
+    .background(WLColorTokens.elevatedCardFill)
     .cornerRadius(10)
   }
 
@@ -212,7 +212,7 @@ struct JournalReviewView: View {
     }
     .padding(.vertical, 12)
     .padding(.horizontal, 16)
-    .background(Color.secondary.opacity(0.1))
+    .background(WLColorTokens.elevatedCardFill)
     .cornerRadius(10)
   }
 


### PR DESCRIPTION
## Summary
- `JournalReviewView` (3 sites) and `FlowReviewSheet` (2 sites) inlined the literal expressions `Color.secondary.opacity(0.15)` and `Color.secondary.opacity(0.1)` — the exact definitions of `WLColorTokens.cardFill` and `WLColorTokens.elevatedCardFill` respectively.
- Replaces each call site with the named token. Zero visual change.
- Centralizes the card-fill / elevated-card-fill intent so future tweaks happen at `WLColorTokens`, not across five callers.

This is a sibling to PR #351 (which adopted `WLColorTokens.pageBackground()` in `CurriculumDetailView` and `StrategyListView`) — same pattern, different surface area.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

Closes a portion of #299 (Phase 4 — Rebuild journal flow views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)