### PR TITLE
refactor(content): extract MainContentLifecycleModifier (#293)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -70,21 +70,15 @@ struct ContentView: View {
   // through intermediate `some View` properties — each return type erases
   // the upstream complexity, letting the checker rest.
 
-  /// Adds lifecycle hooks. Navigation-state reconciliation now lives in
-  /// `navigationViewModel`, which observes `viewModel` directly.
+  /// Adds lifecycle hooks via `MainContentLifecycleModifier`.
+  /// Navigation-state reconciliation lives in `navigationViewModel`.
   private var contentWithEvents: some View {
     MainContentStates(viewModel: viewModel, navigationViewModel: navigationViewModel)
-      .ignoresSafeArea(edges: .bottom)
-      .task { await viewModel.loadCatalog() }
-      .task {
-        // Kick off auto-sync once when the view appears. The service
-        // subscribes to NetworkMonitor and triggers a sync whenever
-        // connectivity is restored.
-        syncService.startAutoSync()
-      }
-      .onChange(of: syncService.syncStatus) { _, newValue in
-        viewModel.handleSyncStatusChange(newValue, totalPending: journalQueue.pendingCount)
-      }
+      .mainContentLifecycle(
+        viewModel: viewModel,
+        syncService: syncService,
+        journalQueue: journalQueue
+      )
   }
 
   /// Adds the alert presentations, sheet stack, and onboarding-check task.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentLifecycleModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentLifecycleModifier.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Bundles the main shell's lifecycle hooks:
+///
+/// - `.ignoresSafeArea(edges: .bottom)` for the watch's home-indicator
+///   inset so content extends to the screen edge.
+/// - `.task { viewModel.loadCatalog() }` for the initial catalog fetch.
+/// - `.task { syncService.startAutoSync() }` for the connectivity-driven
+///   auto-sync subscription.
+/// - `.onChange(of: syncService.syncStatus)` to forward sync transitions
+///   into the view model's queued-pending feedback computation.
+///
+/// Extracting these as a single modifier keeps ContentView focused on
+/// composition and lets the lifecycle wiring be unit-tested or reused
+/// (e.g. in previews) without re-implementing the four-call chain.
+struct MainContentLifecycleModifier: ViewModifier {
+  @ObservedObject var viewModel: ContentViewModel
+  @ObservedObject var syncService: JournalSyncService
+  @ObservedObject var journalQueue: JournalQueue
+
+  func body(content: Content) -> some View {
+    content
+      .ignoresSafeArea(edges: .bottom)
+      .task { await viewModel.loadCatalog() }
+      .task {
+        // Kick off auto-sync once when the view appears. The service
+        // subscribes to NetworkMonitor and triggers a sync whenever
+        // connectivity is restored.
+        syncService.startAutoSync()
+      }
+      .onChange(of: syncService.syncStatus) { _, newValue in
+        viewModel.handleSyncStatusChange(newValue, totalPending: journalQueue.pendingCount)
+      }
+  }
+}
+
+// MARK: - View Extension
+
+extension View {
+  /// Applies the main shell's lifecycle hooks (catalog load, auto-sync
+  /// kickoff, sync-status change forwarding, bottom safe-area
+  /// extension).
+  func mainContentLifecycle(
+    viewModel: ContentViewModel,
+    syncService: JournalSyncService,
+    journalQueue: JournalQueue
+  ) -> some View {
+    modifier(
+      MainContentLifecycleModifier(
+        viewModel: viewModel,
+        syncService: syncService,
+        journalQueue: journalQueue
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- ContentView's `contentWithEvents` inlined the lifecycle chain: `.ignoresSafeArea`, two `.task` hooks (catalog load + auto-sync kickoff), and the `.onChange` forwarder for `syncService.syncStatus → viewModel`'s queued-pending feedback.
- Lift the chain into a dedicated `MainContentLifecycleModifier` so ContentView stays focused on composition and the lifecycle wiring can be referenced (or previewed/tested) in isolation.

Stats:
- `ContentView.swift`: 126 → 120 lines (-6).
- New `Views/Navigation/MainContentLifecycleModifier.swift` (~55 lines) with a `.mainContentLifecycle(viewModel:syncService:journalQueue:)` view extension.

Identical behavior: same catalog load, same auto-sync subscription, same sync-status forwarding, same bottom safe-area extension — all in the same order against the same dependencies.

## Phase 1a progress (#293)

| Step | ContentView lines |
|------|-------------------|
| Pre-rebuild monolith | 85 KB |
| Before #359 | 181 |
| After #359 (MainContentStates) | 146 |
| After #360 (FlowSubmissionPresenter) | 129 |
| After #361 (JournalFlowAlertsModifier) | 126 |
| After this PR (MainContentLifecycleModifier) | 120 |
| Phase 1a #293 target | <50 |

The same architectural note applies as in #361: closing the gap to <50 requires moving the `@StateObject` ownership graph up to the App layer rather than continued modifier extraction. Worth tracking as a follow-up if the literal AC is required.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)