### PR TITLE
refactor(content): extract MainContentStates from ContentView (#293)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -87,37 +87,10 @@ struct ContentView: View {
   // through intermediate `some View` properties — each return type erases
   // the upstream complexity, letting the checker rest.
 
-  /// Inner content — the ZStack only, no modifiers.
-  private var contentZStack: some View {
-    ZStack {
-      if viewModel.layers.isEmpty {
-        if viewModel.isLoading {
-          ProgressView("Loading curriculum…")
-            .foregroundStyle(.white)
-        } else if let error = viewModel.loadErrorMessage {
-          VStack(spacing: 12) {
-            Text(error)
-              .multilineTextAlignment(.center)
-            Button("Retry") {
-              Task { await viewModel.retry() }
-            }
-          }
-          .padding()
-        } else {
-          ProgressView("Loading curriculum…")
-        }
-      } else if viewModel.phaseOrder.isEmpty {
-        Text("No phase information available.")
-      } else {
-        layeredContent
-      }
-    }
-  }
-
   /// Adds lifecycle hooks. Navigation-state reconciliation now lives in
   /// `navigationViewModel`, which observes `viewModel` directly.
   private var contentWithEvents: some View {
-    contentZStack
+    MainContentStates(viewModel: viewModel, navigationViewModel: navigationViewModel)
       .ignoresSafeArea(edges: .bottom)
       .task { await viewModel.loadCatalog() }
       .task {
@@ -164,14 +137,6 @@ struct ContentView: View {
       isInFlow: flowCoordinator.currentStep != .idle,
       onBack: { flowCoordinator.cancel() },
       onMenu: { showingMenu = true }
-    )
-  }
-
-  private var layeredContent: some View {
-    LayerScrollView(
-      viewModel: viewModel,
-      layerSelection: $navigationViewModel.layerSelection,
-      phaseSelection: $navigationViewModel.phaseSelection
     )
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentStates.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentStates.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// State machine for the main shell's body: catalog loading, load
+/// error with retry, empty phase order, or the live layered content.
+///
+/// Lifts the ~30 lines of `if-else` branching out of `ContentView` so
+/// `ContentView` can stay focused on lifecycle, dialogs, and toolbar
+/// wiring. Owns no state of its own; reads `viewModel` for the branch
+/// selector and forwards `navigationViewModel`'s selection bindings into
+/// `LayerScrollView`.
+struct MainContentStates: View {
+  @ObservedObject var viewModel: ContentViewModel
+  @ObservedObject var navigationViewModel: NavigationViewModel
+
+  var body: some View {
+    ZStack {
+      if viewModel.layers.isEmpty {
+        emptyLayersBranch
+      } else if viewModel.phaseOrder.isEmpty {
+        Text("No phase information available.")
+      } else {
+        LayerScrollView(
+          viewModel: viewModel,
+          layerSelection: $navigationViewModel.layerSelection,
+          phaseSelection: $navigationViewModel.phaseSelection
+        )
+      }
+    }
+  }
+
+  /// Loading / load-error / fallback branch — only reached while the
+  /// catalog hasn't populated `viewModel.layers`.
+  @ViewBuilder
+  private var emptyLayersBranch: some View {
+    if viewModel.isLoading {
+      ProgressView("Loading curriculum…")
+        .foregroundStyle(.white)
+    } else if let error = viewModel.loadErrorMessage {
+      VStack(spacing: 12) {
+        Text(error)
+          .multilineTextAlignment(.center)
+        Button("Retry") {
+          Task { await viewModel.retry() }
+        }
+      }
+      .padding()
+    } else {
+      ProgressView("Loading curriculum…")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ContentView's `contentZStack` + `layeredContent` computed properties (~40 lines together) encoded the catalog-loading / load-error-with-retry / empty-phase-order / live-layered-content state machine.
- Extract them into a dedicated `MainContentStates` view so ContentView stays focused on lifecycle, dialogs, and toolbar wiring.

Stats:
- `ContentView.swift`: 181 → 146 lines (-35).
- New `Views/Navigation/MainContentStates.swift` (51 lines) takes `viewModel` + `navigationViewModel` and renders the four branches.
- Zero behavioral change; identical view hierarchy, identical bindings.

## First step toward Phase 1a's <50-line target
Phase 1a (#293) targets ContentView at ≤50 lines (currently 146 after this PR; was 181 before). This is the first focused extraction. Subsequent PRs would lift `contentWithEvents` (lifecycle/onChange), `contentWithDialogs` (alerts/sheets/dialog modifiers), `toolbarContent`, and the init/factory glue out of ContentView. Each extraction stands alone behaviorally, so they can land independently.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)