### PR TITLE
refactor(curriculum,nav): adopt WLTypographyTokens.sectionHeader

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
@@ -14,10 +14,10 @@ struct CurriculumCard: View {
     ZStack(alignment: .topTrailing) {
       VStack(alignment: .leading, spacing: 8) {
         Text(title)
-          .font(.caption)
-          .fontWeight(.medium)
+          .font(WLTypographyTokens.sectionHeader)
+          .fontWeight(WLTypographyTokens.sectionHeaderWeight)
           .foregroundColor(WLColorTokens.secondaryText)
-          .tracking(1.5)
+          .tracking(WLTypographyTokens.sectionHeaderTracking)
 
         Text(expression)
           .font(.body)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -59,10 +59,10 @@ struct PhaseCrystalCard: View {
   private var layerContext: some View {
     VStack(spacing: 4 * scale) {
       Text(layer.title)
-        .font(.caption)
-        .fontWeight(.medium)
+        .font(WLTypographyTokens.sectionHeader)
+        .fontWeight(WLTypographyTokens.sectionHeaderWeight)
         .foregroundColor(WLColorTokens.secondaryText)
-        .tracking(1.5)
+        .tracking(WLTypographyTokens.sectionHeaderTracking)
         .textCase(.uppercase)
         .lineLimit(1)
         .minimumScaleFactor(0.8)


### PR DESCRIPTION
## Summary
- `CurriculumCard.title` and `PhaseCrystalCard.layer.title` both used the literal section-header triplet `.font(.caption) + .fontWeight(.medium) + .tracking(1.5)` — the exact components of `WLTypographyTokens.sectionHeader` / `sectionHeaderWeight` / `sectionHeaderTracking`.
- Replaces each call site with the named tokens. Zero visual change.

Verified token definitions match:

```swift
static let sectionHeader: Font = .caption
static let sectionHeaderWeight: Font.Weight = .medium
static let sectionHeaderTracking: CGFloat = 1.5
```

`CurriculumDetailView` has three similar `.font(.caption) + .tracking(1.5)` section labels (MEDICINAL / TOXIC / etc.) but lacks the `.medium` weight. Adopting the token there would shift the weight from `.regular` to `.medium` — a visual change, so those are intentionally out of scope for this adoption sweep.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)