### PR TITLE
refactor(curriculum): adopt WLColorTokens.cardGradient (#297)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
@@ -30,13 +30,7 @@ struct CurriculumCard: View {
       .padding(.vertical, 12)
       .background(
         RoundedRectangle(cornerRadius: 12)
-          .fill(
-            LinearGradient(
-              gradient: Gradient(colors: [accent.opacity(0.3), accent.opacity(0.1)]),
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
+          .fill(WLColorTokens.cardGradient(accent))
           .overlay(
             RoundedRectangle(cornerRadius: 12)
               .stroke(accent.opacity(0.5), lineWidth: 0.5)


### PR DESCRIPTION
## Summary
- `CurriculumCard` inlined a six-line `LinearGradient(accent.opacity(0.3) → accent.opacity(0.1), .topLeading → .bottomTrailing)` for its tinted background — the exact definition of `WLColorTokens.cardGradient(_:)`.
- Replaces the inline construction with the token call. The 0.5-alpha stroke overlay is preserved as-is (no equivalent token yet, out of scope to add one).

Zero visual change. -7/+1 line diff.

Verified `WLColorTokens.cardGradient(_:)` definition matches the inlined gradient exactly:

```swift
static func cardGradient(_ color: Color) -> LinearGradient {
  LinearGradient(
    gradient: Gradient(colors: [
      color.opacity(surfaceOpacityMedium), // 0.3
      color.opacity(surfaceOpacityLow),    // 0.1
    ]),
    startPoint: .topLeading,
    endPoint: .bottomTrailing
  )
}
```

(`LayerSideIndicator` has a similar `[opacity(0.3), opacity(0.1)]` gradient but uses `.top → .bottom` direction, so it's intentionally not in scope.)

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

Closes a portion of #297 (Phase 3a — curriculum/strategy detail views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)