### PR TITLE
refactor(schedule): tokenize colors in schedule views (#300)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
@@ -50,6 +50,10 @@ enum WLColorTokens {
   /// Accent for privacy / local-only affordances.
   static let privacyAccent: Color = .green
 
+  /// Accent for generic interactive affordances (action buttons, selected
+  /// checkmarks, editable values).
+  static let interactiveAccent: Color = .blue
+
   // MARK: - Text Colors
 
   static let primaryText: Color = .white

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Schedule/ScheduleEditView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Schedule/ScheduleEditView.swift
@@ -44,10 +44,10 @@ struct ScheduleEditView: View {
         } label: {
           HStack {
             Text("Set Time")
-              .foregroundColor(.primary)
+              .foregroundStyle(.primary)
             Spacer()
             Text(timeString)
-              .foregroundColor(.blue)
+              .foregroundStyle(WLColorTokens.interactiveAccent)
           }
         }
       } header: {
@@ -62,11 +62,11 @@ struct ScheduleEditView: View {
           } label: {
             HStack {
               Text(dayName(day))
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
               Spacer()
               if selectedDays.contains(day) {
                 Image(systemName: "checkmark")
-                  .foregroundColor(.blue)
+                  .foregroundStyle(WLColorTokens.interactiveAccent)
               }
             }
           }
@@ -79,7 +79,7 @@ struct ScheduleEditView: View {
       Button("Save") {
         saveSchedule()
       }
-      .foregroundColor(.blue)
+      .foregroundStyle(WLColorTokens.interactiveAccent)
     }
     .navigationTitle(schedule == nil ? "New Schedule" : "Edit Schedule")
     .navigationBarTitleDisplayMode(.inline)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Schedule/ScheduleRow.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Schedule/ScheduleRow.swift
@@ -23,7 +23,7 @@ struct ScheduleRow: View {
           .font(.headline)
         Text(daysString)
           .font(.caption)
-          .foregroundColor(.secondary)
+          .foregroundStyle(.secondary)
       }
 
       Spacer()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Schedule/TimePickerView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Schedule/TimePickerView.swift
@@ -28,7 +28,7 @@ struct TimePickerView: View {
         Button("Done") {
           dismiss()
         }
-        .foregroundColor(.blue)
+        .foregroundStyle(WLColorTokens.interactiveAccent)
         .padding(.bottom)
       }
       .toolbar {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/ScheduleSettingsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/ScheduleSettingsView.swift
@@ -40,14 +40,14 @@ struct ScheduleSettingsView: View {
       } header: {
         Text("Journal Prompts")
           .font(.caption)
-          .foregroundColor(WLColorTokens.secondaryText)
+          .foregroundStyle(WLColorTokens.secondaryText)
       }
 
       Button {
         showingAddSchedule = true
       } label: {
         Label("Add Schedule", systemImage: "plus.circle.fill")
-          .foregroundColor(.blue)
+          .foregroundStyle(WLColorTokens.interactiveAccent)
       }
     }
     .navigationTitle("Schedules")


### PR DESCRIPTION
## Summary
Second Phase 5 (#300) slice — brings the schedule surface into design-token compliance. `ScheduleEditView` already uses a grouped `Form`, so the remaining gap was inline accent colors and the legacy `foregroundColor` API.

- Adds `WLColorTokens.interactiveAccent` for action/selection accents.
- Replaces inline `.blue` (Add Schedule, Set Time value, day checkmark, Save, Done) with the token; keeps `.primary`/`.secondary` system semantics.
- `foregroundColor` → `foregroundStyle` across `ScheduleSettingsView`, `ScheduleEditView`, `ScheduleRow`, `TimePickerView`.

**Visual-neutral:** `interactiveAccent` resolves to the same blue, and `foregroundStyle` renders solid colors identically — so this is a token/API migration with no intended visual change. No service or behavior changes; `ScheduleViewModel` wiring is untouched and `ScheduleViewModelTests` pass.

> Adopting the Liquid Glass button styles (`wlPrimaryButtonStyle`/`.glass`) for the Save/Done/Add actions is deferred to a follow-up, since that is a real visual change better iterated with the simulator.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Visual-neutral by construction (same color values, equivalent API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)