### PR TITLE
refactor(curriculum): adopt secondaryText / tertiaryText tokens (#297)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -25,7 +25,7 @@ struct ClearLightEmotionCard: View {
 
           Text(emotion.layerTitle)
             .font(.caption2)
-            .foregroundColor(.white.opacity(0.5))
+            .foregroundColor(WLColorTokens.tertiaryText)
         }
 
         Spacer()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
@@ -16,7 +16,7 @@ struct CurriculumCard: View {
         Text(title)
           .font(.caption)
           .fontWeight(.medium)
-          .foregroundColor(.white.opacity(0.7))
+          .foregroundColor(WLColorTokens.secondaryText)
           .tracking(1.5)
 
         Text(expression)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumDetailView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumDetailView.swift
@@ -78,7 +78,7 @@ struct CurriculumDetailView: View {
             VStack(alignment: .leading, spacing: 12) {
               Text("MEDICINAL")
                 .font(.caption)
-                .foregroundColor(.white.opacity(0.7))
+                .foregroundColor(WLColorTokens.secondaryText)
                 .tracking(1.5)
                 .padding(.horizontal, 16)
 
@@ -96,7 +96,7 @@ struct CurriculumDetailView: View {
             VStack(alignment: .leading, spacing: 12) {
               Text("TOXIC")
                 .font(.caption)
-                .foregroundColor(.white.opacity(0.7))
+                .foregroundColor(WLColorTokens.secondaryText)
                 .tracking(1.5)
                 .padding(.horizontal, 16)
 
@@ -143,7 +143,7 @@ struct CurriculumDetailView: View {
             VStack(alignment: .leading, spacing: 12) {
               Text("STRATEGIES")
                 .font(.caption)
-                .foregroundColor(.white.opacity(0.7))
+                .foregroundColor(WLColorTokens.secondaryText)
                 .tracking(1.5)
               ForEach(phase.strategies) { strategy in
                 StrategyCard(


### PR DESCRIPTION
## Summary
- Five sites across three Curriculum views inlined `.white.opacity(0.7)` or `.white.opacity(0.5)` for caption-style text foregrounds — the exact definitions of `WLColorTokens.secondaryText` and `WLColorTokens.tertiaryText`.
- Each call site is replaced with the named token. Zero visual change.

Sites:
- `CurriculumDetailView.swift`: 3 caption foregrounds (0.7 → secondaryText)
- `CurriculumCard.swift`: 1 title foreground (0.7 → secondaryText)
- `ClearLightEmotionCard.swift`: 1 layer-title caption (0.5 → tertiaryText)

Continues the Phase 3a adoption pattern landed in #351 (page background) and #352 (card fill / elevated card fill).

One unrelated `.white.opacity(0.6)` at `CurriculumDetailView.swift:72` is intentionally left untouched — no existing token for that opacity, and adding one is out of scope for a pure adoption PR.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

Closes a portion of #297 (Phase 3a — Rebuild curriculum and strategy detail views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)