### PR TITLE
refactor(content): extract JournalFlowAlertsModifier (#293)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -90,13 +90,10 @@ struct ContentView: View {
   /// Adds the alert presentations, sheet stack, and onboarding-check task.
   private var contentWithDialogs: some View {
     contentWithEvents
-      .alert(item: $viewModel.journalFeedback) { feedback in
-        JournalFeedbackAlert.make(feedback) { viewModel.journalFeedback = nil }
-      }
-      .flowConfirmationAlerts(
+      .journalFlowAlerts(
+        viewModel: viewModel,
         flowCoordinator: flowCoordinator,
-        onPrimarySubmit: { await flowSubmissionPresenter.submit(failurePrefix: "Failed to log emotion") },
-        onSecondarySubmit: { await flowSubmissionPresenter.submit(failurePrefix: "Failed to log emotions") }
+        flowSubmissionPresenter: flowSubmissionPresenter
       )
       .mainContentDialogs(
         viewModel: viewModel,

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/JournalFlowAlertsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/JournalFlowAlertsModifier.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Bundles the two top-level alert surfaces the main shell presents:
+///
+/// 1. `journalFeedback` — driven by `ContentViewModel`'s journal feedback
+///    item, dismissed by clearing the published value.
+/// 2. `flowConfirmationAlerts` — the primary / secondary submission
+///    confirmation, owned by `FlowCoordinator` and routed through
+///    `FlowSubmissionPresenter` so the queued / failure copy lives in
+///    one place.
+///
+/// Extracting both keeps ContentView focused on lifecycle and composition;
+/// the modifier is small enough that the alert plumbing reads as one
+/// concept rather than two adjacent chains.
+struct JournalFlowAlertsModifier: ViewModifier {
+  @ObservedObject var viewModel: ContentViewModel
+  @ObservedObject var flowCoordinator: FlowCoordinator
+  let flowSubmissionPresenter: FlowSubmissionPresenter
+
+  func body(content: Content) -> some View {
+    content
+      .alert(item: $viewModel.journalFeedback) { feedback in
+        JournalFeedbackAlert.make(feedback) { viewModel.journalFeedback = nil }
+      }
+      .flowConfirmationAlerts(
+        flowCoordinator: flowCoordinator,
+        onPrimarySubmit: {
+          await flowSubmissionPresenter.submit(failurePrefix: "Failed to log emotion")
+        },
+        onSecondarySubmit: {
+          await flowSubmissionPresenter.submit(failurePrefix: "Failed to log emotions")
+        }
+      )
+  }
+}
+
+// MARK: - View Extension
+
+extension View {
+  /// Applies the journal-feedback alert plus the primary/secondary flow
+  /// confirmation alerts, routing submission through the supplied
+  /// presenter so callers don't repeat the queued/failure copy.
+  func journalFlowAlerts(
+    viewModel: ContentViewModel,
+    flowCoordinator: FlowCoordinator,
+    flowSubmissionPresenter: FlowSubmissionPresenter
+  ) -> some View {
+    modifier(
+      JournalFlowAlertsModifier(
+        viewModel: viewModel,
+        flowCoordinator: flowCoordinator,
+        flowSubmissionPresenter: flowSubmissionPresenter
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- ContentView's `contentWithDialogs` chained two top-level alert surfaces inline: the `journalFeedback` alert (5 lines) and the `flowConfirmationAlerts` modifier (5 lines).
- Lift both into a single `JournalFlowAlertsModifier` so the alert plumbing reads as one concept and the `FlowSubmissionPresenter` wiring lives behind a named seam.
- `ContentView.swift`: 129 → 126 lines (-3).
- New `Views/Navigation/JournalFlowAlertsModifier.swift` (56 lines).

Identical behavior: same `JournalFeedbackAlert`, same submission copy, same dismiss semantics.

## Phase 1a progress (#293)

| Step | ContentView lines |
|------|-------------------|
| Pre-rebuild monolith | 85 KB |
| Before #359 | 181 |
| After #359 (MainContentStates) | 146 |
| After #360 (FlowSubmissionPresenter) | 129 |
| After this PR (JournalFlowAlertsModifier) | 126 |
| Phase 1a #293 target | <50 |

## Architectural note on the <50-line target
The remaining ~76 lines in ContentView are largely structural and hard to compress without restructuring at the App layer:

- **18 lines** — `@StateObject` declarations (SwiftUI requires these where ownership is rooted; can't be moved to a child view without losing ownership semantics).
- **18 lines** — `init` / `init(dependencies:)` wiring (each `@StateObject(wrappedValue: …)` is one line).
- **~40 lines** — `body` + three modifier-chain computed properties (`contentWithEvents`, `contentWithDialogs`, `toolbarContent`).

Further extraction along the current pattern saves ~3-10 lines per PR (each new modifier still needs its dependencies forwarded). Reaching strict <50 would mean moving the dependency graph up to the App layer so ContentView can hold @ObservedObject instead of @StateObject — a structural change rather than a refactor. Worth scoping as a follow-up if the literal AC is required; otherwise the substantive decomposition from 85KB → 126 lines is already done.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)