### PR TITLE
fix(storage): surface journal in-memory fallback as a Storage Error alert (#187)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -32,6 +32,11 @@ struct ContentViewDependencies {
   let syncService: JournalSyncService
   let journalClient: JournalClientProtocol
   let journalRepository: JournalRepositoryProtocol
+  /// True when `makeJournalRepository` couldn't open the on-disk SQLite store
+  /// and fell back to `InMemoryJournalRepository`. Journal entries logged in
+  /// this session will not persist past app termination; the App layer should
+  /// surface this to the user.
+  let journalStorageIsEphemeral: Bool
   let catalogRepository: CatalogRepositoryProtocol
   /// Owns the dual-axis navigation selection and its reconciliation with
   /// `viewModel`; `ContentView` holds it as its single navigation state.
@@ -62,7 +67,7 @@ struct ContentViewDependencies {
       remote: CatalogAPIService(apiClient: apiClient),
       cache: FileCatalogCacheStore()
     )
-    let journalRepository = Self.makeJournalRepository()
+    let (journalRepository, journalStorageIsEphemeral) = Self.makeJournalRepository()
     let syncSettings = SyncSettings()
     let journalQueue = Self.makeJournalQueue()
     let networkMonitor = NetworkMonitor()
@@ -84,7 +89,8 @@ struct ContentViewDependencies {
       journalRepository: journalRepository,
       journalClient: journalClient,
       initialLayerIndex: initialLayer,
-      initialPhaseIndex: storedPhase
+      initialPhaseIndex: storedPhase,
+      journalStorageIsEphemeral: journalStorageIsEphemeral
     )
     let flowCoordinator = FlowCoordinator(contentViewModel: viewModel)
     let syncSettingsViewModel = SyncSettingsViewModel(syncSettings: syncSettings)
@@ -105,6 +111,7 @@ struct ContentViewDependencies {
       syncService: syncService,
       journalClient: journalClient,
       journalRepository: journalRepository,
+      journalStorageIsEphemeral: journalStorageIsEphemeral,
       catalogRepository: catalogRepository,
       navigationViewModel: navigationViewModel
     )
@@ -112,10 +119,14 @@ struct ContentViewDependencies {
 
   // MARK: - Repository / queue construction
 
-  /// Opens the on-disk SQLite journal repository, falling back to
-  /// in-memory storage if open fails (SwiftUI previews, test harness,
-  /// or a corrupted database file). The fallback keeps the app
-  /// functional but entries logged in the session don't persist.
+  /// Opens the on-disk SQLite journal repository, falling back to in-memory
+  /// storage if open fails (SwiftUI previews, test harness, or a corrupted
+  /// database file). The fallback keeps the app functional but entries logged
+  /// in the session don't persist — callers must surface that to the user.
+  ///
+  /// Returns the repository plus an `isInMemoryFallback` flag so the App layer
+  /// can show a "Storage Error" warning rather than silently lose data on the
+  /// next app termination.
   ///
   /// `openPersistent` is injectable so the fallback branch can be tested
   /// without a genuinely corrupt database file.
@@ -126,14 +137,14 @@ struct ContentViewDependencies {
       try repository.open()
       return repository
     }
-  ) -> JournalRepositoryProtocol {
+  ) -> (repository: JournalRepositoryProtocol, isInMemoryFallback: Bool) {
     do {
-      return try openPersistent()
+      return try (openPersistent(), false)
     } catch {
       logger.warning(
         "Journal database open failed: \(error.localizedDescription, privacy: .public). Falling back to in-memory storage."
       )
-      return InMemoryJournalRepository()
+      return (InMemoryJournalRepository(), true)
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
@@ -48,6 +48,12 @@ final class ContentViewModel: ObservableObject {
   let journalRepository: JournalRepositoryProtocol
   private let journalClient: JournalClientProtocol
 
+  /// True when journal storage couldn't be opened on disk and the app fell
+  /// back to in-memory storage — entries logged this session won't persist.
+  /// Set once at construction by `ContentViewDependencies.makeJournalRepository`;
+  /// the App layer surfaces this to the user as a "Storage Error" alert.
+  let journalStorageIsEphemeral: Bool
+
   /// Returns layers filtered according to the current filter mode.
   ///
   /// The filtered layers change based on `layerFilterMode`:
@@ -76,13 +82,15 @@ final class ContentViewModel: ObservableObject {
     journalRepository: JournalRepositoryProtocol,
     journalClient: JournalClientProtocol,
     initialLayerIndex: Int = 0,
-    initialPhaseIndex: Int = 0
+    initialPhaseIndex: Int = 0,
+    journalStorageIsEphemeral: Bool = false
   ) {
     self.catalogRepository = catalogRepository
     self.journalRepository = journalRepository
     self.journalClient = journalClient
     self.selectedLayerIndex = initialLayerIndex
     self.selectedPhaseIndex = initialPhaseIndex
+    self.journalStorageIsEphemeral = journalStorageIsEphemeral
   }
 
   @MainActor

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
@@ -32,6 +32,9 @@ struct RootShellView: View {
   @State private var showingOnboarding = false
   @State private var isShowingDetailView = false
   @State private var navigationPath = NavigationPath()
+  /// True when this session has surfaced the journal-storage warning to the
+  /// user. Reset on relaunch so the warning re-fires until storage recovers.
+  @State private var showingStorageWarning = false
 
   private var flowSubmissionPresenter: FlowSubmissionPresenter {
     FlowSubmissionPresenter(flowCoordinator: flowCoordinator, viewModel: viewModel)
@@ -49,6 +52,19 @@ struct RootShellView: View {
         }
     }
     .environment(\.isShowingDetailView, $isShowingDetailView)
+    // Warn the user immediately if journal storage couldn't open and the app
+    // is running on the in-memory fallback — otherwise entries silently vanish
+    // on the next termination.
+    .task {
+      if viewModel.journalStorageIsEphemeral, !showingStorageWarning {
+        showingStorageWarning = true
+      }
+    }
+    .alert("Storage Error", isPresented: $showingStorageWarning) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text("Your journal couldn't be opened, so entries logged this session won't be saved. Please reopen the app; if the problem continues, contact support.")
+    }
   }
 
   // MARK: - Body decomposition

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
@@ -11,16 +11,18 @@ struct ContentViewDependenciesTests {
   @Test("makeJournalRepository returns the persistent repo when the open succeeds")
   func makeJournalRepository_returnsPersistentOnSuccess() {
     let persistent = InMemoryJournalRepository()
-    let repo = ContentViewDependencies.makeJournalRepository(openPersistent: { persistent })
-    #expect(repo as AnyObject === persistent)
+    let result = ContentViewDependencies.makeJournalRepository(openPersistent: { persistent })
+    #expect(result.repository as AnyObject === persistent)
+    #expect(result.isInMemoryFallback == false)
   }
 
-  @Test("makeJournalRepository falls back to in-memory when the open fails")
+  @Test("makeJournalRepository falls back to in-memory and signals isInMemoryFallback when the open fails")
   func makeJournalRepository_fallsBackOnOpenFailure() {
-    let repo = ContentViewDependencies.makeJournalRepository(openPersistent: {
+    let result = ContentViewDependencies.makeJournalRepository(openPersistent: {
       throw FactoryFailure()
     })
-    #expect(repo is InMemoryJournalRepository)
+    #expect(result.repository is InMemoryJournalRepository)
+    #expect(result.isInMemoryFallback == true)
   }
 
   // MARK: - makeJournalQueue


### PR DESCRIPTION
## Summary
Third **bugfix** in the analytics epic (#187), addressing the last live "data clears" risk that maps to the user's symptom.

### The bug
If `JournalRepository.open()` throws (corrupted DB file, sandboxed write failure, etc.), `ContentViewDependencies.makeJournalRepository` silently falls back to `InMemoryJournalRepository`. The app keeps running but every entry the user logs in that session **vanishes on the next app termination** — matching the "data clears every 24 hours" symptom on a watch that gets terminated and relaunched between sessions. The only signal today is an OS-level log line nobody reads.

### The fix
- `makeJournalRepository` now returns `(repository, isInMemoryFallback)`.
- The flag rides on `ContentViewDependencies` and into `ContentViewModel` (as `let journalStorageIsEphemeral: Bool`, default `false` for back-compat).
- `RootShellView` shows a one-time **"Storage Error"** alert per session when the fallback is active, telling the user entries won't be saved and to reopen the app. The alert re-fires on each launch until storage recovers — so the user keeps being warned rather than silently losing data.

### Test plan
- [x] Updated `ContentViewDependenciesTests` for the tuple return; the failure-path test now asserts `isInMemoryFallback == true` and the success-path test asserts `isInMemoryFallback == false`.
- [x] `frontend/WavelengthWatch/run-tests-individually.sh` — all suites pass
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] **Manual:** simulate the fallback by corrupting the on-disk DB (or running the app with a mock that throws on open) and confirm the alert appears at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)