### PR TITLE
refactor(journal): FlowReviewSheet uses shared expression cards (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/EmotionExpressionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/EmotionExpressionCard.swift
@@ -8,9 +8,9 @@ import SwiftUI
 /// journal selection (flow review), and any future surfaces that need
 /// to render a single dosage-tinted expression — see Phase 3b (#298).
 ///
-/// First call site: `JournalReviewView`. Promoted to `Views/Components/`
-/// from its earlier home in `Views/Journal/` so non-journal callers can
-/// discover and reuse it without leaking journal-specific naming.
+/// Canonical review card used by the live journal flow (`FlowReviewSheet`).
+/// Layout puts the dosage tag *below* the expression for legibility on the
+/// narrow watch screen (per #159) rather than crowding it onto the same row.
 struct EmotionExpressionCard: View {
   let label: String
   let expression: String
@@ -22,28 +22,30 @@ struct EmotionExpressionCard: View {
         .font(.caption)
         .foregroundStyle(.secondary)
         .textCase(.uppercase)
+        .tracking(1.2)
 
-      HStack {
+      Text(expression)
+        .font(.body)
+        .fontWeight(.bold)
+        .lineLimit(nil)
+
+      HStack(spacing: 6) {
         Circle()
           .fill(dosage == .medicinal ? Color.green : Color.red)
-          .frame(width: 10, height: 10)
-
-        Text(expression)
-          .font(.body)
-          .fontWeight(.medium)
-          .foregroundStyle(.primary)
-
-        Spacer()
+          .frame(width: WLSpacingTokens.indicatorDotMedium, height: WLSpacingTokens.indicatorDotMedium)
 
         Text(dosage == .medicinal ? "Medicinal" : "Toxic")
-          .font(.caption)
+          .font(.caption2)
           .foregroundStyle(.secondary)
+          .textCase(.uppercase)
       }
     }
-    .padding(.vertical, 12)
-    .padding(.horizontal, 16)
-    .background(WLColorTokens.elevatedCardFill)
-    .cornerRadius(10)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(WLSpacingTokens.cardPaddingStandard)
+    .background(
+      RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
+        .fill(WLColorTokens.cardFill)
+    )
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -18,7 +18,7 @@ struct FlowReviewSheet: View {
             .padding(.top)
 
           if let primary = flowCoordinator.selections.primary {
-            emotionCard(
+            EmotionExpressionCard(
               label: "Primary Emotion",
               expression: primary.expression,
               dosage: primary.dosage
@@ -26,7 +26,7 @@ struct FlowReviewSheet: View {
           }
 
           if let secondary = flowCoordinator.selections.secondary {
-            emotionCard(
+            EmotionExpressionCard(
               label: "Secondary Emotion",
               expression: secondary.expression,
               dosage: secondary.dosage
@@ -34,7 +34,7 @@ struct FlowReviewSheet: View {
           }
 
           if let strategy = flowCoordinator.selections.strategy {
-            strategyCard(strategy: strategy)
+            StrategyExpressionCard(strategy: strategy)
           }
 
           // Submit button with celebratory gradient styling (fixes #160)
@@ -102,66 +102,6 @@ struct FlowReviewSheet: View {
         }
       }
     }
-  }
-
-  private func emotionCard(label: String, expression: String, dosage: CatalogDosage) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
-      // Label
-      Text(label)
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .textCase(.uppercase)
-        .tracking(1.2)
-
-      // Expression (main content)
-      Text(expression)
-        .font(.body)
-        .fontWeight(.bold)
-        .lineLimit(nil)
-
-      // Dosage tag underneath (fixes #159: increased circle size for visibility)
-      HStack(spacing: 6) {
-        Circle()
-          .fill(dosage == .medicinal ? Color.green : Color.red)
-          .frame(width: 10, height: 10)
-
-        Text(dosage == .medicinal ? "Medicinal" : "Toxic")
-          .font(.caption2)
-          .foregroundColor(.secondary)
-          .textCase(.uppercase)
-      }
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(12)
-    .background(
-      RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
-        .fill(WLColorTokens.cardFill)
-    )
-  }
-
-  private func strategyCard(strategy: CatalogStrategyModel) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
-      Text("Strategy")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .textCase(.uppercase)
-
-      HStack {
-        Circle()
-          .fill(Color(stage: strategy.color))
-          .frame(width: 10, height: 10)
-
-        Text(strategy.strategy)
-          .font(.body)
-          .fontWeight(.medium)
-
-        Spacer()
-      }
-    }
-    .padding(.vertical, 12)
-    .padding(.horizontal, 16)
-    .background(WLColorTokens.elevatedCardFill)
-    .cornerRadius(10)
   }
 
   @MainActor


### PR DESCRIPTION
## Summary
- The live journal review sheet (`FlowReviewSheet`) hand-rolled private `emotionCard`/`strategyCard` helpers that duplicated the Phase 3b `EmotionExpressionCard` / `StrategyExpressionCard`. This wires the live flow to render through the shared, reusable component library instead of a private copy — giving those promoted components their intended in-app home and removing ~58 lines of duplication.
- `EmotionExpressionCard` now carries the review sheet's refined layout (dosage tag *below* the expression per #159, tokenized `RoundedRectangle` background) so **the live UI is unchanged**. Its public `label`/`expression`/`dosage` API is stable, so call sites are unaffected.
- `StrategyExpressionCard` was already pixel-identical to the deleted `strategyCard` helper (both use `Color(stage:)` + `elevatedCardFill`), so adopting it is a no-op visually.

Part of #299 (Phase 4: rebuild journal flow / consolidate). This is the first of two slices — the next removes the now-fully-orphaned legacy `JournalFlowViewModel`/`JournalReviewView` path.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all 43 suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Build compiles; `EmotionExpressionCard` API unchanged so existing tests stay green
- [ ] Visual: review sheet renders primary/secondary emotion + strategy identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)