### PR TITLE
a11y(transparency): degrade translucent surfaces to opaque under Reduce Transparency (#302)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLGlassModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLGlassModifier.swift
@@ -20,6 +20,7 @@ struct WLGlassModifier: ViewModifier {
   let intensity: WLGlassIntensity
   let tint: Color?
   let cornerRadius: CGFloat
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
   init(
     intensity: WLGlassIntensity = .regular,
@@ -32,11 +33,30 @@ struct WLGlassModifier: ViewModifier {
   }
 
   func body(content: Content) -> some View {
-    if #available(watchOS 26, *) {
+    if reduceTransparency {
+      // "Reduce Transparency" on: skip glass/translucency entirely and use a
+      // solid, legible surface (Liquid Glass degrades to opaque).
+      applyOpaque(to: content)
+    } else if #available(watchOS 26, *) {
       applyGlass(to: content)
     } else {
       applyFallback(to: content)
     }
+  }
+
+  private func applyOpaque(to content: Content) -> some View {
+    content
+      .background(
+        RoundedRectangle(cornerRadius: cornerRadius)
+          .fill(WLColorTokens.opaqueSurface)
+          .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius)
+              .stroke(
+                (tint ?? Color.white).opacity(0.3),
+                lineWidth: WLSpacingTokens.cardBorderWidth
+              )
+          )
+      )
   }
 
   @available(watchOS 26, *)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLSurfaceModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLSurfaceModifier.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Card background that uses a translucent fill normally but a solid opaque
+/// surface when "Reduce Transparency" is enabled. Reads the environment itself
+/// so call sites don't each need `@Environment(\.accessibilityReduceTransparency)`.
+private struct WLCardSurface: ViewModifier {
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+  let translucentFill: Color
+  let cornerRadius: CGFloat
+
+  func body(content: Content) -> some View {
+    content.background(
+      RoundedRectangle(cornerRadius: cornerRadius)
+        .fill(reduceTransparency ? WLColorTokens.opaqueSurface : translucentFill)
+    )
+  }
+}
+
+extension View {
+  /// Applies a rounded card background that degrades from `translucentFill` to
+  /// a solid opaque surface under Reduce Transparency.
+  func wlCardSurface(_ translucentFill: Color, cornerRadius: CGFloat) -> some View {
+    modifier(WLCardSurface(translucentFill: translucentFill, cornerRadius: cornerRadius))
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
@@ -38,6 +38,10 @@ enum WLColorTokens {
   /// Elevated card fill (for review sheets, etc.)
   static let elevatedCardFill = Color.secondary.opacity(0.1)
 
+  /// Solid, fully opaque card surface used when the "Reduce Transparency"
+  /// accessibility setting is on, so translucent fills don't reduce legibility.
+  static let opaqueSurface = Color(white: 0.18)
+
   // MARK: - Semantic Accents
 
   /// Accent for rest-period UI (calm/contraction). Distinct from the

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/EmotionExpressionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/EmotionExpressionCard.swift
@@ -42,10 +42,7 @@ struct EmotionExpressionCard: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(WLSpacingTokens.cardPaddingStandard)
-    .background(
-      RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
-        .fill(WLColorTokens.cardFill)
-    )
+    .wlCardSurface(WLColorTokens.cardFill, cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
@@ -37,8 +37,7 @@ struct StrategyExpressionCard: View {
     }
     .padding(.vertical, 12)
     .padding(.horizontal, 16)
-    .background(WLColorTokens.elevatedCardFill)
-    .cornerRadius(10)
+    .wlCardSurface(WLColorTokens.elevatedCardFill, cornerRadius: 10)
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/RestPeriodHeader.swift
@@ -19,10 +19,7 @@ struct RestPeriodHeader: View {
     }
     .padding(.vertical, 12)
     .frame(maxWidth: .infinity)
-    .background(
-      RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
-        .fill(WLColorTokens.restAccent.opacity(0.1))
-    )
+    .wlCardSurface(WLColorTokens.restAccent.opacity(0.1), cornerRadius: WLSpacingTokens.cardCornerRadius)
   }
 }
 


### PR DESCRIPTION
## Summary
Third Phase 6b (#302) accessibility slice, implementing the AC "Reduced Transparency: Liquid Glass degrades to opaque backgrounds."

- Adds `WLColorTokens.opaqueSurface` (a solid card surface) and a reusable `wlCardSurface(_:cornerRadius:)` modifier that renders the given translucent fill normally but a solid opaque surface when Reduce Transparency is on. It reads `@Environment(\.accessibilityReduceTransparency)` itself, so call sites stay clean.
- `WLGlassModifier` now short-circuits to an opaque background when Reduce Transparency is enabled, rather than applying `glassEffect`/the translucent fallback.
- Migrates the journal-flow surfaces (`EmotionExpressionCard`, `StrategyExpressionCard`, `RestPeriodHeader`) to `wlCardSurface`. **Non-reduced appearance is unchanged** (same fills/radii); `StrategyExpressionCard` also sheds the deprecated `.cornerRadius` in the process.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — builds clean, all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] **On-device (needs your hardware):** with Reduce Transparency on, confirm the journal review/expression cards render with solid, legible backgrounds.

> Scope note: this covers the design-system primitive + the journal-flow card surfaces. The other custom translucent surfaces (`CurriculumCard` gradient, `StrategyCard`/`ClearLightEmotionCard`, navigation cards) are a follow-up to adopt `wlCardSurface`; system `Form`/`List` backgrounds (settings) are handled by the OS under Reduce Transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)