### PR TITLE
refactor(journal): extract JournalReviewActions (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewActions.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewActions.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Submit + Edit action pair at the bottom of `JournalReviewView`.
+/// The submit button toggles a `ProgressView` while `isSubmitting`,
+/// and both buttons disable while submission is in flight.
+///
+/// Extracted from `JournalReviewView` so the review body stays
+/// composition-focused and the action affordances live behind a
+/// single named entry point.
+struct JournalReviewActions: View {
+  let isSubmitting: Bool
+  let onSubmit: () -> Void
+  let onEdit: () -> Void
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Button(action: onSubmit) {
+        if isSubmitting {
+          ProgressView()
+            .progressViewStyle(CircularProgressViewStyle())
+        } else {
+          Text("Submit Entry")
+            .fontWeight(.semibold)
+        }
+      }
+      .disabled(isSubmitting)
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 12)
+      .background(isSubmitting ? Color.gray : Color.blue)
+      .foregroundStyle(.white)
+      .cornerRadius(10)
+
+      Button(action: onEdit) {
+        Text("Edit")
+          .foregroundStyle(.blue)
+      }
+      .disabled(isSubmitting)
+    }
+  }
+}
+
+#if DEBUG
+#Preview("Idle") {
+  JournalReviewActions(isSubmitting: false, onSubmit: {}, onEdit: {})
+    .padding()
+    .background(Color.black)
+}
+
+#Preview("Submitting") {
+  JournalReviewActions(isSubmitting: true, onSubmit: {}, onEdit: {})
+    .padding()
+    .background(Color.black)
+}
+#endif

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
@@ -78,34 +78,11 @@ struct JournalReviewView: View {
           Divider()
         }
 
-        // Action buttons
-        VStack(spacing: 12) {
-          Button {
-            submitEntry()
-          } label: {
-            if isSubmitting {
-              ProgressView()
-                .progressViewStyle(CircularProgressViewStyle())
-            } else {
-              Text("Submit Entry")
-                .fontWeight(.semibold)
-            }
-          }
-          .disabled(isSubmitting)
-          .frame(maxWidth: .infinity)
-          .padding(.vertical, 12)
-          .background(isSubmitting ? Color.gray : Color.blue)
-          .foregroundColor(.white)
-          .cornerRadius(10)
-
-          Button {
-            onEdit()
-          } label: {
-            Text("Edit")
-              .foregroundColor(.blue)
-          }
-          .disabled(isSubmitting)
-        }
+        JournalReviewActions(
+          isSubmitting: isSubmitting,
+          onSubmit: submitEntry,
+          onEdit: onEdit
+        )
         .padding(.bottom)
       }
       .padding(.horizontal)


### PR DESCRIPTION
## Summary
- `JournalReviewView` inlined a ~30-line Submit + Edit action pair: the submit button with its in-flight `ProgressView` swap, both buttons' `isSubmitting` disable wiring, and the inlined background/foreground styling.
- Lift it into a focused `JournalReviewActions` view with a three-arg surface: `isSubmitting`, `onSubmit`, `onEdit`.

Stats:
- `JournalReviewView.swift`: 282 → 258 lines (-24).
- New `Views/Journal/JournalReviewActions.swift` (~54 lines) with two `#Preview` macros (idle / submitting) so the state toggle is reviewable without running the app.

Adopted `.foregroundStyle` in the new file (was `.foregroundColor` in the original — pre-existing deprecation that PR #366's review flagged in passing; clearing it here while the code is touched).

Zero behavioral change: same submit action, same edit action, same disable semantics, same visual treatment.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)