### PR TITLE
refactor(content): extract DetailDestinationView from ContentView (#293)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -49,12 +49,7 @@ struct ContentView: View {
         .navigationTitle("")
         .wlNavigationBar()
         .navigationDestination(for: DetailDestination.self) { destination in
-          switch destination {
-          case let .curriculum(layer, phase, colorName):
-            CurriculumDetailView(layer: layer, phase: phase, color: Color(stage: colorName))
-          case let .strategy(phase, colorName):
-            StrategyListView(phase: phase, color: Color(stage: colorName))
-          }
+          DetailDestinationView(destination: destination)
         }
     }
     .environmentObject(viewModel)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/DetailDestinationView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/DetailDestinationView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Routes a `DetailDestination` enum case to the appropriate detail
+/// view. Lifted out of `ContentView.body` so the navigation destination
+/// configuration stays a one-line `.navigationDestination(for:)` call.
+struct DetailDestinationView: View {
+  let destination: DetailDestination
+
+  var body: some View {
+    switch destination {
+    case let .curriculum(layer, phase, colorName):
+      CurriculumDetailView(layer: layer, phase: phase, color: Color(stage: colorName))
+    case let .strategy(phase, colorName):
+      StrategyListView(phase: phase, color: Color(stage: colorName))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `ContentView.body` inlined the `.navigationDestination(for: DetailDestination.self)` switch — 6 lines of routing inside the modifier closure.
- Lift it into a dedicated `DetailDestinationView` so the navigation destination configuration stays a one-line modifier call.

Stats:
- `ContentView.swift`: 120 → 115 lines (-5).
- New `Views/Navigation/DetailDestinationView.swift` (17 lines) switches between `CurriculumDetailView` and `StrategyListView` based on the destination case.

Identical routing behavior — same instances constructed with the same arguments.

## Phase 1a progress (#293)

| Step | ContentView lines |
|------|-------------------|
| Pre-rebuild monolith | 85 KB |
| After #362 (MainContentLifecycleModifier) | 120 |
| After this PR (DetailDestinationView) | 115 |
| Phase 1a #293 target | <50 |

Same architectural note as #361/#362: closing the remaining gap requires moving the `@StateObject` ownership graph up to the App layer rather than continued modifier/view extraction.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)