### PR TITLE
refactor(content): thin ContentView shell, extract RootShellView (#293)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ContentView.swift
@@ -1,88 +1,18 @@
 import SwiftUI
 
+/// Thin shell that names the app's root view. All composition lives
+/// in `RootShellView`; ObservableObject dependencies are read from the
+/// environment (injected at the App layer in `WavelengthWatchApp`).
 struct ContentView: View {
-  @ObservedObject var viewModel: ContentViewModel
-  @ObservedObject var flowCoordinator: FlowCoordinator
-  @ObservedObject var syncSettingsViewModel: SyncSettingsViewModel
-  @ObservedObject var networkMonitor: NetworkMonitor
-  @ObservedObject var journalQueue: JournalQueue
-  @ObservedObject var syncService: JournalSyncService
-  @ObservedObject var navigationViewModel: NavigationViewModel
-  @EnvironmentObject private var notificationDelegate: NotificationDelegate
   let journalClient: JournalClientProtocol
   let journalRepository: JournalRepositoryProtocol
   let catalogRepository: CatalogRepositoryProtocol
-  @State private var showingMenu = false
-  @State private var showingOnboarding = false
-  @State private var isShowingDetailView = false
-  @State private var navigationPath = NavigationPath()
-
-  private var flowSubmissionPresenter: FlowSubmissionPresenter {
-    FlowSubmissionPresenter(flowCoordinator: flowCoordinator, viewModel: viewModel)
-  }
 
   var body: some View {
-    NavigationStack(path: $navigationPath) {
-      contentWithDialogs
-        .toolbar { toolbarContent }
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle("")
-        .wlNavigationBar()
-        .navigationDestination(for: DetailDestination.self) { destination in
-          DetailDestinationView(destination: destination)
-        }
-    }
-    .environmentObject(viewModel)
-    .environmentObject(flowCoordinator)
-    .environment(\.isShowingDetailView, $isShowingDetailView)
-  }
-
-  // MARK: - Body decomposition
-
-  //
-  // The view body chains ~30 modifiers across lifecycle, onChange, alerts,
-  // sheets, toolbar, and navigation. Swift 6's type checker can't resolve
-  // that single expression in reasonable time, so we stage the chain
-  // through intermediate `some View` properties — each return type erases
-  // the upstream complexity, letting the checker rest.
-
-  private var contentWithEvents: some View {
-    MainContentStates(viewModel: viewModel, navigationViewModel: navigationViewModel)
-      .mainContentLifecycle(
-        viewModel: viewModel,
-        syncService: syncService,
-        journalQueue: journalQueue
-      )
-  }
-
-  private var contentWithDialogs: some View {
-    contentWithEvents
-      .journalFlowAlerts(
-        viewModel: viewModel,
-        flowCoordinator: flowCoordinator,
-        flowSubmissionPresenter: flowSubmissionPresenter
-      )
-      .mainContentDialogs(
-        viewModel: viewModel,
-        flowCoordinator: flowCoordinator,
-        syncSettingsViewModel: syncSettingsViewModel,
-        notificationDelegate: notificationDelegate,
-        journalClient: journalClient,
-        journalQueue: journalQueue,
-        syncService: syncService,
-        networkMonitor: networkMonitor,
-        showingMenu: $showingMenu,
-        showingOnboarding: $showingOnboarding,
-        navigationPath: $navigationPath
-      )
-  }
-
-  private var toolbarContent: some ToolbarContent {
-    MainNavigationToolbar(
-      isShowingDetailView: isShowingDetailView,
-      isInFlow: flowCoordinator.currentStep != .idle,
-      onBack: { flowCoordinator.cancel() },
-      onMenu: { showingMenu = true }
+    RootShellView(
+      journalClient: journalClient,
+      journalRepository: journalRepository,
+      catalogRepository: catalogRepository
     )
   }
 }
@@ -90,16 +20,16 @@ struct ContentView: View {
 #Preview {
   let deps = ContentViewDependencies.live()
   return ContentView(
-    viewModel: deps.viewModel,
-    flowCoordinator: deps.flowCoordinator,
-    syncSettingsViewModel: deps.syncSettingsViewModel,
-    networkMonitor: deps.networkMonitor,
-    journalQueue: deps.journalQueue,
-    syncService: deps.syncService,
-    navigationViewModel: deps.navigationViewModel,
     journalClient: deps.journalClient,
     journalRepository: deps.journalRepository,
     catalogRepository: deps.catalogRepository
   )
+  .environmentObject(deps.viewModel)
+  .environmentObject(deps.flowCoordinator)
+  .environmentObject(deps.syncSettingsViewModel)
+  .environmentObject(deps.networkMonitor)
+  .environmentObject(deps.journalQueue)
+  .environmentObject(deps.syncService)
+  .environmentObject(deps.navigationViewModel)
   .environmentObject(NotificationDelegate())
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// Root shell that composes the main app surface: the `NavigationStack`,
+/// the dual-axis content states, lifecycle hooks, alert/dialog stack,
+/// toolbar, and destination routing.
+///
+/// All shared `ObservableObject` dependencies are pulled from the
+/// environment (injected at the App layer in `WavelengthWatchApp`).
+/// The three protocol-typed services (`journalClient`,
+/// `journalRepository`, `catalogRepository`) come in as init parameters
+/// because Swift environment values don't compose cleanly with protocol
+/// existentials.
+///
+/// Extracted from `ContentView` so the view that names the app's root
+/// can stay a thin shell — this view owns the sheet/navigation state
+/// and the modifier-chain staging required by Swift 6's type-checker.
+struct RootShellView: View {
+  @EnvironmentObject private var viewModel: ContentViewModel
+  @EnvironmentObject private var flowCoordinator: FlowCoordinator
+  @EnvironmentObject private var syncSettingsViewModel: SyncSettingsViewModel
+  @EnvironmentObject private var networkMonitor: NetworkMonitor
+  @EnvironmentObject private var journalQueue: JournalQueue
+  @EnvironmentObject private var syncService: JournalSyncService
+  @EnvironmentObject private var navigationViewModel: NavigationViewModel
+  @EnvironmentObject private var notificationDelegate: NotificationDelegate
+
+  let journalClient: JournalClientProtocol
+  let journalRepository: JournalRepositoryProtocol
+  let catalogRepository: CatalogRepositoryProtocol
+
+  @State private var showingMenu = false
+  @State private var showingOnboarding = false
+  @State private var isShowingDetailView = false
+  @State private var navigationPath = NavigationPath()
+
+  private var flowSubmissionPresenter: FlowSubmissionPresenter {
+    FlowSubmissionPresenter(flowCoordinator: flowCoordinator, viewModel: viewModel)
+  }
+
+  var body: some View {
+    NavigationStack(path: $navigationPath) {
+      contentWithDialogs
+        .toolbar { toolbarContent }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("")
+        .wlNavigationBar()
+        .navigationDestination(for: DetailDestination.self) { destination in
+          DetailDestinationView(destination: destination)
+        }
+    }
+    .environment(\.isShowingDetailView, $isShowingDetailView)
+  }
+
+  // MARK: - Body decomposition
+
+  //
+  // The view body chains ~30 modifiers across lifecycle, onChange, alerts,
+  // sheets, toolbar, and navigation. Swift 6's type checker can't resolve
+  // that single expression in reasonable time, so we stage the chain
+  // through intermediate `some View` properties — each return type erases
+  // the upstream complexity, letting the checker rest.
+
+  private var contentWithEvents: some View {
+    MainContentStates(viewModel: viewModel, navigationViewModel: navigationViewModel)
+      .mainContentLifecycle(
+        viewModel: viewModel,
+        syncService: syncService,
+        journalQueue: journalQueue
+      )
+  }
+
+  private var contentWithDialogs: some View {
+    contentWithEvents
+      .journalFlowAlerts(
+        viewModel: viewModel,
+        flowCoordinator: flowCoordinator,
+        flowSubmissionPresenter: flowSubmissionPresenter
+      )
+      .mainContentDialogs(
+        viewModel: viewModel,
+        flowCoordinator: flowCoordinator,
+        syncSettingsViewModel: syncSettingsViewModel,
+        notificationDelegate: notificationDelegate,
+        journalClient: journalClient,
+        journalQueue: journalQueue,
+        syncService: syncService,
+        networkMonitor: networkMonitor,
+        showingMenu: $showingMenu,
+        showingOnboarding: $showingOnboarding,
+        navigationPath: $navigationPath
+      )
+  }
+
+  private var toolbarContent: some ToolbarContent {
+    MainNavigationToolbar(
+      isShowingDetailView: isShowingDetailView,
+      isInFlow: flowCoordinator.currentStep != .idle,
+      onBack: { flowCoordinator.cancel() },
+      onMenu: { showingMenu = true }
+    )
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/WavelengthWatchApp.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/WavelengthWatchApp.swift
@@ -82,17 +82,17 @@ struct WavelengthWatch_Watch_AppApp: App {
   var body: some Scene {
     WindowGroup {
       ContentView(
-        viewModel: viewModel,
-        flowCoordinator: flowCoordinator,
-        syncSettingsViewModel: syncSettingsViewModel,
-        networkMonitor: networkMonitor,
-        journalQueue: journalQueue,
-        syncService: syncService,
-        navigationViewModel: navigationViewModel,
         journalClient: journalClient,
         journalRepository: journalRepository,
         catalogRepository: catalogRepository
       )
+      .environmentObject(viewModel)
+      .environmentObject(flowCoordinator)
+      .environmentObject(syncSettingsViewModel)
+      .environmentObject(networkMonitor)
+      .environmentObject(journalQueue)
+      .environmentObject(syncService)
+      .environmentObject(navigationViewModel)
       .environmentObject(notificationDelegate)
     }
   }


### PR DESCRIPTION
## Summary
Closes the strict `<50 lines` AC for Phase 1a by moving all composition out of `ContentView` into a new `RootShellView` and switching to `environmentObject`-based dependency injection.

Stats:
- `ContentView.swift`: 104 → **35 lines**.
- New `Views/Navigation/RootShellView.swift` (~102 lines) — holds the 8 `@EnvironmentObject` reads, the 4 `@State` sheet/navigation toggles, the modifier-chain staging (still required by Swift 6's type-checker — comment preserved), and the 3 protocol-typed `let` services (passed in by `ContentView` since Swift environment values don't compose cleanly with protocol existentials).
- `WavelengthWatchApp.swift`: `ContentView`'s init shrinks to 3 args (the protocols); the 7 view-models flow through 7 chained `.environmentObject(...)` calls in the `WindowGroup` body.

Behavioral equivalence: same view hierarchy, same dependency wiring (just rooted at the `WindowGroup` body rather than at `ContentView`'s own body). All 43 frontend test suites pass.

## Phase 1a ACs (#293)

| AC | Status |
|---|---|
| `ContentView.swift` deleted or reduced to a thin shell (`< 50 lines`) | ✅ 35 lines |
| All views in focused files under the new directory structure | ✅ Done across the session's chip-aways and #364 |
| App compiles and launches | ✅ (43/43 suites pass; build green locally) |
| No circular dependencies between view modules | ✅ |
| Existing tests that touch Services/Models still pass | ✅ |

After this lands, #293 is ready to close.

## ContentView final shape
```swift
struct ContentView: View {
  let journalClient: JournalClientProtocol
  let journalRepository: JournalRepositoryProtocol
  let catalogRepository: CatalogRepositoryProtocol

  var body: some View {
    RootShellView(
      journalClient: journalClient,
      journalRepository: journalRepository,
      catalogRepository: catalogRepository
    )
  }
}
```
(plus a `#Preview` block that constructs the live graph for fast iteration).

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — 43/43 suites pass
- [x] `swiftformat --lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)