### PR TITLE
refactor(journal): extract review-card components from JournalReviewView (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewEmotionCard.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Card displayed in `JournalReviewView` for each selected emotion
+/// (primary or secondary). Shows the label, expression, and a
+/// medicinal/toxic indicator with matching tint.
+///
+/// Extracted from `JournalReviewView` so the review screen's body
+/// reads as composition rather than inline form-building.
+struct JournalReviewEmotionCard: View {
+  let label: String
+  let expression: String
+  let dosage: CatalogDosage
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(label)
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .textCase(.uppercase)
+
+      HStack {
+        Circle()
+          .fill(dosage == .medicinal ? Color.green : Color.red)
+          .frame(width: 10, height: 10)
+
+        Text(expression)
+          .font(.body)
+          .fontWeight(.medium)
+          .foregroundColor(.primary)
+
+        Spacer()
+
+        Text(dosage == .medicinal ? "Medicinal" : "Toxic")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    }
+    .padding(.vertical, 12)
+    .padding(.horizontal, 16)
+    .background(WLColorTokens.elevatedCardFill)
+    .cornerRadius(10)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewEmotionCard.swift
@@ -41,3 +41,25 @@ struct JournalReviewEmotionCard: View {
     .cornerRadius(10)
   }
 }
+
+#if DEBUG
+#Preview("Emotion Card — Medicinal") {
+  JournalReviewEmotionCard(
+    label: "Primary Emotion",
+    expression: "Gratitude",
+    dosage: .medicinal
+  )
+  .padding()
+  .background(Color.black)
+}
+
+#Preview("Emotion Card — Toxic") {
+  JournalReviewEmotionCard(
+    label: "Secondary Emotion",
+    expression: "Resentment",
+    dosage: .toxic
+  )
+  .padding()
+  .background(Color.black)
+}
+#endif

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewStrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewStrategyCard.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Card displayed in `JournalReviewView` for the selected strategy.
+/// Shows the strategy name with its color indicator tinted via the
+/// catalog model's `color` field.
+///
+/// Extracted from `JournalReviewView` along with the `colorForStrategy`
+/// helper so the review screen's body stays composition-focused.
+/// `colorForStrategy` switches on lowercase color names, which matches
+/// the catalog's strategy-color casing (distinct from layer-stage names
+/// consumed by `Color(stage:)`).
+struct JournalReviewStrategyCard: View {
+  let strategy: CatalogStrategyModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Strategy")
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .textCase(.uppercase)
+
+      HStack {
+        Circle()
+          .fill(Self.colorForStrategy(strategy.color))
+          .frame(width: 10, height: 10)
+
+        Text(strategy.strategy)
+          .font(.body)
+          .fontWeight(.medium)
+          .foregroundColor(.primary)
+
+        Spacer()
+      }
+    }
+    .padding(.vertical, 12)
+    .padding(.horizontal, 16)
+    .background(WLColorTokens.elevatedCardFill)
+    .cornerRadius(10)
+  }
+
+  static func colorForStrategy(_ colorName: String) -> Color {
+    switch colorName.lowercased() {
+    case "blue": .blue
+    case "cyan": .cyan
+    case "green": .green
+    case "yellow": .yellow
+    case "orange": .orange
+    case "red": .red
+    case "purple": .purple
+    case "pink": .pink
+    default: .gray
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewStrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewStrategyCard.swift
@@ -38,7 +38,7 @@ struct JournalReviewStrategyCard: View {
     .cornerRadius(10)
   }
 
-  static func colorForStrategy(_ colorName: String) -> Color {
+  private static func colorForStrategy(_ colorName: String) -> Color {
     switch colorName.lowercased() {
     case "blue": .blue
     case "cyan": .cyan
@@ -52,3 +52,13 @@ struct JournalReviewStrategyCard: View {
     }
   }
 }
+
+#if DEBUG
+#Preview("Strategy Card") {
+  JournalReviewStrategyCard(
+    strategy: CatalogStrategyModel(id: 1, strategy: "Take a deep breath", color: "blue")
+  )
+  .padding()
+  .background(Color.black)
+}
+#endif

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
@@ -71,7 +71,7 @@ struct JournalReviewView: View {
         if flowViewModel.entryType == .emotion {
           // Primary emotion
           if let primary = flowViewModel.getPrimaryCurriculum() {
-            emotionCard(
+            JournalReviewEmotionCard(
               label: "Primary Emotion",
               expression: primary.expression,
               dosage: primary.dosage
@@ -80,7 +80,7 @@ struct JournalReviewView: View {
 
           // Secondary emotion (if selected)
           if let secondary = flowViewModel.getSecondaryCurriculum() {
-            emotionCard(
+            JournalReviewEmotionCard(
               label: "Secondary Emotion",
               expression: secondary.expression,
               dosage: secondary.dosage
@@ -89,7 +89,7 @@ struct JournalReviewView: View {
 
           // Strategy (if selected)
           if let strategy = flowViewModel.getStrategy() {
-            strategyCard(strategy: strategy)
+            JournalReviewStrategyCard(strategy: strategy)
           }
 
           Divider()
@@ -158,76 +158,6 @@ struct JournalReviewView: View {
 
   private var formattedTimestamp: String {
     Self.timestampFormatter.string(from: Date())
-  }
-
-  private func emotionCard(label: String, expression: String, dosage: CatalogDosage) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
-      Text(label)
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .textCase(.uppercase)
-
-      HStack {
-        Circle()
-          .fill(dosage == .medicinal ? Color.green : Color.red)
-          .frame(width: 10, height: 10)
-
-        Text(expression)
-          .font(.body)
-          .fontWeight(.medium)
-          .foregroundColor(.primary)
-
-        Spacer()
-
-        Text(dosage == .medicinal ? "Medicinal" : "Toxic")
-          .font(.caption)
-          .foregroundColor(.secondary)
-      }
-    }
-    .padding(.vertical, 12)
-    .padding(.horizontal, 16)
-    .background(WLColorTokens.elevatedCardFill)
-    .cornerRadius(10)
-  }
-
-  private func strategyCard(strategy: CatalogStrategyModel) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
-      Text("Strategy")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .textCase(.uppercase)
-
-      HStack {
-        Circle()
-          .fill(colorForStrategy(strategy.color))
-          .frame(width: 10, height: 10)
-
-        Text(strategy.strategy)
-          .font(.body)
-          .fontWeight(.medium)
-          .foregroundColor(.primary)
-
-        Spacer()
-      }
-    }
-    .padding(.vertical, 12)
-    .padding(.horizontal, 16)
-    .background(WLColorTokens.elevatedCardFill)
-    .cornerRadius(10)
-  }
-
-  private func colorForStrategy(_ colorName: String) -> Color {
-    switch colorName.lowercased() {
-    case "blue": .blue
-    case "cyan": .cyan
-    case "green": .green
-    case "yellow": .yellow
-    case "orange": .orange
-    case "red": .red
-    case "purple": .purple
-    case "pink": .pink
-    default: .gray
-    }
   }
 
   private func submitEntry() {


### PR DESCRIPTION
## Summary
- `JournalReviewView` inlined two card helpers — `emotionCard(label:expression:dosage:)` and `strategyCard(strategy:)` — plus the strategy-only `colorForStrategy(_:)` mapper. Together they were ~70 lines of view-building inside the review body.
- Lift each into a focused, standalone view in `Views/Journal/`.

Stats:
- `Views/JournalReviewView.swift`: 368 → 298 lines (-70).
- New `Views/Journal/JournalReviewEmotionCard.swift` (43 lines).
- New `Views/Journal/JournalReviewStrategyCard.swift` (54 lines) — owns `colorForStrategy(_:)` as a `static` helper.

The review screen's body now reads as composition (`JournalReviewEmotionCard(...)`, `JournalReviewStrategyCard(...)`) rather than inline form-building.

## On colorForStrategy

The mapper switches on lowercase color names (`"blue"`, `"cyan"`, ...), which matches the catalog's strategy-color casing. That's intentionally distinct from `Color(stage:)`, which expects capitalized layer-stage names (`"Beige"`, `"Purple"`, ...). Both forms are now documented at the strategy-card file. `FlowReviewSheet.swift:151` uses `Color(stage: strategy.color)` for the same intent — likely a long-standing bug worth filing as a follow-up issue, but out of scope for this extraction PR which is strict zero-behavior-change.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)