### PR TITLE
refactor(sync): tokenize status colors in SyncStatusView (#300)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
@@ -54,6 +54,12 @@ enum WLColorTokens {
   /// checkmarks, editable values).
   static let interactiveAccent: Color = .blue
 
+  /// Positive status (online, sync succeeded).
+  static let statusPositive: Color = .green
+
+  /// Negative status (offline, sync failed).
+  static let statusNegative: Color = .red
+
   // MARK: - Text Colors
 
   static let primaryText: Color = .white

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/SyncStatusView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/SyncStatusView.swift
@@ -17,12 +17,14 @@ struct SyncStatusView: View {
       Section("Network") {
         HStack {
           Image(systemName: networkMonitor.isConnected ? "wifi" : "wifi.slash")
-            .foregroundColor(networkMonitor.isConnected ? .green : .red)
+            .foregroundStyle(networkMonitor.isConnected ? WLColorTokens.statusPositive : WLColorTokens.statusNegative)
+            .accessibilityHidden(true)
           Text(networkMonitor.isConnected ? "Online" : "Offline")
           Spacer()
           Circle()
-            .fill(networkMonitor.isConnected ? Color.green : Color.red)
+            .fill(networkMonitor.isConnected ? WLColorTokens.statusPositive : WLColorTokens.statusNegative)
             .frame(width: 8, height: 8)
+            .accessibilityHidden(true)
         }
       }
 
@@ -31,7 +33,7 @@ struct SyncStatusView: View {
           Text("Pending Entries")
           Spacer()
           Text("\(queue.pendingCount)")
-            .foregroundColor(.secondary)
+            .foregroundStyle(.secondary)
             .monospacedDigit()
         }
 
@@ -41,7 +43,7 @@ struct SyncStatusView: View {
               .progressViewStyle(.linear)
             Text("\(Int(progress * 100))%")
               .font(.caption2)
-              .foregroundColor(.secondary)
+              .foregroundStyle(.secondary)
               .monospacedDigit()
           }
         } else if syncService.isSyncing {
@@ -70,13 +72,14 @@ struct SyncStatusView: View {
         Section("Last Error") {
           Text(manualSyncError)
             .font(.caption)
-            .foregroundColor(.red)
+            .foregroundStyle(WLColorTokens.statusNegative)
         }
       } else if case let .success(count) = syncService.syncStatus, count > 0 {
         Section("Last Sync") {
           HStack {
             Image(systemName: "checkmark.circle.fill")
-              .foregroundColor(.green)
+              .foregroundStyle(WLColorTokens.statusPositive)
+              .accessibilityHidden(true)
             Text("Synced \(count) entr\(count == 1 ? "y" : "ies")")
               .font(.caption)
           }


### PR DESCRIPTION
## Summary
Final main Phase 5 (#300) slice — brings `SyncStatusView` into design-token compliance.

- Adds `WLColorTokens.statusPositive` (green) / `statusNegative` (red) for online/offline and sync success/failure states.
- Routes the inline `.green`/`.red` through the tokens and modernizes `foregroundColor` → `foregroundStyle`.
- `accessibilityHidden` on the decorative status glyphs (wifi icon, connectivity dot, success checkmark) — the adjacent text ("Online"/"Offline", "Synced N entries") already conveys the state.

**Visual-neutral** (tokens resolve to the same green/red). Keeps the grouped `List` — this is a read-only status display, not an input form, so the grouped-`Form` AC doesn't apply here. No service or behavior changes; still observes `JournalQueue`/`JournalSyncService`/`NetworkMonitor`.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Visual-neutral by construction (same colors, equivalent API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)