### PR TITLE
fix(catalog): persist cache in Documents and fall back to stale on remote failure (#187)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
@@ -72,22 +72,6 @@ final class FileCatalogCacheStore: CatalogCachePersisting {
   }
 }
 
-final class InMemoryCatalogCache: CatalogCachePersisting {
-  private var storage: Data?
-
-  func loadCatalogData() throws -> Data? {
-    storage
-  }
-
-  func writeCatalogData(_ data: Data) throws {
-    storage = data
-  }
-
-  func removeCatalogData() throws {
-    storage = nil
-  }
-}
-
 final class CatalogRepository: CatalogRepositoryProtocol {
   private let remote: CatalogRemoteServicing
   private let cache: CatalogCachePersisting

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
@@ -19,6 +19,11 @@ protocol CatalogRepositoryProtocol {
 
 protocol CatalogRepositoryLogging {
   func cacheDecodingFailed(_ error: Error)
+  func remoteFailedServingStaleCatalog(_ error: Error)
+}
+
+extension CatalogRepositoryLogging {
+  func remoteFailedServingStaleCatalog(_ error: Error) {}
 }
 
 struct CatalogAPIService: CatalogRemoteServicing {
@@ -144,12 +149,16 @@ final class CatalogRepository: CatalogRepositoryProtocol {
       // next successful load will refresh. Only `forceRefresh` callers (e.g.
       // an explicit "refresh now" tap) propagate the error.
       if !forceRefresh, let envelope {
+        logger.remoteFailedServingStaleCatalog(error)
         return envelope.catalog
       }
       throw error
     }
   }
 
+  /// Force-refreshes the catalog from the remote. Always throws on remote
+  /// failure rather than falling back to a stale cache — callers are explicit
+  /// user actions ("refresh now") that should surface the failure.
   func refreshCatalog() async throws -> CatalogResponseModel {
     let catalog = try await remote.fetchCatalog()
     try? writeEnvelope(catalog)
@@ -162,5 +171,9 @@ struct DefaultCatalogRepositoryLogger: CatalogRepositoryLogging {
 
   func cacheDecodingFailed(_ error: Error) {
     DefaultCatalogRepositoryLogger.logger.error("Failed to decode catalog cache: \(error.localizedDescription, privacy: .public)")
+  }
+
+  func remoteFailedServingStaleCatalog(_ error: Error) {
+    DefaultCatalogRepositoryLogger.logger.warning("Remote catalog fetch failed; serving stale cache: \(error.localizedDescription, privacy: .public)")
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
@@ -39,7 +39,14 @@ final class FileCatalogCacheStore: CatalogCachePersisting {
   }
 
   convenience init(fileName: String = "catalog-cache.json", fileManager: FileManager = .default) {
-    let directory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+    // Use Documents (persistent) rather than Caches (purgeable by the OS under
+    // storage pressure). The watch is an offline-first surface — losing the
+    // catalog leaves the user with no curriculum to browse. We fall back to
+    // the Caches dir, then a temp path, only if Documents is unavailable.
+    let directory =
+      fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+        ?? fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+        ?? URL(fileURLWithPath: NSTemporaryDirectory())
     self.init(fileURL: directory.appendingPathComponent(fileName), fileManager: fileManager)
   }
 
@@ -138,12 +145,25 @@ final class CatalogRepository: CatalogRepositoryProtocol {
   }
 
   func loadCatalog(forceRefresh: Bool = false) async throws -> CatalogResponseModel {
-    if !forceRefresh, let envelope = readEnvelope(), isFresh(envelope) {
+    let envelope = readEnvelope()
+    if !forceRefresh, let envelope, isFresh(envelope) {
       return envelope.catalog
     }
-    let catalog = try await remote.fetchCatalog()
-    try? writeEnvelope(catalog)
-    return catalog
+    do {
+      let catalog = try await remote.fetchCatalog()
+      try? writeEnvelope(catalog)
+      return catalog
+    } catch {
+      // Remote failed (offline / backend down). Rather than wiping the user's
+      // curriculum every 24h once the TTL expires, fall back to any cached
+      // envelope we have — even if it's stale. The user keeps browsing; the
+      // next successful load will refresh. Only `forceRefresh` callers (e.g.
+      // an explicit "refresh now" tap) propagate the error.
+      if !forceRefresh, let envelope {
+        return envelope.catalog
+      }
+      throw error
+    }
   }
 
   func refreshCatalog() async throws -> CatalogResponseModel {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
@@ -102,4 +102,18 @@ struct CatalogRepositoryFallbackTests {
       _ = try await repository.loadCatalog(forceRefresh: false)
     }
   }
+
+  @Test("loadCatalog with forceRefresh throws when remote fails and there is no cache")
+  func loadCatalog_forceRefreshWithEmptyCache_throws() async throws {
+    let cache = InMemoryCatalogCacheMock()
+    let repository = makeRepository(
+      remote: FailingRemoteStub(error: NetworkDown()),
+      cache: cache,
+      now: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    await #expect(throws: Error.self) {
+      _ = try await repository.loadCatalog(forceRefresh: true)
+    }
+  }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Tests for the CatalogRepository's stale-cache graceful-degradation behavior.
+///
+/// The watch is offline-first: when the cache is stale (older than the TTL)
+/// and the remote fetch fails (offline / backend down), the repository must
+/// return the stale cached catalog rather than throw — otherwise curriculum
+/// browsing vanishes every 24 hours.
+///
+/// Lives next to the legacy `CatalogRepositoryTests` in
+/// `WavelengthWatch_Watch_AppTests.swift`, hence the distinct struct name.
+struct CatalogRepositoryFallbackTests {
+  private struct NetworkDown: Error {}
+
+  private func makeCatalog(phase: String = "Rising") -> CatalogResponseModel {
+    CatalogResponseModel(
+      phaseOrder: [phase],
+      layers: [
+        CatalogLayerModel(
+          id: 1,
+          color: "Beige",
+          title: "BEIGE",
+          subtitle: "Survival",
+          phases: [
+            CatalogPhaseModel(
+              id: 1,
+              name: phase,
+              medicinal: [CatalogCurriculumEntryModel(id: 10, dosage: .medicinal, expression: "Grounded")],
+              toxic: [],
+              strategies: []
+            ),
+          ]
+        ),
+      ]
+    )
+  }
+
+  /// Returns a repository that writes/reads through a shared in-memory cache
+  /// at the provided clock instant.
+  private func makeRepository(
+    remote: CatalogRemoteServicing,
+    cache: CatalogCachePersisting,
+    now: Date,
+    ttl: TimeInterval = 60 * 60 * 24
+  ) -> CatalogRepository {
+    CatalogRepository(
+      remote: remote,
+      cache: cache,
+      dateProvider: { now },
+      cacheTTL: ttl
+    )
+  }
+
+  @Test("loadCatalog returns stale cached catalog when remote fetch fails")
+  func loadCatalog_remoteFails_returnsStaleCache() async throws {
+    let originalCatalog = makeCatalog(phase: "Rising")
+    let cache = InMemoryCatalogCache()
+    let initialDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // 1. First successful load populates the cache at `initialDate`.
+    let working = makeRepository(
+      remote: CatalogRemoteStub(response: originalCatalog),
+      cache: cache,
+      now: initialDate
+    )
+    _ = try await working.loadCatalog(forceRefresh: false)
+
+    // 2. Advance the clock past the TTL — the cache is now stale, and the
+    //    remote is now down.
+    let staleDate = initialDate.addingTimeInterval(60 * 60 * 25)
+    let failing = makeRepository(
+      remote: FailingRemoteStub(error: NetworkDown()),
+      cache: cache,
+      now: staleDate
+    )
+
+    // 3. The repository must fall back to the stale cache, not throw.
+    let result = try await failing.loadCatalog(forceRefresh: false)
+    #expect(result == originalCatalog)
+  }
+
+  @Test("loadCatalog with forceRefresh propagates remote errors even if a cache exists")
+  func loadCatalog_forceRefresh_throwsOnRemoteFailureEvenWithCache() async throws {
+    let originalCatalog = makeCatalog(phase: "Peaking")
+    let cache = InMemoryCatalogCache()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // Populate cache.
+    let working = makeRepository(
+      remote: CatalogRemoteStub(response: originalCatalog),
+      cache: cache,
+      now: now
+    )
+    _ = try await working.loadCatalog(forceRefresh: false)
+
+    // forceRefresh = true means the caller wants fresh data; on remote failure
+    // we must propagate (no silent stale return).
+    let failing = makeRepository(
+      remote: FailingRemoteStub(error: NetworkDown()),
+      cache: cache,
+      now: now
+    )
+    await #expect(throws: Error.self) {
+      _ = try await failing.loadCatalog(forceRefresh: true)
+    }
+  }
+
+  @Test("loadCatalog still throws when remote fails and there is no cache at all")
+  func loadCatalog_remoteFailsWithEmptyCache_throws() async throws {
+    let cache = InMemoryCatalogCache()
+    let repository = makeRepository(
+      remote: FailingRemoteStub(error: NetworkDown()),
+      cache: cache,
+      now: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    await #expect(throws: Error.self) {
+      _ = try await repository.loadCatalog(forceRefresh: false)
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
@@ -2,15 +2,6 @@ import Foundation
 import Testing
 @testable import WavelengthWatch_Watch_App
 
-/// Tests for the CatalogRepository's stale-cache graceful-degradation behavior.
-///
-/// The watch is offline-first: when the cache is stale (older than the TTL)
-/// and the remote fetch fails (offline / backend down), the repository must
-/// return the stale cached catalog rather than throw — otherwise curriculum
-/// browsing vanishes every 24 hours.
-///
-/// Lives next to the legacy `CatalogRepositoryTests` in
-/// `WavelengthWatch_Watch_AppTests.swift`, hence the distinct struct name.
 struct CatalogRepositoryFallbackTests {
   private struct NetworkDown: Error {}
 
@@ -37,8 +28,6 @@ struct CatalogRepositoryFallbackTests {
     )
   }
 
-  /// Returns a repository that writes/reads through a shared in-memory cache
-  /// at the provided clock instant.
   private func makeRepository(
     remote: CatalogRemoteServicing,
     cache: CatalogCachePersisting,
@@ -56,10 +45,9 @@ struct CatalogRepositoryFallbackTests {
   @Test("loadCatalog returns stale cached catalog when remote fetch fails")
   func loadCatalog_remoteFails_returnsStaleCache() async throws {
     let originalCatalog = makeCatalog(phase: "Rising")
-    let cache = InMemoryCatalogCache()
+    let cache = InMemoryCatalogCacheMock()
     let initialDate = Date(timeIntervalSince1970: 1_700_000_000)
 
-    // 1. First successful load populates the cache at `initialDate`.
     let working = makeRepository(
       remote: CatalogRemoteStub(response: originalCatalog),
       cache: cache,
@@ -67,8 +55,6 @@ struct CatalogRepositoryFallbackTests {
     )
     _ = try await working.loadCatalog(forceRefresh: false)
 
-    // 2. Advance the clock past the TTL — the cache is now stale, and the
-    //    remote is now down.
     let staleDate = initialDate.addingTimeInterval(60 * 60 * 25)
     let failing = makeRepository(
       remote: FailingRemoteStub(error: NetworkDown()),
@@ -76,7 +62,6 @@ struct CatalogRepositoryFallbackTests {
       now: staleDate
     )
 
-    // 3. The repository must fall back to the stale cache, not throw.
     let result = try await failing.loadCatalog(forceRefresh: false)
     #expect(result == originalCatalog)
   }
@@ -84,10 +69,9 @@ struct CatalogRepositoryFallbackTests {
   @Test("loadCatalog with forceRefresh propagates remote errors even if a cache exists")
   func loadCatalog_forceRefresh_throwsOnRemoteFailureEvenWithCache() async throws {
     let originalCatalog = makeCatalog(phase: "Peaking")
-    let cache = InMemoryCatalogCache()
+    let cache = InMemoryCatalogCacheMock()
     let now = Date(timeIntervalSince1970: 1_700_000_000)
 
-    // Populate cache.
     let working = makeRepository(
       remote: CatalogRemoteStub(response: originalCatalog),
       cache: cache,
@@ -95,8 +79,6 @@ struct CatalogRepositoryFallbackTests {
     )
     _ = try await working.loadCatalog(forceRefresh: false)
 
-    // forceRefresh = true means the caller wants fresh data; on remote failure
-    // we must propagate (no silent stale return).
     let failing = makeRepository(
       remote: FailingRemoteStub(error: NetworkDown()),
       cache: cache,
@@ -109,7 +91,7 @@ struct CatalogRepositoryFallbackTests {
 
   @Test("loadCatalog still throws when remote fails and there is no cache at all")
   func loadCatalog_remoteFailsWithEmptyCache_throws() async throws {
-    let cache = InMemoryCatalogCache()
+    let cache = InMemoryCatalogCacheMock()
     let repository = makeRepository(
       remote: FailingRemoteStub(error: NetworkDown()),
       cache: cache,


### PR DESCRIPTION
## Summary
Second **bugfix** in the analytics epic (#187), addressing the "curriculum vanishes every 24 hours" half of the user-reported data-clearing symptom.

### Two interacting bugs
1. **`FileCatalogCacheStore` wrote to `cachesDirectory`** — purgeable by iOS/watchOS under storage pressure. Default location now `documentsDirectory` (still falls back to `cachesDirectory`, then a temp path, if Documents is unavailable). The watch is offline-first; losing the cached catalog means no curriculum to browse.
2. **`CatalogRepository.loadCatalog(forceRefresh: false)`** bypassed the cached envelope entirely once the 24h TTL expired and propagated the network error if remote refresh failed. Now: if remote throws and a cached envelope exists (even stale), return it — the user keeps browsing and the next successful load refreshes. `forceRefresh: true` callers still propagate the error (they explicitly asked for fresh).

### Test plan
- [x] Added `CatalogRepositoryFallbackTests` covering:
  - stale cache + remote failure → returns the stale catalog
  - `forceRefresh` still propagates on remote failure
  - no cache + remote failure → still throws
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass
- [x] `pre-commit run --all-files` — all hooks pass

### Migration notes
Existing users' caches in `cachesDirectory` are simply ignored — on next load the new code looks in Documents, finds nothing, fetches fresh, and writes there. No data loss (catalog is server-derived).

### Follow-ups (separate PRs)
- `EmotionalLandscapeViewModel` still has the same backend-first/no-local-fallback bug class.
- The silent `InMemoryJournalRepository` fallback (`ContentViewDependencies`) still loses entries on app termination if SQLite open ever fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)