### PR TITLE
refactor(settings): Liquid Glass grouped Form for SyncSettingsView (#300)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
@@ -44,6 +44,12 @@ enum WLColorTokens {
   /// "Purple" layer color even though both currently resolve to `.purple`.
   static let restAccent: Color = .purple
 
+  /// Accent for cloud-sync / backup affordances.
+  static let syncAccent: Color = .blue
+
+  /// Accent for privacy / local-only affordances.
+  static let privacyAccent: Color = .green
+
   // MARK: - Text Colors
 
   static let primaryText: Color = .white

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/SyncSettingsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/SyncSettingsView.swift
@@ -17,59 +17,66 @@ struct SyncSettingsView: View {
   @ObservedObject var viewModel: SyncSettingsViewModel
   @Environment(\.dismiss) private var dismiss
 
+  /// Accent for the active mode: blue when cloud sync is on, green when
+  /// the journal stays local-only.
+  private var accent: Color {
+    viewModel.cloudSyncEnabled ? WLColorTokens.syncAccent : WLColorTokens.privacyAccent
+  }
+
   var body: some View {
-    ScrollView {
-      VStack(spacing: 16) {
+    Form {
+      Section {
         VStack(spacing: 8) {
           Image(systemName: viewModel.cloudSyncEnabled ? "icloud.fill" : "lock.shield.fill")
             .font(.system(size: 40))
-            .foregroundColor(viewModel.cloudSyncEnabled ? .blue : .green)
+            .foregroundStyle(accent)
+            .accessibilityHidden(true)
 
           Text(viewModel.cloudSyncEnabled ? "Cloud Backup" : "Privacy First")
             .font(.headline)
         }
+        .frame(maxWidth: .infinity)
+        .listRowBackground(Color.clear)
+      }
 
+      Section {
         Toggle("Sync to Cloud", isOn: $viewModel.cloudSyncEnabled)
           .accessibilityLabel("Cloud sync toggle")
-
-        VStack(spacing: 12) {
-          if viewModel.cloudSyncEnabled {
-            privacyExplanation(
-              icon: "checkmark.circle.fill",
-              color: .blue,
-              title: "Cloud Backup Active",
-              description: "Your journal entries are backed up to the cloud for safe keeping and future device transfers."
-            )
-            privacyExplanation(
-              icon: "lock.fill",
-              color: .blue,
-              title: "Your Data",
-              description: "Entries are associated with your device ID, not your Apple ID. Data is used for anonymized analytics aggregation."
-            )
-          } else {
-            privacyExplanation(
-              icon: "lock.shield.fill",
-              color: .green,
-              title: "Complete Privacy",
-              description: "Your journal stays on this watch. No data transmission, complete privacy."
-            )
-            privacyExplanation(
-              icon: "checkmark.circle.fill",
-              color: .green,
-              title: "Analytics Work Offline",
-              description: "All insights and analytics are computed locally on your device."
-            )
-          }
-        }
-
+      } footer: {
         Text("You can change this anytime")
-          .font(.caption2)
-          .foregroundColor(.secondary)
-          .multilineTextAlignment(.center)
-
-        Spacer()
+          .font(WLTypographyTokens.tag)
+          .foregroundStyle(.secondary)
       }
-      .padding()
+
+      Section {
+        if viewModel.cloudSyncEnabled {
+          privacyExplanation(
+            icon: "checkmark.circle.fill",
+            color: WLColorTokens.syncAccent,
+            title: "Cloud Backup Active",
+            description: "Your journal entries are backed up to the cloud for safe keeping and future device transfers."
+          )
+          privacyExplanation(
+            icon: "lock.fill",
+            color: WLColorTokens.syncAccent,
+            title: "Your Data",
+            description: "Entries are associated with your device ID, not your Apple ID. Data is used for anonymized analytics aggregation."
+          )
+        } else {
+          privacyExplanation(
+            icon: "lock.shield.fill",
+            color: WLColorTokens.privacyAccent,
+            title: "Complete Privacy",
+            description: "Your journal stays on this watch. No data transmission, complete privacy."
+          )
+          privacyExplanation(
+            icon: "checkmark.circle.fill",
+            color: WLColorTokens.privacyAccent,
+            title: "Analytics Work Offline",
+            description: "All insights and analytics are computed locally on your device."
+          )
+        }
+      }
     }
     .navigationTitle("Sync Settings")
     .navigationBarTitleDisplayMode(.inline)
@@ -78,9 +85,10 @@ struct SyncSettingsView: View {
   private func privacyExplanation(icon: String, color: Color, title: String, description: String) -> some View {
     HStack(alignment: .top, spacing: 8) {
       Image(systemName: icon)
-        .foregroundColor(color)
+        .foregroundStyle(color)
         .font(.caption)
         .frame(width: 16)
+        .accessibilityHidden(true)
 
       VStack(alignment: .leading, spacing: 2) {
         Text(title)
@@ -89,7 +97,7 @@ struct SyncSettingsView: View {
 
         Text(description)
           .font(.caption2)
-          .foregroundColor(.secondary)
+          .foregroundStyle(.secondary)
       }
     }
   }


### PR DESCRIPTION
## Summary
First slice of Phase 5 (#300). Rebuilds `SyncSettingsView` on a grouped SwiftUI `Form` (per the AC "all forms use Liquid Glass grouped style") instead of a bare `ScrollView` + `VStack`:

- Header (icon + mode title), the cloud-sync `Toggle`, and the privacy explanations now live in distinct `Form` sections; the "you can change this anytime" line becomes the toggle section's footer.
- Adds semantic `WLColorTokens.syncAccent` (blue) / `privacyAccent` (green) tokens and uses them instead of hardcoded `.blue`/`.green`. Decorative icons are `accessibilityHidden`.
- `foregroundColor` → `foregroundStyle` throughout.
- No service or behavior changes; the toggle still binds to `SyncSettingsViewModel.cloudSyncEnabled`, and existing `SyncSettingsTests` pass unchanged.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] **Visual (cannot run simulator here):** confirm the grouped Form renders well on-watch — the centered icon/title header in its own section, the toggle section + footer, and the explanation rows. Flagging because this is a structural layout change I can't visually verify in this environment.

> Note: this slice was briefly committed to `main` by mistake and immediately reverted (commit `88b2373`); it now lands properly via this PR for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)