### PR TITLE
refactor(curriculum): adopt WLColorTokens.cardFill(tinted:) in StrategyCard

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
@@ -28,7 +28,7 @@ struct StrategyCard: View {
       .padding(8)
       .background(
         RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
-          .fill(color.opacity(0.08))
+          .fill(WLColorTokens.cardFill(tinted: color))
       )
       .onTapGesture {
         if primaryID != nil || flowCoordinator.currentStep == .selectingStrategy {


### PR DESCRIPTION
## Summary
- `StrategyCard`'s background filled with `color.opacity(0.08)` — the exact definition of `WLColorTokens.cardFill(tinted:)` (which composes `color × surfaceOpacitySubtle`, where `surfaceOpacitySubtle == 0.08`).
- Replaces the inline literal with the named factory call.

Single call site across all non-Analytics views; no broader sweep available. Zero visual change.

```swift
static func cardFill(tinted color: Color) -> Color {
    color.opacity(surfaceOpacitySubtle)
}
static let surfaceOpacitySubtle: Double = 0.08
```

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)