### PR TITLE
refactor(journal): tokenize remaining inline colors in flow views (#299)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
@@ -38,6 +38,12 @@ enum WLColorTokens {
   /// Elevated card fill (for review sheets, etc.)
   static let elevatedCardFill = Color.secondary.opacity(0.1)
 
+  // MARK: - Semantic Accents
+
+  /// Accent for rest-period UI (calm/contraction). Distinct from the
+  /// "Purple" layer color even though both currently resolve to `.purple`.
+  static let restAccent: Color = .purple
+
   // MARK: - Text Colors
 
   static let primaryText: Color = .white
@@ -70,6 +76,19 @@ enum WLColorTokens {
         color.opacity(surfaceOpacityMedium),
         color.opacity(surfaceOpacityLow),
       ]),
+      startPoint: .topLeading,
+      endPoint: .bottomTrailing
+    )
+  }
+
+  /// Celebratory tint for the primary journal-submit action. Renders a
+  /// muted gray while a submission is in flight and the blue→purple→indigo
+  /// flourish otherwise.
+  static func submitButtonGradient(isSubmitting: Bool) -> LinearGradient {
+    LinearGradient(
+      colors: isSubmitting
+        ? [Color.gray.opacity(0.6), Color.gray.opacity(0.4)]
+        : [Color.blue.opacity(0.8), restAccent.opacity(0.6), Color.indigo.opacity(0.7)],
       startPoint: .topLeading,
       endPoint: .bottomTrailing
     )

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -57,15 +57,7 @@ struct FlowReviewSheet: View {
           }
           .disabled(isSubmitting)
           .buttonStyle(.borderedProminent)
-          .tint(
-            LinearGradient(
-              colors: isSubmitting
-                ? [Color.gray.opacity(0.6), Color.gray.opacity(0.4)]
-                : [Color.blue.opacity(0.8), Color.purple.opacity(0.6), Color.indigo.opacity(0.7)],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
+          .tint(WLColorTokens.submitButtonGradient(isSubmitting: isSubmitting))
           .frame(maxWidth: .infinity)
         }
         .padding()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
@@ -8,7 +8,7 @@ struct RestPeriodHeader: View {
     VStack(spacing: 8) {
       Image(systemName: "moon.zzz.fill")
         .font(.system(size: 36))
-        .foregroundStyle(.purple.opacity(0.8))
+        .foregroundStyle(WLColorTokens.restAccent.opacity(0.8))
         .accessibilityHidden(true)
 
       Text("Your natural rhythm may be asking you to rest")
@@ -21,7 +21,7 @@ struct RestPeriodHeader: View {
     .frame(maxWidth: .infinity)
     .background(
       RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
-        .fill(Color.purple.opacity(0.1))
+        .fill(WLColorTokens.restAccent.opacity(0.1))
     )
   }
 }


### PR DESCRIPTION
## Summary
Closes the last #299 acceptance criterion — "all flow views use the Liquid Glass design system from Phase 1b" — by moving the remaining inline colors in the live journal flow into `WLColorTokens`, per the documented convention ("Views should reference these tokens instead of constructing colors inline").

- `WLColorTokens.submitButtonGradient(isSubmitting:)` — the celebratory submit tint, preserving the existing blue→purple→indigo flourish and the gray in-flight state. `FlowReviewSheet` now references it instead of an inline `LinearGradient`.
- `WLColorTokens.restAccent` — semantic accent for rest UI (resolves to `.purple`, kept distinct from the "Purple" layer color). `RestPeriodHeader` uses it for the icon and background tint.

No visual change — the gradient and rest-header colors render identically; only their source moved into tokens. After this, `FlowReviewSheet` and `RestPeriodHeader` have no remaining inline raw colors, and the system alerts (confirmation/feedback) use unstyled system presentation by design.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Grep confirms no remaining `Color.`/inline `LinearGradient` in the live flow views

🤖 Generated with [Claude Code](https://claude.com/claude-code)