### PR TITLE
refactor(journal): extract JournalReviewTimestamp (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewTimestamp.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/JournalReviewTimestamp.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// "Logged At" timestamp card displayed near the top of
+/// `JournalReviewView`. Formats `Date()` at render time using a
+/// medium-date + short-time style.
+///
+/// Extracted from `JournalReviewView` so the review body stays
+/// composition-focused; the formatter is owned here instead of as a
+/// static on the parent view.
+struct JournalReviewTimestamp: View {
+  /// Date to render. Defaults to `Date()` at construction so the
+  /// timestamp captured by the view reflects roughly when the review
+  /// appeared, matching the previous in-view behavior.
+  let timestamp: Date
+
+  init(timestamp: Date = Date()) {
+    self.timestamp = timestamp
+  }
+
+  var body: some View {
+    VStack(spacing: 4) {
+      Text("Logged At")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+
+      Text(Self.formatter.string(from: timestamp))
+        .font(.body)
+        .foregroundStyle(.primary)
+    }
+    .padding(.vertical, 8)
+    .padding(.horizontal, 12)
+    .frame(maxWidth: .infinity)
+    .background(WLColorTokens.elevatedCardFill)
+    .cornerRadius(8)
+  }
+
+  private static let formatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .short
+    return formatter
+  }()
+}
+
+#if DEBUG
+#Preview("Timestamp") {
+  JournalReviewTimestamp()
+    .padding()
+    .background(Color.black)
+}
+#endif

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/JournalReviewView.swift
@@ -31,22 +31,7 @@ struct JournalReviewView: View {
           JournalReviewRestHeader()
         }
 
-        // Timestamp
-        VStack(spacing: 4) {
-          Text("Logged At")
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .textCase(.uppercase)
-
-          Text(formattedTimestamp)
-            .font(.body)
-            .foregroundColor(.primary)
-        }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 12)
-        .frame(maxWidth: .infinity)
-        .background(WLColorTokens.elevatedCardFill)
-        .cornerRadius(8)
+        JournalReviewTimestamp()
 
         Divider()
 
@@ -107,17 +92,6 @@ struct JournalReviewView: View {
       submitTask = nil
       isSubmitting = false
     }
-  }
-
-  private static let timestampFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    formatter.timeStyle = .short
-    return formatter
-  }()
-
-  private var formattedTimestamp: String {
-    Self.timestampFormatter.string(from: Date())
   }
 
   private func submitEntry() {


### PR DESCRIPTION
## Summary
- `JournalReviewView` inlined a ~16-line "Logged At" timestamp card plus the static `timestampFormatter` and `formattedTimestamp` helpers (~10 lines). Together the timestamp concern was spread across three parts of the file.
- Lift everything into a focused `JournalReviewTimestamp` view that owns its own `DateFormatter` and exposes an optional `timestamp:` parameter (defaults to `Date()` so the existing call-site behavior is preserved).

Stats:
- `JournalReviewView.swift`: 258 → 232 lines (-26).
- New `Views/Journal/JournalReviewTimestamp.swift` (~52 lines) with a `#Preview` macro and `.foregroundStyle` adopted.

Zero behavioral change: same medium-date + short-time formatting, same uppercase caption label, same elevated-card-fill background.

## Phase 4 progress (#299)

| Step | JournalReviewView lines |
|------|-------------------------|
| Session start | 368 |
| After #365 (review-card components) | 298 |
| After #366 (rest header) | 282 |
| After #367 (actions block) | 258 |
| After this PR (timestamp section) | 232 |

The review screen body is now almost entirely composition: `JournalReviewTimestamp()`, `JournalReviewEmotionCard(...)`, `JournalReviewStrategyCard(...)`, `JournalReviewActions(...)`, plus the `if .rest { JournalReviewRestHeader() }` branch.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)