### PR TITLE
refactor(journal): extract JournalReviewRestHeader (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewRestHeader.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewRestHeader.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Supportive header shown above the review screen when the entry
+/// type is `.rest`. Encourages the user instead of treating rest as
+/// an emotion to log.
+///
+/// Extracted from `JournalReviewView` so the review screen's body
+/// stays composition-focused; the rest-specific styling (moon icon,
+/// purple tint, supportive copy) lives behind one named entry point.
+struct JournalReviewRestHeader: View {
+  var body: some View {
+    VStack(spacing: 8) {
+      Image(systemName: "moon.zzz.fill")
+        .font(.system(size: 36))
+        .foregroundColor(.purple.opacity(0.8))
+
+      Text("Your natural rhythm may be asking you to rest")
+        .font(.body)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal)
+    }
+    .padding(.vertical, 12)
+    .frame(maxWidth: .infinity)
+    .background(
+      RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
+        .fill(Color.purple.opacity(0.1))
+    )
+  }
+}
+
+#if DEBUG
+#Preview("Rest Header") {
+  JournalReviewRestHeader()
+    .padding()
+    .background(Color.black)
+}
+#endif

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewRestHeader.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewRestHeader.swift
@@ -12,11 +12,11 @@ struct JournalReviewRestHeader: View {
     VStack(spacing: 8) {
       Image(systemName: "moon.zzz.fill")
         .font(.system(size: 36))
-        .foregroundColor(.purple.opacity(0.8))
+        .foregroundStyle(.purple.opacity(0.8))
 
       Text("Your natural rhythm may be asking you to rest")
         .font(.body)
-        .foregroundColor(.secondary)
+        .foregroundStyle(.secondary)
         .multilineTextAlignment(.center)
         .padding(.horizontal)
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
@@ -29,23 +29,7 @@ struct JournalReviewView: View {
 
         // Supportive message for REST entries
         if flowViewModel.entryType == .rest {
-          VStack(spacing: 8) {
-            Image(systemName: "moon.zzz.fill")
-              .font(.system(size: 36))
-              .foregroundColor(.purple.opacity(0.8))
-
-            Text("Your natural rhythm may be asking you to rest")
-              .font(.body)
-              .foregroundColor(.secondary)
-              .multilineTextAlignment(.center)
-              .padding(.horizontal)
-          }
-          .padding(.vertical, 12)
-          .frame(maxWidth: .infinity)
-          .background(
-            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
-              .fill(Color.purple.opacity(0.1))
-          )
+          JournalReviewRestHeader()
         }
 
         // Timestamp

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
@@ -27,7 +27,6 @@ struct JournalReviewView: View {
           .fontWeight(.semibold)
           .padding(.top)
 
-        // Supportive message for REST entries
         if flowViewModel.entryType == .rest {
           JournalReviewRestHeader()
         }


### PR DESCRIPTION
## Summary
- `JournalReviewView` inlined a ~20-line supportive header (moon icon, purple tint, "Your natural rhythm may be asking you to rest" copy) shown when the entry type is `.rest`.
- Lift it into a standalone `JournalReviewRestHeader` view so the rest-specific styling lives behind one named entry point and the review body stays composition-focused.

Stats:
- `JournalReviewView.swift`: 298 → 282 lines (-16).
- New `Views/Journal/JournalReviewRestHeader.swift` (~37 lines) with a `#Preview` for fast visual iteration.

Zero behavioral change.

Continues the `JournalReviewView` decomposition started in #365. The view body now reads almost entirely as composition.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)