### PR TITLE
a11y(curriculum): expose tap-to-log cards as VoiceOver buttons (#302)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -69,6 +69,12 @@ struct ClearLightEmotionCard: View {
     } message: {
       Text("Would you like to log \"\(emotion.entry.expression)\"?")
     }
+    // Tapped via onTapGesture; expose as one labeled VoiceOver button.
+    .accessibilityElement(children: .ignore)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityLabel("\(dosageType == .medicinal ? "Medicinal" : "Toxic"): \(emotion.entry.expression), \(emotion.layerTitle)")
+    .accessibilityHint("Logs this entry")
+    .accessibilityAction { showingJournalConfirmation = true }
   }
 
   private func handleLogAction() {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
@@ -55,6 +55,13 @@ struct CurriculumCard: View {
     } message: {
       Text("Would you like to log \"\(expression)\"?")
     }
+    // The card is tapped via onTapGesture, which SwiftUI does not expose as a
+    // VoiceOver action; present it as one labeled button instead.
+    .accessibilityElement(children: .ignore)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityLabel("\(title): \(expression)")
+    .accessibilityHint("Logs this entry")
+    .accessibilityAction { showingJournalConfirmation = true }
   }
 
   private func handleLogAction() {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
@@ -12,6 +12,12 @@ struct StrategyCard: View {
     phase.medicinal.first?.id ?? phase.toxic.first?.id
   }
 
+  /// Whether tapping logs anything: either a curriculum entry exists to log
+  /// the strategy against, or we're inside the strategy-selection flow.
+  private var isActionable: Bool {
+    primaryID != nil || flowCoordinator.currentStep == .selectingStrategy
+  }
+
   var body: some View {
     ZStack(alignment: .topTrailing) {
       HStack {
@@ -31,12 +37,12 @@ struct StrategyCard: View {
           .fill(WLColorTokens.cardFill(tinted: color))
       )
       .onTapGesture {
-        if primaryID != nil || flowCoordinator.currentStep == .selectingStrategy {
+        if isActionable {
           showingJournalConfirmation = true
         }
       }
 
-      if primaryID != nil || flowCoordinator.currentStep == .selectingStrategy {
+      if isActionable {
         MysticalJournalIcon(color: color)
           .padding(.top, 6)
           .padding(.trailing, 8)
@@ -53,16 +59,16 @@ struct StrategyCard: View {
     } message: {
       Text("Would you like to log \"\(strategy.strategy)\"?")
     }
-    // Tapped via onTapGesture; expose as one labeled VoiceOver button whose
-    // action mirrors the tap's actionable guard.
+    // Tapped via onTapGesture; expose as one labeled VoiceOver element. Only
+    // advertise the button trait / action when a tap would actually log
+    // something, so VoiceOver never announces a dead button.
     .accessibilityElement(children: .ignore)
-    .accessibilityAddTraits(.isButton)
     .accessibilityLabel("Strategy: \(strategy.strategy)")
-    .accessibilityHint("Logs this strategy")
+    .accessibilityAddTraits(isActionable ? .isButton : [])
+    .accessibilityHint(isActionable ? "Logs this strategy" : "")
     .accessibilityAction {
-      if primaryID != nil || flowCoordinator.currentStep == .selectingStrategy {
-        showingJournalConfirmation = true
-      }
+      guard isActionable else { return }
+      showingJournalConfirmation = true
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
@@ -53,6 +53,17 @@ struct StrategyCard: View {
     } message: {
       Text("Would you like to log \"\(strategy.strategy)\"?")
     }
+    // Tapped via onTapGesture; expose as one labeled VoiceOver button whose
+    // action mirrors the tap's actionable guard.
+    .accessibilityElement(children: .ignore)
+    .accessibilityAddTraits(.isButton)
+    .accessibilityLabel("Strategy: \(strategy.strategy)")
+    .accessibilityHint("Logs this strategy")
+    .accessibilityAction {
+      if primaryID != nil || flowCoordinator.currentStep == .selectingStrategy {
+        showingJournalConfirmation = true
+      }
+    }
   }
 
   private func handleLogAction() {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
@@ -78,17 +78,17 @@ struct StrategyListView: View {
                   }
               }
             }
-            // Tapped via onTapGesture; expose each row as one labeled
-            // VoiceOver button whose action mirrors the tap's guard.
+            // Tapped via onTapGesture; expose each row as one labeled VoiceOver
+            // element. Only advertise the button trait / action when a tap
+            // would log something, so VoiceOver never announces a dead button.
             .accessibilityElement(children: .ignore)
-            .accessibilityAddTraits(.isButton)
             .accessibilityLabel("Strategy: \(item.strategy)")
-            .accessibilityHint("Logs this strategy")
+            .accessibilityAddTraits(fallbackCurriculumID != nil ? .isButton : [])
+            .accessibilityHint(fallbackCurriculumID != nil ? "Logs this strategy" : "")
             .accessibilityAction {
-              if fallbackCurriculumID != nil {
-                selectedStrategy = item
-                showingJournalConfirmation = true
-              }
+              guard fallbackCurriculumID != nil else { return }
+              selectedStrategy = item
+              showingJournalConfirmation = true
             }
           }
         }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
@@ -78,6 +78,18 @@ struct StrategyListView: View {
                   }
               }
             }
+            // Tapped via onTapGesture; expose each row as one labeled
+            // VoiceOver button whose action mirrors the tap's guard.
+            .accessibilityElement(children: .ignore)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel("Strategy: \(item.strategy)")
+            .accessibilityHint("Logs this strategy")
+            .accessibilityAction {
+              if fallbackCurriculumID != nil {
+                selectedStrategy = item
+                showingJournalConfirmation = true
+              }
+            }
           }
         }
         .padding(.horizontal, 8)


### PR DESCRIPTION
## Summary
First Phase 6b (#302) accessibility slice, targeting the AC "VoiceOver: all interactive elements have accessibility labels."

The curriculum/strategy cards log via `onTapGesture`, which SwiftUI does **not** expose as a VoiceOver action — so VoiceOver users had no actionable element and no announced purpose. Each tappable card is now a single button-trait accessibility element with a curated label + hint and an `accessibilityAction` mirroring the tap (including the actionable guards on `StrategyCard` / `StrategyListView` rows; the decorative journal icon is absorbed via `children: .ignore`).

Covers `CurriculumCard`, `ClearLightEmotionCard`, `StrategyCard`, and `StrategyListView` rows. No visual change (accessibility modifiers only).

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — builds clean, all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] **On-device (needs your hardware):** confirm VoiceOver announces each card as a button with the label/hint and that double-tap triggers the log confirmation. I can't run VoiceOver in this environment.

> Scope note: this is the VoiceOver-labels portion of #302. Reduce-transparency, reduce-motion, Dynamic Type, backward-compat, and 60fps/Instruments validation are separate follow-up slices / on-device validation (#302 stays open pending your hardware sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)