### PR TITLE
a11y(motion): suppress decorative animation under Reduce Motion (#302)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLButtonStyle.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLButtonStyle.swift
@@ -26,7 +26,7 @@ struct WLPrimaryButtonStyle: ButtonStyle {
           .fill(tint.opacity(configuration.isPressed ? 0.5 : 0.8))
       )
       .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
-      .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+      .wlAnimation(.easeInOut(duration: 0.15), value: configuration.isPressed)
   }
 }
 
@@ -59,7 +59,7 @@ struct WLSecondaryButtonStyle: ButtonStyle {
           )
       )
       .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
-      .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+      .wlAnimation(.easeInOut(duration: 0.15), value: configuration.isPressed)
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLMotionModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLMotionModifier.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Applies an animation that is suppressed when the system "Reduce Motion"
+/// accessibility setting is on. Reads the environment itself, so call sites
+/// don't each need to declare `@Environment(\.accessibilityReduceMotion)`.
+private struct WLConditionalAnimation<V: Equatable>: ViewModifier {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  let animation: Animation?
+  let value: V
+
+  func body(content: Content) -> some View {
+    content.animation(reduceMotion ? nil : animation, value: value)
+  }
+}
+
+extension View {
+  /// Like `.animation(_:value:)`, but yields no animation when Reduce Motion
+  /// is enabled. Use for decorative / morphing motion that should respect the
+  /// accessibility setting.
+  func wlAnimation(_ animation: Animation?, value: some Equatable) -> some View {
+    modifier(WLConditionalAnimation(animation: animation, value: value))
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/MysticalJournalIcon.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/MysticalJournalIcon.swift
@@ -34,5 +34,11 @@ struct MysticalJournalIcon: View {
         isGlowing = true
       }
     }
+    // Stay reactive if Reduce Motion is toggled mid-session: snap to the
+    // static base when enabled (so the icon doesn't freeze mid-glow) and
+    // resume the loop when disabled.
+    .onChange(of: reduceMotion) { _, nowReducing in
+      isGlowing = !nowReducing
+    }
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/MysticalJournalIcon.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/MysticalJournalIcon.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MysticalJournalIcon: View {
   let color: Color
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var isGlowing = false
 
   var body: some View {
@@ -22,12 +23,16 @@ struct MysticalJournalIcon: View {
         .foregroundColor(color.opacity(isGlowing ? 0.9 : 0.6))
     }
     .scaleEffect(isGlowing ? 1.1 : 1.0)
-    .animation(
+    .wlAnimation(
       .easeInOut(duration: 1.5).repeatForever(autoreverses: true),
       value: isGlowing
     )
     .onAppear {
-      isGlowing = true
+      // Don't start the perpetual glow loop under Reduce Motion — leave the
+      // icon static at its base appearance.
+      if !reduceMotion {
+        isGlowing = true
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Second Phase 6b (#302) accessibility slice, targeting the AC "Reduced Motion: fluid morphing animations are suppressed."

- Adds a reusable `wlAnimation(_:value:)` view modifier (in `DesignSystem/Modifiers/WLMotionModifier.swift`) that drops the animation when the system Reduce Motion setting is on. It reads `@Environment(\.accessibilityReduceMotion)` itself, so call sites don't each need to declare it.
- `MysticalJournalIcon`: its perpetual `.repeatForever` glow loop is the worst-case continuous motion — now it doesn't start under Reduce Motion (icon stays static at its base appearance), and the scale animation routes through `wlAnimation`.
- `WLPrimaryButtonStyle` / `WLSecondaryButtonStyle`: the press-scale animation routes through `wlAnimation` (applied to the label, since a `ButtonStyle` can't read `@Environment` directly).

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — builds clean, all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] **On-device (needs your hardware):** with Reduce Motion on, confirm the journal `+` icon no longer pulses and button presses don't animate.

> Scope note: the navigation transition animations (`LayerScrollView`, `LayerView`, `LayerSideIndicator`, `LayerCardView`) are a follow-up to adopt the same helper — kept out of this PR to stay reviewable. Analytics animations (`CircularProgressView`, `HorizontalBarChart`) are out of scope (tracked under analytics/#373).

🤖 Generated with [Claude Code](https://claude.com/claude-code)