### PR TITLE
test(journal): cover FlowSubmissionPresenter feedback + reset logic (#301)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowSubmissionPresenterTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowSubmissionPresenterTests.swift
@@ -47,11 +47,12 @@ struct FlowSubmissionPresenterTests {
     await presenter.submit(failurePrefix: "Failed to log emotion")
 
     if case .queued = viewModel.journalFeedback?.kind {
-      #expect(Bool(true))
+      // Reaching this branch is the assertion.
     } else {
-      #expect(Bool(false), "Expected queued feedback")
+      Issue.record("Expected queued feedback, got \(String(describing: viewModel.journalFeedback?.kind))")
     }
     #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
+    #expect(coordinator.selections.primary == nil)
   }
 
   @Test("failed submit shows prefixed failure feedback and preserves state for retry")
@@ -64,7 +65,7 @@ struct FlowSubmissionPresenterTests {
     if case let .failure(message) = viewModel.journalFeedback?.kind {
       #expect(message.contains("Failed to log emotion"))
     } else {
-      #expect(Bool(false), "Expected failure feedback")
+      Issue.record("Expected failure feedback, got \(String(describing: viewModel.journalFeedback?.kind))")
     }
     // On unrecoverable failure the flow is NOT reset, so the user can retry.
     #expect(coordinator.currentStep != FlowCoordinator.FlowStep.idle)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowSubmissionPresenterTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowSubmissionPresenterTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Tests for FlowSubmissionPresenter — the seam that turns a flow submission
+/// into user-visible feedback and decides whether to reset the flow.
+@MainActor
+struct FlowSubmissionPresenterTests {
+  private func makeSetup(
+    shouldQueue: Bool = false,
+    shouldFail: Bool = false
+  ) async -> (ContentViewModel, FlowCoordinator) {
+    let catalog = CatalogTestHelper.createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let journalClient = JournalClientMock()
+    journalClient.shouldQueue = shouldQueue
+    journalClient.shouldFail = shouldFail
+    let viewModel = ContentViewModel(
+      catalogRepository: repository,
+      journalRepository: InMemoryJournalRepository(),
+      journalClient: journalClient
+    )
+    await viewModel.loadCatalog()
+    let coordinator = FlowCoordinator(contentViewModel: viewModel)
+    // Put the flow in a submittable state with a primary emotion selected.
+    let primary = catalog.layers[1].phases[0].medicinal[0]
+    coordinator.startPrimarySelection()
+    coordinator.capturePrimary(primary)
+    return (viewModel, coordinator)
+  }
+
+  @Test("successful submit resets the flow to idle")
+  func submit_success_resetsFlow() async {
+    let (viewModel, coordinator) = await makeSetup()
+    let presenter = FlowSubmissionPresenter(flowCoordinator: coordinator, viewModel: viewModel)
+
+    await presenter.submit(failurePrefix: "Failed to log emotion")
+
+    #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
+    #expect(coordinator.selections.primary == nil)
+  }
+
+  @Test("queued submit shows queued feedback and resets the flow")
+  func submit_queued_showsQueuedFeedbackAndResets() async {
+    let (viewModel, coordinator) = await makeSetup(shouldQueue: true)
+    let presenter = FlowSubmissionPresenter(flowCoordinator: coordinator, viewModel: viewModel)
+
+    await presenter.submit(failurePrefix: "Failed to log emotion")
+
+    if case .queued = viewModel.journalFeedback?.kind {
+      #expect(Bool(true))
+    } else {
+      #expect(Bool(false), "Expected queued feedback")
+    }
+    #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
+  }
+
+  @Test("failed submit shows prefixed failure feedback and preserves state for retry")
+  func submit_failure_showsFailureAndPreservesState() async {
+    let (viewModel, coordinator) = await makeSetup(shouldFail: true)
+    let presenter = FlowSubmissionPresenter(flowCoordinator: coordinator, viewModel: viewModel)
+
+    await presenter.submit(failurePrefix: "Failed to log emotion")
+
+    if case let .failure(message) = viewModel.journalFeedback?.kind {
+      #expect(message.contains("Failed to log emotion"))
+    } else {
+      #expect(Bool(false), "Expected failure feedback")
+    }
+    // On unrecoverable failure the flow is NOT reset, so the user can retry.
+    #expect(coordinator.currentStep != FlowCoordinator.FlowStep.idle)
+    #expect(coordinator.selections.primary != nil)
+  }
+}


### PR DESCRIPTION
## Summary
`FlowSubmissionPresenter` (the seam that turns a flow submission into user-visible feedback and decides whether to reset the flow) was the one flow ViewModel without dedicated tests. This covers its three branches via `JournalClientMock`:

- **success** → flow resets to `.idle`
- **`queuedForRetry`** → queued feedback shown, flow resets
- **failure** → prefixed failure feedback, flow state preserved (not reset) so the user can retry

Final logic-coverage slice for #301 per the agreed approach (cover views/components/ViewModels with genuine testable logic; the project deliberately uses no ViewInspector/XCUITest, so view internals stay shallow construction tests).

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Test-only addition; no production changes