### PR TITLE
fix(analytics): AnalyticsViewModel respects cloud-sync setting (#187)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
@@ -24,6 +24,7 @@ final class AnalyticsViewModel: ObservableObject {
   private let localCalculator: LocalAnalyticsCalculatorProtocol?
   private let journalRepository: JournalRepositoryProtocol?
   private let catalogRepository: CatalogRepositoryProtocol?
+  private let syncSettings: SyncSettings
   private let userDefaults: UserDefaults
   private let userDefaultsKey = "com.wavelengthwatch.userIdentifier"
 
@@ -32,24 +33,38 @@ final class AnalyticsViewModel: ObservableObject {
     localCalculator: LocalAnalyticsCalculatorProtocol? = nil,
     journalRepository: JournalRepositoryProtocol? = nil,
     catalogRepository: CatalogRepositoryProtocol? = nil,
+    syncSettings: SyncSettings = SyncSettings(),
     userDefaults: UserDefaults = .standard
   ) {
     self.analyticsService = analyticsService
     self.localCalculator = localCalculator
     self.journalRepository = journalRepository
     self.catalogRepository = catalogRepository
+    self.syncSettings = syncSettings
     self.userDefaults = userDefaults
   }
 
-  /// Fetches analytics overview data from backend with local fallback.
+  /// Loads analytics overview, choosing the data source by the user's sync
+  /// preference (per #187: "analytics read from local SQLite DB — works for
+  /// both modes").
   ///
-  /// Strategy:
-  /// 1. Try backend first for fresh data
-  /// 2. If backend fails and local components available, calculate from local storage
-  /// 3. If both fail, report error
+  /// - Cloud sync **enabled**: try backend first, fall back to local on error.
+  /// - Cloud sync **disabled**: use the local calculator exclusively. Hitting
+  ///   the backend in local-only mode would return zero entries for this user
+  ///   (sync is off, nothing's there), making the screen appear empty even
+  ///   though local SQLite has the user's data.
   func loadAnalytics() async {
     state = .loading
 
+    if syncSettings.cloudSyncEnabled {
+      await loadWithBackendFallback()
+    } else {
+      await loadFromLocalOnly()
+    }
+  }
+
+  /// Loads from backend with fallback to local calculator on backend error.
+  private func loadWithBackendFallback() async {
     do {
       let userId = numericUserIdentifier()
       let overview = try await analyticsService.getOverview(userId: userId)
@@ -61,6 +76,15 @@ final class AnalyticsViewModel: ObservableObject {
       } else {
         state = .error("Failed to load analytics: \(error.localizedDescription)")
       }
+    }
+  }
+
+  /// Loads exclusively from the local calculator (cloud sync disabled mode).
+  private func loadFromLocalOnly() async {
+    if let localOverview = await tryLocalCalculation() {
+      state = .loaded(localOverview)
+    } else {
+      state = .error("Local analytics not available. Please enable cloud sync or try again later.")
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
@@ -1,14 +1,18 @@
 import Foundation
 
-/// View model for analytics overview screen.
+/// View model for the analytics overview screen.
 ///
-/// Fetches and manages analytics data from the backend with local fallback,
-/// handling loading states, errors, and empty data scenarios.
+/// Chooses its data source based on `SyncSettings.cloudSyncEnabled`
+/// (per #187: "analytics read from local SQLite DB — works for both modes"):
+/// - **Cloud sync on**: tries backend first, falls back to the local
+///   calculator on a thrown error.
+/// - **Cloud sync off**: reads exclusively from the local calculator.
+///   Hitting the backend in local-only mode would return an empty overview
+///   (nothing has been synced for this user), making the screen appear empty.
 ///
-/// ## Data Strategy
-/// - Tries backend first for fresh data
-/// - Falls back to local calculation if backend fails
-/// - Requires local calculator, journal repository, and catalog for offline support
+/// Note: `SyncSettings` is read at each `loadAnalytics()` call, not observed.
+/// If the user toggles sync while the screen is open, the new mode applies on
+/// the next load/retry.
 @MainActor
 final class AnalyticsViewModel: ObservableObject {
   enum LoadingState: Equatable {
@@ -84,7 +88,10 @@ final class AnalyticsViewModel: ObservableObject {
     if let localOverview = await tryLocalCalculation() {
       state = .loaded(localOverview)
     } else {
-      state = .error("Local analytics not available. Please enable cloud sync or try again later.")
+      // Reached only when the view is constructed without local components
+      // (a wiring bug, not user-facing). Avoid telling a user who deliberately
+      // disabled cloud sync to "enable cloud sync".
+      state = .error("Analytics are temporarily unavailable. Please try again later.")
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsView.swift
@@ -17,9 +17,11 @@ struct AnalyticsView: View {
   /// - Parameters:
   ///   - journalRepository: Repository for fetching local journal entries
   ///   - catalogRepository: Repository with cached catalog (required for offline analytics)
+  ///   - syncSettings: Cloud-sync preference; analytics use local data exclusively when sync is disabled
   init(
     journalRepository: JournalRepositoryProtocol,
-    catalogRepository: CatalogRepositoryProtocol
+    catalogRepository: CatalogRepositoryProtocol,
+    syncSettings: SyncSettings = SyncSettings()
   ) {
     self.journalRepository = journalRepository
     self.catalogRepository = catalogRepository
@@ -41,7 +43,8 @@ struct AnalyticsView: View {
         analyticsService: analyticsService,
         localCalculator: localCalculator,
         journalRepository: journalRepository,
-        catalogRepository: catalogRepository
+        catalogRepository: catalogRepository,
+        syncSettings: syncSettings
       )
     )
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -250,7 +250,7 @@ struct AnalyticsViewModelTests {
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
       syncSettings: cloudSyncOn(),
-      userDefaults: .standard
+      userDefaults: UserDefaults(suiteName: UUID().uuidString) ?? .standard
     )
 
     await viewModel.loadAnalytics()
@@ -612,7 +612,7 @@ struct AnalyticsViewModelTests {
     await viewModel.loadAnalytics()
 
     if case let .error(message) = viewModel.state {
-      #expect(message.contains("Local analytics not available"))
+      #expect(message.contains("temporarily unavailable"))
     } else {
       Issue.record("Expected error state, got \(viewModel.state)")
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -64,13 +64,30 @@ struct AnalyticsViewModelTests {
     }
   }
 
+  // MARK: - SyncSettings Helpers
+
+  /// SyncSettings backed by mock persistence with cloud sync enabled — so
+  /// tests exercising the backend path use this instead of polluting
+  /// UserDefaults.standard.
+  private func cloudSyncOn() -> SyncSettings {
+    let settings = SyncSettings(persistence: MockSyncSettingsPersistence())
+    settings.cloudSyncEnabled = true
+    return settings
+  }
+
+  /// SyncSettings backed by mock persistence with cloud sync disabled (the
+  /// privacy-first default).
+  private func cloudSyncOff() -> SyncSettings {
+    SyncSettings(persistence: MockSyncSettingsPersistence())
+  }
+
   // MARK: - Initialization Tests
 
   @Test("viewModel starts in idle state")
   @MainActor
   func viewModel_startsInIdleState() {
     let mockService = MockAnalyticsService()
-    let viewModel = AnalyticsViewModel(analyticsService: mockService)
+    let viewModel = AnalyticsViewModel(analyticsService: mockService, syncSettings: cloudSyncOn())
 
     #expect(viewModel.state == .idle)
   }
@@ -97,7 +114,7 @@ struct AnalyticsViewModelTests {
     )
     mockService.overviewToReturn = mockOverview
 
-    let viewModel = AnalyticsViewModel(analyticsService: mockService)
+    let viewModel = AnalyticsViewModel(analyticsService: mockService, syncSettings: cloudSyncOn())
 
     await viewModel.loadAnalytics()
 
@@ -115,7 +132,7 @@ struct AnalyticsViewModelTests {
     let mockService = MockAnalyticsService()
     mockService.errorToThrow = NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "Network error"])
 
-    let viewModel = AnalyticsViewModel(analyticsService: mockService)
+    let viewModel = AnalyticsViewModel(analyticsService: mockService, syncSettings: cloudSyncOn())
 
     await viewModel.loadAnalytics()
 
@@ -147,7 +164,7 @@ struct AnalyticsViewModelTests {
       secondaryEmotionsPct: 0
     )
 
-    let viewModel = AnalyticsViewModel(analyticsService: mockService)
+    let viewModel = AnalyticsViewModel(analyticsService: mockService, syncSettings: cloudSyncOn())
 
     // Start loading but don't await
     let task = Task {
@@ -177,7 +194,7 @@ struct AnalyticsViewModelTests {
     let mockService = MockAnalyticsService()
     mockService.errorToThrow = NSError(domain: "test", code: -1)
 
-    let viewModel = AnalyticsViewModel(analyticsService: mockService)
+    let viewModel = AnalyticsViewModel(analyticsService: mockService, syncSettings: cloudSyncOn())
 
     await viewModel.loadAnalytics()
     #expect(mockService.getOverviewCallCount == 1)
@@ -232,6 +249,7 @@ struct AnalyticsViewModelTests {
 
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
+      syncSettings: cloudSyncOn(),
       userDefaults: .standard
     )
 
@@ -414,7 +432,8 @@ struct AnalyticsViewModelTests {
       analyticsService: mockService,
       localCalculator: mockCalculator,
       journalRepository: mockRepository,
-      catalogRepository: mockCatalog
+      catalogRepository: mockCatalog,
+      syncSettings: cloudSyncOn()
     )
 
     await viewModel.loadAnalytics()
@@ -444,7 +463,8 @@ struct AnalyticsViewModelTests {
       analyticsService: mockService,
       localCalculator: nil,
       journalRepository: mockRepository,
-      catalogRepository: mockCatalog
+      catalogRepository: mockCatalog,
+      syncSettings: cloudSyncOn()
     )
 
     await viewModel.loadAnalytics()
@@ -485,7 +505,8 @@ struct AnalyticsViewModelTests {
       analyticsService: mockService,
       localCalculator: mockCalculator,
       journalRepository: mockRepository,
-      catalogRepository: mockCatalog
+      catalogRepository: mockCatalog,
+      syncSettings: cloudSyncOn()
     )
 
     await viewModel.loadAnalytics()
@@ -524,5 +545,77 @@ struct AnalyticsViewModelTests {
         ),
       ]
     )
+  }
+
+  // MARK: - Local-only mode (cloud sync disabled)
+
+  @Test("viewModel uses local calculator exclusively when cloud sync is disabled")
+  @MainActor
+  func viewModel_usesLocalOnlyWhenCloudSyncDisabled() async {
+    // Backend is wired but should NOT be called when cloud sync is off, even
+    // if it would have succeeded: hitting it returns zero entries for this
+    // user (sync is off, nothing's there) and would erase the user's view.
+    let mockService = MockAnalyticsService()
+    let backendOverview = AnalyticsOverview(
+      totalEntries: 0, currentStreak: 0, longestStreak: 0,
+      avgFrequency: 0, lastCheckIn: nil, medicinalRatio: 0, medicinalTrend: 0,
+      dominantLayerId: nil, dominantPhaseId: nil,
+      uniqueEmotions: 0, strategiesUsed: 0, secondaryEmotionsPct: 0
+    )
+    mockService.overviewToReturn = backendOverview
+
+    let mockCalculator = MockLocalAnalyticsCalculator()
+    let localOverview = AnalyticsOverview(
+      totalEntries: 7, currentStreak: 2, longestStreak: 4,
+      avgFrequency: 1.5, lastCheckIn: Date(), medicinalRatio: 0.6, medicinalTrend: 0.1,
+      dominantLayerId: 2, dominantPhaseId: 1,
+      uniqueEmotions: 5, strategiesUsed: 3, secondaryEmotionsPct: 0.5
+    )
+    mockCalculator.overviewToReturn = localOverview
+
+    let mockRepository = MockJournalRepository()
+    mockRepository.entriesToReturn = [
+      LocalJournalEntry(createdAt: Date(), userID: 1, curriculumID: 1, entryType: .emotion),
+    ]
+    let mockCatalog = MockCatalogRepository()
+    mockCatalog.catalogToReturn = testCatalog()
+
+    let viewModel = AnalyticsViewModel(
+      analyticsService: mockService,
+      localCalculator: mockCalculator,
+      journalRepository: mockRepository,
+      catalogRepository: mockCatalog,
+      syncSettings: cloudSyncOff()
+    )
+
+    await viewModel.loadAnalytics()
+
+    if case let .loaded(overview) = viewModel.state {
+      #expect(overview == localOverview)
+    } else {
+      Issue.record("Expected loaded state with local data, got \(viewModel.state)")
+    }
+    #expect(mockService.getOverviewCallCount == 0, "Backend must not be called in local-only mode")
+    #expect(mockCalculator.calculateOverviewCallCount == 1)
+  }
+
+  @Test("viewModel surfaces a friendly error when local-only and the calculator is unavailable")
+  @MainActor
+  func viewModel_reportsErrorWhenLocalOnlyAndCalculatorUnavailable() async {
+    let mockService = MockAnalyticsService()
+    let viewModel = AnalyticsViewModel(
+      analyticsService: mockService,
+      // No local calculator / repository / catalog wired.
+      syncSettings: cloudSyncOff()
+    )
+
+    await viewModel.loadAnalytics()
+
+    if case let .error(message) = viewModel.state {
+      #expect(message.contains("Local analytics not available"))
+    } else {
+      Issue.record("Expected error state, got \(viewModel.state)")
+    }
+    #expect(mockService.getOverviewCallCount == 0)
   }
 }


### PR DESCRIPTION
## Summary
First **bug fix** in the analytics epic (#187). Likely cause of the user-reported "analytics view shows empty" half of the "data clears every 24 hours" symptom.

### The bug
`AnalyticsViewModel` (the overview screen) always hit the backend first and only fell back to local on a thrown error. With cloud sync **disabled** (the privacy-first default per `SyncSettings`), the backend has no entries for the user → the call **succeeds** with an empty `AnalyticsOverview` → the overview screen shows empty even though local SQLite has the user's actual data.

The epic's stated architecture is "analytics read from local SQLite DB — works for both modes", and `SelfCareViewModel`/`TemporalPatternsViewModel`/`GrowthIndicatorsViewModel` already branch on `SyncSettings.cloudSyncEnabled`. `AnalyticsViewModel` was the outlier — likely missed during the local-first migration that produced #250–#255.

### The fix
- Take `SyncSettings` as a dependency (default `SyncSettings()`, matching the SelfCare pattern).
- `loadAnalytics` now branches:
  - **cloud sync ON** → `loadWithBackendFallback` (previous behavior, refactored)
  - **cloud sync OFF** → `loadFromLocalOnly` (use the local calculator exclusively; surface a friendly error if local components aren't wired)
- Propagate `syncSettings` through `AnalyticsView`.
- Tests get a deterministic `SyncSettings` backed by `MockSyncSettingsPersistence` (no `UserDefaults.standard` pollution); two new tests cover the local-only path (uses-local-not-backend, friendly-error-when-calculator-unavailable).

### Follow-ups (separate PRs)
- `EmotionalLandscapeViewModel` has the same bug class and is **worse** — no local fallback at all, no `LocalAnalyticsCalculator` dependency. Needs an `EmotionalLandscape` method on the calculator.
- The other halves of the "24h clears" symptom:
  - `CatalogRepository` uses `cachesDirectory` (OS-purgeable) + a 24h TTL — could make curriculum disappear daily.
  - `ContentViewDependencies.makeJournalRepository` silently falls back to `InMemoryJournalRepository` if SQLite open fails — would lose journal entries on any app termination.

## Test plan
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass (including 2 new local-only tests + the updated existing ones)
- [x] `pre-commit run --all-files` — all hooks pass
- [x] No production change to the cloud-sync-on path (refactored, behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)