### PR TITLE
refactor(onboarding): Liquid Glass primary button + a11y/API cleanup (#300)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/OnboardingView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/OnboardingView.swift
@@ -73,7 +73,7 @@ struct OnboardingView: View {
 
         Text("How would you like to store your journal?")
           .font(.caption)
-          .foregroundColor(.secondary)
+          .foregroundStyle(.secondary)
           .multilineTextAlignment(.center)
           .accessibilityIdentifier("onboarding_storage_question")
 
@@ -87,16 +87,15 @@ struct OnboardingView: View {
           completeOnboarding()
         } label: {
           Text("Continue")
-            .font(.headline)
             .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.borderedProminent)
+        .wlPrimaryButtonStyle()
         .accessibilityLabel("Continue with selected storage mode")
         .accessibilityIdentifier("onboarding_continue_button")
 
         Text("You can change this anytime in Settings")
           .font(.caption2)
-          .foregroundColor(.secondary)
+          .foregroundStyle(.secondary)
           .multilineTextAlignment(.center)
           .accessibilityIdentifier("onboarding_settings_hint")
       }
@@ -111,17 +110,18 @@ struct OnboardingView: View {
       HStack(spacing: 12) {
         Image(systemName: mode.icon)
           .font(.title2)
-          .foregroundColor(selectedMode == mode ? .accentColor : .secondary)
+          .foregroundStyle(selectedMode == mode ? Color.accentColor : .secondary)
           .frame(width: 30)
+          .accessibilityHidden(true)
 
         VStack(alignment: .leading, spacing: 4) {
           Text(mode.title)
             .font(.headline)
-            .foregroundColor(.primary)
+            .foregroundStyle(.primary)
 
           Text(mode.description)
             .font(.caption2)
-            .foregroundColor(.secondary)
+            .foregroundStyle(.secondary)
             .multilineTextAlignment(.leading)
         }
 
@@ -129,10 +129,12 @@ struct OnboardingView: View {
 
         if selectedMode == mode {
           Image(systemName: "checkmark.circle.fill")
-            .foregroundColor(.accentColor)
+            .foregroundStyle(Color.accentColor)
+            .accessibilityHidden(true)
         } else {
           Image(systemName: "circle")
-            .foregroundColor(.secondary)
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
         }
       }
       .padding(12)


### PR DESCRIPTION
## Summary
Third Phase 5 (#300) slice — brings `OnboardingView` up to the Liquid Glass / design-system bar.

- Adopts the Liquid Glass primary button style (`wlPrimaryButtonStyle` → `.glassProminent` on watchOS 26, `WLPrimaryButtonStyle` fallback) on the "Continue" CTA, replacing `.borderedProminent`. This is the first real adoption of the design system's primary button style.
- Modernizes `foregroundColor` → `foregroundStyle` throughout; keeps the semantic `.accentColor` / `.primary` / `.secondary` roles (already themeable — not hardcoded literals, so left as-is).
- `accessibilityHidden` on the decorative storage-option icons and the selection indicator, so VoiceOver reads only each option's button label.

No behavior change — onboarding still persists the storage choice via `SyncSettingsViewModel.completeOnboarding()`.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass, **including `OnboardingViewUITests`** (confirms the Continue button still renders, is tappable, and dismisses)
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] **Visual (cannot run simulator here):** confirm the Continue button's Liquid Glass prominent styling looks right on-watch (the one visual change; functionally verified by UI tests).

> Note: onboarding intentionally keeps its custom storage-option selection cards rather than a grouped `Form` — it's a welcome/choice screen, not a settings form. The grouped-`Form` AC applies to the sync/schedule settings forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)