### PR TITLE
ci: dedupe PR runs and retry watchOS simulator launch flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,19 @@
 name: CI
 
 on:
+  # Run on direct pushes to main and on every PR. Restricting push to main
+  # (rather than "**") stops PR branches from spawning a duplicate run for the
+  # same commit — one via push, one via pull_request — which doubled cost and
+  # flake exposure and produced an ambiguous mixed check status.
   push:
-    branches: [ "**" ]
+    branches: [ main ]
   pull_request:
     branches: [ "**" ]
+
+# Cancel superseded runs for the same ref so rapid pushes don't pile up.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -110,10 +119,23 @@ jobs:
         run: swiftformat --lint frontend
 
       - name: Build and test watchOS app
-        timeout-minutes: 25
+        timeout-minutes: 35
         run: |
           cd frontend/WavelengthWatch
-          # Clean simulator state to prevent "termination assertions" errors
-          xcrun simctl shutdown all || true
-          xcrun simctl erase all || true
-          ./run-tests-individually.sh
+          # The watchOS simulator intermittently refuses to launch the app with
+          # "Application has termination assertions" (FBSOpenApplicationServiceErrorDomain),
+          # an infrastructure flake unrelated to the build. Reset simulator state
+          # and retry once before declaring failure.
+          for attempt in 1 2; do
+            echo "::group::watchOS test attempt $attempt"
+            xcrun simctl shutdown all || true
+            xcrun simctl erase all || true
+            if ./run-tests-individually.sh; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Attempt $attempt failed; resetting simulator and retrying."
+          done
+          echo "watchOS tests failed after 2 attempts."
+          exit 1


### PR DESCRIPTION
## Summary
Two CI reliability fixes prompted by repeated `FBSOpenApplicationServiceErrorDomain` ("Application has termination assertions") failures on otherwise-green PRs (#379, #381), and the long-standing duplicate-run behavior.

1. **Dedupe runs.** `push` now triggers only on `main` (was `"**"`). PR branch pushes were spawning two identical runs for the same commit — one via `push`, one via `pull_request` — which doubled cost, doubled flake exposure, and left the same required check (`Frontend (watchOS) - format & build`) reporting a mixed SUCCESS/FAILURE status that blocked clean merges. Added a `concurrency` group with `cancel-in-progress` so rapid pushes cancel superseded runs.
2. **Retry the simulator flake.** The watchOS build-and-test step now resets simulator state and retries once before failing. The build itself succeeds; the flake is purely the simulator refusing to launch the app. Step timeout bumped 25m → 35m to accommodate a second pass.

This PR should itself receive a single CI run (pull_request only) exercising the new retry logic.

## Test plan
- [x] `pre-commit run --all-files` — YAML check passes; `ci.yml` is valid YAML
- [x] No change to build/test logic — only workflow triggers, concurrency, and a retry wrapper around the existing `run-tests-individually.sh` invocation
- [ ] Observe on this PR: exactly one CI run (not two), and the frontend step retries rather than hard-failing on a simulator launch flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)