### PR TITLE
feat(journal): add rest-period entry to the live flow (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
@@ -158,6 +158,18 @@ final class ContentViewModel: ObservableObject {
     currentInitiatedBy = .self_initiated
   }
 
+  /// Throwing rest-period submission for use by FlowCoordinator.
+  ///
+  /// Mirrors `journalThrowing` but logs a rest period (no curriculum/strategy),
+  /// propagating errors so callers can preserve state for retry.
+  @MainActor
+  func journalRestThrowing(initiatedBy: InitiatedBy? = nil) async throws {
+    let effectiveInitiatedBy = initiatedBy ?? currentInitiatedBy
+    _ = try await journalClient.submitRestPeriod(initiatedBy: effectiveInitiatedBy)
+    // Reset to self-initiated after successful submission
+    currentInitiatedBy = .self_initiated
+  }
+
   @MainActor
   func setInitiatedBy(_ value: InitiatedBy) {
     currentInitiatedBy = value

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowCoordinator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowCoordinator.swift
@@ -23,6 +23,10 @@ final class FlowCoordinator: ObservableObject {
   /// Current step in the flow state machine
   @Published var currentStep: FlowStep = .idle
 
+  /// Whether this run logs an emotion or a rest period. Rest periods skip
+  /// emotion/secondary/strategy selection and go straight to review.
+  @Published var entryType: EntryType = .emotion
+
   /// User selections throughout the flow
   @Published var selections: Selections = .init()
 
@@ -40,6 +44,15 @@ final class FlowCoordinator: ObservableObject {
   func startPrimarySelection() {
     contentViewModel.layerFilterMode = .emotionsOnly
     currentStep = .selectingPrimary
+  }
+
+  /// Starts a rest-period entry.
+  ///
+  /// Rest periods carry no emotion/strategy selections, so this skips the
+  /// browsing steps entirely and jumps straight to review for confirmation.
+  func startRestPeriod() {
+    entryType = .rest
+    currentStep = .review
   }
 
   /// Captures the primary emotion selection
@@ -105,6 +118,13 @@ final class FlowCoordinator: ObservableObject {
   /// - Throws: FlowError.missingPrimaryEmotion if no primary emotion is selected
   /// - Throws: Network/API errors from journal client
   func submit() async throws {
+    // Rest periods carry no emotion selection, so they bypass the
+    // primary-emotion guard and log directly.
+    if entryType == .rest {
+      try await contentViewModel.journalRestThrowing(initiatedBy: .self_initiated)
+      return
+    }
+
     guard let primary = selections.primary else {
       throw FlowError.missingPrimaryEmotion
     }
@@ -137,6 +157,7 @@ final class FlowCoordinator: ObservableObject {
   /// This ensures users can browse the full catalog after flow completion.
   func reset() {
     currentStep = .idle
+    entryType = .emotion
     selections = .init()
     contentViewModel.layerFilterMode = .all
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -17,24 +17,28 @@ struct FlowReviewSheet: View {
             .fontWeight(.semibold)
             .padding(.top)
 
-          if let primary = flowCoordinator.selections.primary {
-            EmotionExpressionCard(
-              label: "Primary Emotion",
-              expression: primary.expression,
-              dosage: primary.dosage
-            )
-          }
+          if flowCoordinator.entryType == .rest {
+            RestPeriodHeader()
+          } else {
+            if let primary = flowCoordinator.selections.primary {
+              EmotionExpressionCard(
+                label: "Primary Emotion",
+                expression: primary.expression,
+                dosage: primary.dosage
+              )
+            }
 
-          if let secondary = flowCoordinator.selections.secondary {
-            EmotionExpressionCard(
-              label: "Secondary Emotion",
-              expression: secondary.expression,
-              dosage: secondary.dosage
-            )
-          }
+            if let secondary = flowCoordinator.selections.secondary {
+              EmotionExpressionCard(
+                label: "Secondary Emotion",
+                expression: secondary.expression,
+                dosage: secondary.dosage
+              )
+            }
 
-          if let strategy = flowCoordinator.selections.strategy {
-            StrategyExpressionCard(strategy: strategy)
+            if let strategy = flowCoordinator.selections.strategy {
+              StrategyExpressionCard(strategy: strategy)
+            }
           }
 
           // Submit button with celebratory gradient styling (fixes #160)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Supportive header shown on the review screen when the entry type is
+/// `.rest`. Frames rest as honoring a natural contraction rather than an
+/// emotion to log. ViewModel-free.
+struct RestPeriodHeader: View {
+  var body: some View {
+    VStack(spacing: 8) {
+      Image(systemName: "moon.zzz.fill")
+        .font(.system(size: 36))
+        .foregroundStyle(.purple.opacity(0.8))
+
+      Text("Your natural rhythm may be asking you to rest")
+        .font(.body)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal)
+    }
+    .padding(.vertical, 12)
+    .frame(maxWidth: .infinity)
+    .background(
+      RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
+        .fill(Color.purple.opacity(0.1))
+    )
+  }
+}
+
+#if DEBUG
+#Preview("Rest Header") {
+  RestPeriodHeader()
+    .padding()
+    .background(Color.black)
+}
+#endif

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
@@ -9,6 +9,7 @@ struct RestPeriodHeader: View {
       Image(systemName: "moon.zzz.fill")
         .font(.system(size: 36))
         .foregroundStyle(.purple.opacity(0.8))
+        .accessibilityHidden(true)
 
       Text("Your natural rhythm may be asking you to rest")
         .font(.body)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Menu/MenuView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Menu/MenuView.swift
@@ -27,6 +27,17 @@ struct MenuView: View {
       .accessibilityLabel("Log your current emotion")
       .accessibilityHint("Opens emotion logging flow")
 
+      // Rest periods need no catalog, so this stays enabled even when
+      // the catalog is empty, and jumps straight to the review sheet.
+      Button {
+        flowCoordinator.startRestPeriod()
+        isPresented = false
+      } label: {
+        Label("Honoring Rest", systemImage: "moon.zzz")
+      }
+      .accessibilityLabel("Log a rest period")
+      .accessibilityHint("Records that you are honoring a natural rest")
+
       NavigationLink(destination: ScheduleSettingsView()) {
         Label("Schedules", systemImage: "clock")
       }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewModelTests.swift
@@ -91,6 +91,18 @@ struct ContentViewModelTests {
     #expect(submission.2 == nil) // strategyID
   }
 
+  @Test func journalRestThrowingSubmitsRestPeriod() async throws {
+    let repository = CatalogRepositoryMock(cached: SampleData.catalog, result: .success(SampleData.catalog))
+    let journal = JournalClientMock()
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journal)
+
+    try await viewModel.journalRestThrowing(initiatedBy: .self_initiated)
+
+    #expect(journal.restSubmissions.count == 1)
+    #expect(journal.submissions.isEmpty)
+    #expect(journal.restSubmissions[0] == .self_initiated)
+  }
+
   // MARK: - Layer Filtering Tests
 
   @Test func filteredLayersDefaultsToAll() async {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowCoordinatorTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowCoordinatorTests.swift
@@ -187,6 +187,21 @@ struct FlowCoordinatorTests {
     #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
   }
 
+  @Test("rest entry returns to clean state after a successful submit + reset")
+  func submit_inRestMode_thenReset_returnsToCleanState() async throws {
+    let (viewModel, coordinator, _) = await createTestSetup()
+
+    coordinator.startRestPeriod()
+    try await coordinator.submit()
+    // Mirrors the success-alert "OK" path, which calls cancel()/reset().
+    coordinator.reset()
+
+    #expect(coordinator.entryType == EntryType.emotion)
+    #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
+    #expect(coordinator.selections.primary == nil)
+    #expect(viewModel.layerFilterMode == LayerFilterMode.all)
+  }
+
   // MARK: - Cancellation Tests
 
   @Test("cancel resets to idle state and clears selections")

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowCoordinatorTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowCoordinatorTests.swift
@@ -129,6 +129,64 @@ struct FlowCoordinatorTests {
     #expect(coordinator.currentStep == FlowCoordinator.FlowStep.review)
   }
 
+  // MARK: - Rest Period Tests
+
+  @Test("startRestPeriod sets rest entry type and jumps to review")
+  func startRestPeriod_setsRestEntryTypeAndReview() async {
+    let (viewModel, coordinator, _) = await createTestSetup()
+
+    coordinator.startRestPeriod()
+
+    #expect(coordinator.entryType == EntryType.rest)
+    #expect(coordinator.currentStep == FlowCoordinator.FlowStep.review)
+    // Rest needs no emotion browsing, so the catalog stays fully visible.
+    #expect(viewModel.layerFilterMode == LayerFilterMode.all)
+  }
+
+  @Test("rest flow defaults to emotion entry type before starting")
+  func entryType_defaultsToEmotion() async {
+    let (_, coordinator, _) = await createTestSetup()
+
+    #expect(coordinator.entryType == EntryType.emotion)
+  }
+
+  @Test("submit in rest mode calls submitRestPeriod, not emotion submit")
+  func submit_inRestMode_callsRestSubmission() async throws {
+    let catalog = CatalogTestHelper.createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let journalClient = JournalClientMock()
+    let viewModel = ContentViewModel(catalogRepository: repository, journalRepository: InMemoryJournalRepository(), journalClient: journalClient)
+    await viewModel.loadCatalog()
+    let coordinator = FlowCoordinator(contentViewModel: viewModel)
+
+    coordinator.startRestPeriod()
+    try await coordinator.submit()
+
+    #expect(journalClient.restSubmissions.count == 1)
+    #expect(journalClient.submissions.isEmpty)
+  }
+
+  @Test("submit in rest mode does not require a primary emotion")
+  func submit_inRestMode_withoutPrimary_doesNotThrow() async throws {
+    let (_, coordinator, _) = await createTestSetup()
+
+    coordinator.startRestPeriod()
+
+    // Should not throw FlowError.missingPrimaryEmotion despite no primary.
+    try await coordinator.submit()
+  }
+
+  @Test("reset clears rest entry type back to emotion")
+  func reset_clearsRestEntryType() async {
+    let (_, coordinator, _) = await createTestSetup()
+
+    coordinator.startRestPeriod()
+    coordinator.reset()
+
+    #expect(coordinator.entryType == EntryType.emotion)
+    #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
+  }
+
   // MARK: - Cancellation Tests
 
   @Test("cancel resets to idle state and clears selections")


### PR DESCRIPTION
## Summary
The live `FlowCoordinator` flow only supported emotion entries. Rest-period logging lived only in the orphaned `JournalFlowViewModel` (removed in #375), so it was unreachable in the app. This re-introduces it on the live FlowCoordinator path, satisfying #299's "Entry type selection" and "Rest period flow works: entry type → submit" ACs.

- **FlowCoordinator**: new `entryType` + `startRestPeriod()` which skips emotion/secondary/strategy selection and jumps straight to `.review`. `submit()` branches to a rest submission (no primary-emotion guard); `reset()` restores `.emotion`.
- **ContentViewModel**: new `journalRestThrowing(initiatedBy:)`, mirroring `journalThrowing` but calling the existing `JournalClient.submitRestPeriod`.
- **FlowReviewSheet**: renders a supportive `RestPeriodHeader` (moon icon + "honoring rest" copy) instead of emotion/strategy cards when the entry is a rest period. Submit/cancel/alert logic is unchanged because `submit()` branches internally.
- **MenuView**: new "Honoring Rest" action beside "Log Emotion"; needs no catalog and opens the review sheet directly.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass, including 5 new FlowCoordinator rest tests + a ContentViewModel rest test (TDD: written failing first)
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] Visual (cannot run simulator visually here): confirm the menu "Honoring Rest" tap dismisses the menu sheet and presents the rest review sheet cleanly, and that success/cancel reset `entryType` to `.emotion`

### Notes for reviewer
- The rest button sets `currentStep = .review` while dismissing the menu sheet; both sheets are independent `.sheet` modifiers on the same parent (`MainContentDialogsModifier`), so this is state-driven. Flagging the sheet transition for visual confirmation since I can't run the simulator here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)