### PR TITLE
refactor(nav,settings): adopt secondaryText / tertiaryText tokens

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainNavigationToolbar.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainNavigationToolbar.swift
@@ -17,14 +17,14 @@ struct MainNavigationToolbar: ToolbarContent {
           Button(action: onBack) {
             Image(systemName: "chevron.left")
               .font(.system(size: UIConstants.menuButtonSize))
-              .foregroundColor(.white.opacity(0.7))
+              .foregroundColor(WLColorTokens.secondaryText)
           }
           .buttonStyle(.plain)
         } else {
           Button(action: onMenu) {
             Image(systemName: "ellipsis.circle")
               .font(.system(size: UIConstants.menuButtonSize))
-              .foregroundColor(.white.opacity(0.7))
+              .foregroundColor(WLColorTokens.secondaryText)
           }
           .buttonStyle(.plain)
         }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -61,7 +61,7 @@ struct PhaseCrystalCard: View {
       Text(layer.title)
         .font(.caption)
         .fontWeight(.medium)
-        .foregroundColor(.white.opacity(0.7))
+        .foregroundColor(WLColorTokens.secondaryText)
         .tracking(1.5)
         .textCase(.uppercase)
         .lineLimit(1)
@@ -69,7 +69,7 @@ struct PhaseCrystalCard: View {
 
       Text(layer.subtitle)
         .font(.caption2)
-        .foregroundColor(.white.opacity(0.5))
+        .foregroundColor(WLColorTokens.tertiaryText)
         .lineLimit(1)
         .minimumScaleFactor(0.8)
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/ScheduleSettingsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/ScheduleSettingsView.swift
@@ -40,7 +40,7 @@ struct ScheduleSettingsView: View {
       } header: {
         Text("Journal Prompts")
           .font(.caption)
-          .foregroundColor(.white.opacity(0.7))
+          .foregroundColor(WLColorTokens.secondaryText)
       }
 
       Button {


### PR DESCRIPTION
## Summary
- Sweeps the remaining five `.white.opacity(0.7|0.5)` sites in non-Analytics views to `WLColorTokens.secondaryText` / `WLColorTokens.tertiaryText` — the exact opacity definitions of those tokens.
- Zero visual change. Completes the cross-cutting adoption started in #353 for Curriculum views.

Sites:
- `MainNavigationToolbar.swift`: 2 toolbar icon foregrounds (0.7 → secondaryText)
- `PhaseCrystalCard.swift`: layer title (0.7 → secondaryText), subtitle (0.5 → tertiaryText)
- `ScheduleSettingsView.swift`: section header caption (0.7 → secondaryText)

After this lands, no non-Analytics view inlines `Color.white.opacity(0.7)` / `(0.5)` for text foregrounds. Analytics views are excluded per the epic scope.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

Closes a portion of #295 (Phase 2a — Liquid Glass chrome) and #300 (Phase 5 — settings/schedule views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)