### PR TITLE
refactor: adopt WLSpacingTokens cardCornerRadius/cardCornerRadiusSmall

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -33,7 +33,7 @@ struct ClearLightEmotionCard: View {
       .padding(.horizontal, 16)
       .padding(.vertical, 10)
       .background(
-        RoundedRectangle(cornerRadius: 12)
+        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
           .fill(
             LinearGradient(
               gradient: Gradient(colors: [
@@ -45,7 +45,7 @@ struct ClearLightEmotionCard: View {
             )
           )
           .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
               .stroke(emotion.sourceColor.opacity(0.3), lineWidth: 0.5)
           )
       )

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
@@ -29,10 +29,10 @@ struct CurriculumCard: View {
       .padding(.horizontal, 16)
       .padding(.vertical, 12)
       .background(
-        RoundedRectangle(cornerRadius: 12)
+        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
           .fill(WLColorTokens.cardGradient(accent))
           .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
               .stroke(accent.opacity(0.5), lineWidth: 0.5)
           )
       )

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
@@ -27,7 +27,7 @@ struct StrategyCard: View {
       }
       .padding(8)
       .background(
-        RoundedRectangle(cornerRadius: 8)
+        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
           .fill(color.opacity(0.08))
       )
       .onTapGesture {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
@@ -58,7 +58,7 @@ struct StrategyListView: View {
               .padding(.horizontal, 16)
               .padding(.vertical, 10)
               .background(
-                RoundedRectangle(cornerRadius: 8)
+                RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
                   .fill(color.opacity(0.1))
               )
               .onTapGesture {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -134,7 +134,7 @@ struct FlowReviewSheet: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(12)
     .background(
-      RoundedRectangle(cornerRadius: 8)
+      RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
         .fill(WLColorTokens.cardFill)
     )
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
@@ -43,7 +43,7 @@ struct JournalReviewView: View {
           .padding(.vertical, 12)
           .frame(maxWidth: .infinity)
           .background(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
               .fill(Color.purple.opacity(0.1))
           )
         }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/OnboardingView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/OnboardingView.swift
@@ -137,10 +137,10 @@ struct OnboardingView: View {
       }
       .padding(12)
       .background(
-        RoundedRectangle(cornerRadius: 12)
+        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
           .fill(selectedMode == mode ? Color.accentColor.opacity(0.15) : Color.clear)
           .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
               .stroke(selectedMode == mode ? Color.accentColor : Color.secondary.opacity(0.3), lineWidth: 1)
           )
       )


### PR DESCRIPTION
## Summary
- Ten sites across seven non-Analytics view files inlined `RoundedRectangle(cornerRadius: 12)` or `(cornerRadius: 8)` — the exact definitions of `WLSpacingTokens.cardCornerRadius` (12) and `cardCornerRadiusSmall` (8).
- Each call site is replaced with the named token.
- Particularly helpful where a fill and an overlay-stroke share the same radius (`CurriculumCard`, `OnboardingView`, `ClearLightEmotionCard`): both sides now reference the same token, so a future tweak can't desynchronize them.

Sites adopted:
- `cardCornerRadius (12)` — `JournalReviewView`, `OnboardingView` (×2), `ClearLightEmotionCard` (×2), `CurriculumCard` (×2)
- `cardCornerRadiusSmall (8)` — `FlowReviewSheet`, `StrategyCard`, `StrategyListView`

Analytics views (`StreakDisplayView`, `AnalyticsViewSections`, `StrategyUsageView`) keep their literals — Analytics is excluded from the Liquid Glass rebuild per the epic scope (#292).

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)