### PR TITLE
refactor(content): extract FlowSubmissionPresenter from ContentView (#293)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -37,25 +37,8 @@ struct ContentView: View {
     _navigationViewModel = StateObject(wrappedValue: dependencies.navigationViewModel)
   }
 
-  /// Submits the current FlowCoordinator entry and renders the appropriate
-  /// feedback. Centralised so the two confirmation alerts (primary and
-  /// secondary) share identical queued/failure handling — the only thing
-  /// that varies is the failure copy.
-  @MainActor
-  private func submitFlowEntry(failurePrefix: String) async {
-    do {
-      try await flowCoordinator.submit()
-      flowCoordinator.reset()
-    } catch JournalError.queuedForRetry {
-      viewModel.journalFeedback = .init(
-        kind: .queued("Saved offline. Will sync automatically.")
-      )
-      flowCoordinator.reset()
-    } catch {
-      viewModel.journalFeedback = .init(
-        kind: .failure("\(failurePrefix): \(error.localizedDescription)")
-      )
-    }
+  private var flowSubmissionPresenter: FlowSubmissionPresenter {
+    FlowSubmissionPresenter(flowCoordinator: flowCoordinator, viewModel: viewModel)
   }
 
   var body: some View {
@@ -112,8 +95,8 @@ struct ContentView: View {
       }
       .flowConfirmationAlerts(
         flowCoordinator: flowCoordinator,
-        onPrimarySubmit: { await submitFlowEntry(failurePrefix: "Failed to log emotion") },
-        onSecondarySubmit: { await submitFlowEntry(failurePrefix: "Failed to log emotions") }
+        onPrimarySubmit: { await flowSubmissionPresenter.submit(failurePrefix: "Failed to log emotion") },
+        onSecondarySubmit: { await flowSubmissionPresenter.submit(failurePrefix: "Failed to log emotions") }
       )
       .mainContentDialogs(
         viewModel: viewModel,

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowSubmissionPresenter.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowSubmissionPresenter.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Bridges `FlowCoordinator.submit()` to `ContentViewModel.journalFeedback`.
+///
+/// The two flow-confirmation alerts (primary, secondary) share identical
+/// queued / failure handling — only the failure-prefix copy varies.
+/// Centralising the logic here keeps `ContentView` focused on view
+/// composition and preserves `FlowCoordinator`'s "pure state management,
+/// no UI" boundary; this presenter is the explicit seam where flow
+/// submission becomes user-visible feedback.
+@MainActor
+struct FlowSubmissionPresenter {
+  let flowCoordinator: FlowCoordinator
+  let viewModel: ContentViewModel
+
+  /// Submits the current flow entry and renders the appropriate feedback.
+  /// - Parameter failurePrefix: Copy shown before the underlying error
+  ///   description on unrecoverable failure (e.g. `"Failed to log emotion"`
+  ///   for primary, `"Failed to log emotions"` for secondary).
+  func submit(failurePrefix: String) async {
+    do {
+      try await flowCoordinator.submit()
+      flowCoordinator.reset()
+    } catch JournalError.queuedForRetry {
+      viewModel.journalFeedback = .init(
+        kind: .queued("Saved offline. Will sync automatically.")
+      )
+      flowCoordinator.reset()
+    } catch {
+      viewModel.journalFeedback = .init(
+        kind: .failure("\(failurePrefix): \(error.localizedDescription)")
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ContentView's `submitFlowEntry` function (20 lines) was glue code bridging `FlowCoordinator.submit()` result handling to `ContentViewModel.journalFeedback` for the two confirmation alerts.
- Lift it into a dedicated `@MainActor struct FlowSubmissionPresenter` so:
  - ContentView drops the function and its surrounding boilerplate (146 → 129 lines).
  - `FlowCoordinator`'s documented "pure state management, no UI" boundary (FlowCoordinator.swift:11-13) stays intact — the feedback-mutation seam is now an explicit, named type rather than buried in the view.
  - Future flow surfaces can construct the same presenter rather than re-implement the queued / failure copy.

## Behavioral equivalence
Identical to the prior code:
- Same `flowCoordinator.submit()` call.
- Same `reset()` timing (after success and after queued).
- Same queued-for-retry copy (`"Saved offline. Will sync automatically."`).
- Same failure-prefix formatting (`"\(failurePrefix): \(error.localizedDescription)"`).

## Path toward Phase 1a's <50-line target
Continues the chip-away started in #359 (`MainContentStates` extraction):

| Step | ContentView lines | Reduction |
|------|-------------------|-----------|
| Pre-rebuild monolith | 85 KB / ~3,000+ lines | — |
| Before #359 | 181 | — |
| After #359 (MainContentStates) | 146 | −35 |
| After this PR (FlowSubmissionPresenter) | 129 | −17 |
| Target (Phase 1a #293) | <50 | −79 more |

Next natural extractions (separate PRs): `contentWithDialogs` modifier chain, `contentWithEvents` lifecycle hooks, `toolbarContent`, possibly the init/factory glue.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)