### PR TITLE
a11y(views): extend Reduce Motion/Transparency to remaining nav + cards (#302)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLSurfaceModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLSurfaceModifier.swift
@@ -3,23 +3,52 @@ import SwiftUI
 /// Card background that uses a translucent fill normally but a solid opaque
 /// surface when "Reduce Transparency" is enabled. Reads the environment itself
 /// so call sites don't each need `@Environment(\.accessibilityReduceTransparency)`.
-private struct WLCardSurface: ViewModifier {
+///
+/// The fill is any `ShapeStyle` — a flat `Color` or a `LinearGradient` — and is
+/// swapped for `WLColorTokens.opaqueSurface` under Reduce Transparency so the
+/// surface stays legible. An optional `stroke` border is preserved in both
+/// modes, since the border provides edge definition independent of translucency.
+struct WLCardSurface: ViewModifier {
   @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-  let translucentFill: Color
+  let translucentFill: AnyShapeStyle
   let cornerRadius: CGFloat
+  let stroke: Color?
+  let strokeWidth: CGFloat
 
   func body(content: Content) -> some View {
-    content.background(
+    content.background(background)
+  }
+
+  private var background: some View {
+    RoundedRectangle(cornerRadius: cornerRadius)
+      .fill(reduceTransparency ? AnyShapeStyle(WLColorTokens.opaqueSurface) : translucentFill)
+      .overlay(strokeOverlay)
+  }
+
+  @ViewBuilder
+  private var strokeOverlay: some View {
+    if let stroke {
       RoundedRectangle(cornerRadius: cornerRadius)
-        .fill(reduceTransparency ? WLColorTokens.opaqueSurface : translucentFill)
-    )
+        .stroke(stroke, lineWidth: strokeWidth)
+    }
   }
 }
 
 extension View {
   /// Applies a rounded card background that degrades from `translucentFill` to
-  /// a solid opaque surface under Reduce Transparency.
-  func wlCardSurface(_ translucentFill: Color, cornerRadius: CGFloat) -> some View {
-    modifier(WLCardSurface(translucentFill: translucentFill, cornerRadius: cornerRadius))
+  /// a solid opaque surface under Reduce Transparency. Pass a `Color` or a
+  /// `LinearGradient` as the fill, and an optional `stroke` border.
+  func wlCardSurface(
+    _ translucentFill: some ShapeStyle,
+    cornerRadius: CGFloat,
+    stroke: Color? = nil,
+    strokeWidth: CGFloat = 0.5
+  ) -> some View {
+    modifier(WLCardSurface(
+      translucentFill: AnyShapeStyle(translucentFill),
+      cornerRadius: cornerRadius,
+      stroke: stroke,
+      strokeWidth: strokeWidth
+    ))
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLSurfaceModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Modifiers/WLSurfaceModifier.swift
@@ -38,6 +38,9 @@ extension View {
   /// Applies a rounded card background that degrades from `translucentFill` to
   /// a solid opaque surface under Reduce Transparency. Pass a `Color` or a
   /// `LinearGradient` as the fill, and an optional `stroke` border.
+  ///
+  /// - Parameter strokeWidth: Border width; has no effect unless `stroke` is
+  ///   non-nil (the border is only drawn when a stroke color is supplied).
   func wlCardSurface(
     _ translucentFill: some ShapeStyle,
     cornerRadius: CGFloat,

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -32,22 +32,17 @@ struct ClearLightEmotionCard: View {
       }
       .padding(.horizontal, 16)
       .padding(.vertical, 10)
-      .background(
-        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
-          .fill(
-            LinearGradient(
-              gradient: Gradient(colors: [
-                emotion.sourceColor.opacity(0.2),
-                emotion.sourceColor.opacity(0.1),
-              ]),
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
-              .stroke(emotion.sourceColor.opacity(0.3), lineWidth: 0.5)
-          )
+      .wlCardSurface(
+        LinearGradient(
+          gradient: Gradient(colors: [
+            emotion.sourceColor.opacity(0.2),
+            emotion.sourceColor.opacity(0.1),
+          ]),
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        ),
+        cornerRadius: WLSpacingTokens.cardCornerRadius,
+        stroke: emotion.sourceColor.opacity(0.3)
       )
       .padding(.horizontal, 8)
       .onTapGesture {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
@@ -28,13 +28,10 @@ struct CurriculumCard: View {
       .frame(maxWidth: .infinity, alignment: .leading)
       .padding(.horizontal, 16)
       .padding(.vertical, 12)
-      .background(
-        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
-          .fill(WLColorTokens.cardGradient(accent))
-          .overlay(
-            RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadius)
-              .stroke(accent.opacity(0.5), lineWidth: 0.5)
-          )
+      .wlCardSurface(
+        WLColorTokens.cardGradient(accent),
+        cornerRadius: WLSpacingTokens.cardCornerRadius,
+        stroke: accent.opacity(0.5)
       )
       .onTapGesture {
         showingJournalConfirmation = true

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
@@ -32,9 +32,9 @@ struct StrategyCard: View {
         Spacer(minLength: 20)
       }
       .padding(8)
-      .background(
-        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusSmall)
-          .fill(WLColorTokens.cardFill(tinted: color))
+      .wlCardSurface(
+        WLColorTokens.cardFill(tinted: color),
+        cornerRadius: WLSpacingTokens.cardCornerRadiusSmall
       )
       .onTapGesture {
         if isActionable {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
@@ -42,6 +42,7 @@ struct LayerCardView: View {
     .offset(y: transformEffect.offset)
     .opacity(transformEffect.opacity)
     .zIndex(layerIndex == selectedLayerIndex ? 10 : Double(10 - abs(layerIndex - selectedLayerIndex)))
-    .animation(.interactiveSpring(response: 0.4, dampingFraction: 0.8), value: selectedLayerIndex)
+    // Decorative 3D card morph — suppressed under Reduce Motion.
+    .wlAnimation(.interactiveSpring(response: 0.4, dampingFraction: 0.8), value: selectedLayerIndex)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
@@ -42,7 +42,6 @@ struct LayerCardView: View {
     .offset(y: transformEffect.offset)
     .opacity(transformEffect.opacity)
     .zIndex(layerIndex == selectedLayerIndex ? 10 : Double(10 - abs(layerIndex - selectedLayerIndex)))
-    // Decorative 3D card morph — suppressed under Reduce Motion.
     .wlAnimation(.interactiveSpring(response: 0.4, dampingFraction: 0.8), value: selectedLayerIndex)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerSideIndicator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerSideIndicator.swift
@@ -54,7 +54,8 @@ struct LayerSideIndicator: View {
       )
       .scaleEffect(distance > 2 ? 0.6 : 1.0)
       .opacity(distance > 3 ? 0 : 1)
-      .animation(.interactiveSpring(response: 0.3, dampingFraction: 0.7), value: selection)
+      // Decorative capsule resize/scale morph — suppressed under Reduce Motion.
+      .wlAnimation(.interactiveSpring(response: 0.3, dampingFraction: 0.7), value: selection)
   }
 
   private func fill(for layer: CatalogLayerModel, selected: Bool) -> LinearGradient {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerSideIndicator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerSideIndicator.swift
@@ -54,7 +54,6 @@ struct LayerSideIndicator: View {
       )
       .scaleEffect(distance > 2 ? 0.6 : 1.0)
       .opacity(distance > 3 ? 0 : 1)
-      // Decorative capsule resize/scale morph — suppressed under Reduce Motion.
       .wlAnimation(.interactiveSpring(response: 0.3, dampingFraction: 0.7), value: selection)
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
@@ -59,7 +59,8 @@ struct LayerView: View {
         Circle()
           .fill(isSelected ? Color.white : Color.white.opacity(0.3))
           .frame(width: isSelected ? 6 : 4, height: isSelected ? 6 : 4)
-          .animation(.easeInOut(duration: 0.2), value: selection)
+          // Decorative page-dot resize — suppressed under Reduce Motion.
+          .wlAnimation(.easeInOut(duration: 0.2), value: selection)
       }
     }
     .padding(.horizontal, 8)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
@@ -59,7 +59,6 @@ struct LayerView: View {
         Circle()
           .fill(isSelected ? Color.white : Color.white.opacity(0.3))
           .frame(width: isSelected ? 6 : 4, height: isSelected ? 6 : 4)
-          // Decorative page-dot resize — suppressed under Reduce Motion.
           .wlAnimation(.easeInOut(duration: 0.2), value: selection)
       }
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -11,6 +11,7 @@ struct PhaseCrystalCard: View {
   let phase: CatalogPhaseModel
   let color: Color
   let scale: CGFloat
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
   var body: some View {
     ZStack {
@@ -118,18 +119,29 @@ struct PhaseCrystalCard: View {
     }
   }
 
+  /// Translucent dark scrim normally; a solid opaque surface when "Reduce
+  /// Transparency" is on so the layer-tinted page can't bleed through and
+  /// reduce legibility. The gradient stroke and depth shadows are preserved
+  /// in both modes.
+  private var cardFill: AnyShapeStyle {
+    if reduceTransparency {
+      return AnyShapeStyle(WLColorTokens.opaqueSurface)
+    }
+    return AnyShapeStyle(
+      LinearGradient(
+        gradient: Gradient(colors: [
+          Color.black.opacity(0.4),
+          Color.black.opacity(0.6),
+        ]),
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+    )
+  }
+
   private var cardBackground: some View {
     RoundedRectangle(cornerRadius: 16)
-      .fill(
-        LinearGradient(
-          gradient: Gradient(colors: [
-            Color.black.opacity(0.4),
-            Color.black.opacity(0.6),
-          ]),
-          startPoint: .topLeading,
-          endPoint: .bottomTrailing
-        )
-      )
+      .fill(cardFill)
       .overlay(
         RoundedRectangle(cornerRadius: 16)
           .stroke(

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLSurfaceModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLSurfaceModifierTests.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Stored-property tests for `WLCardSurface`, mirroring `WLGlassModifierTests`.
+///
+/// The fill is type-erased to `AnyShapeStyle` (not `Equatable`), so these assert
+/// the plumbing that *is* comparable — corner radius, stroke, and stroke width —
+/// which is what call sites depend on staying intact. The translucent→opaque
+/// degradation itself lives in `body` behind `@Environment` and is a visual
+/// behavior validated on-device per the Phase 6b checklist (#302).
+struct WLSurfaceModifierTests {
+  @Test("Corner radius is preserved")
+  func cornerRadius_isPreserved() {
+    let modifier = WLCardSurface(
+      translucentFill: AnyShapeStyle(Color.red),
+      cornerRadius: 18,
+      stroke: nil,
+      strokeWidth: 0.5
+    )
+    #expect(modifier.cornerRadius == 18)
+  }
+
+  @Test("Stroke defaults to nil via the View extension")
+  func stroke_defaultsToNil() {
+    let view = Color.clear.wlCardSurface(Color.red, cornerRadius: 12)
+    // The extension returns a ModifiedContent whose modifier carries the
+    // defaults; constructing the modifier directly mirrors that default.
+    let modifier = WLCardSurface(
+      translucentFill: AnyShapeStyle(Color.red),
+      cornerRadius: 12,
+      stroke: nil,
+      strokeWidth: 0.5
+    )
+    #expect(modifier.stroke == nil)
+    #expect(modifier.strokeWidth == 0.5)
+    _ = view
+  }
+
+  @Test("Stroke color is preserved")
+  func stroke_isPreserved() {
+    let modifier = WLCardSurface(
+      translucentFill: AnyShapeStyle(Color.green),
+      cornerRadius: 10,
+      stroke: .blue,
+      strokeWidth: 2
+    )
+    #expect(modifier.stroke == .blue)
+    #expect(modifier.strokeWidth == 2)
+  }
+
+  @Test("A gradient fill is accepted without a stroke")
+  func gradientFill_isAccepted() {
+    let gradient = LinearGradient(
+      colors: [.purple, .indigo],
+      startPoint: .top,
+      endPoint: .bottom
+    )
+    let modifier = WLCardSurface(
+      translucentFill: AnyShapeStyle(gradient),
+      cornerRadius: 16,
+      stroke: nil,
+      strokeWidth: 0.5
+    )
+    #expect(modifier.cornerRadius == 16)
+    #expect(modifier.stroke == nil)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLSurfaceModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WLSurfaceModifierTests.swift
@@ -10,8 +10,7 @@ import Testing
 /// degradation itself lives in `body` behind `@Environment` and is a visual
 /// behavior validated on-device per the Phase 6b checklist (#302).
 struct WLSurfaceModifierTests {
-  @Test("Corner radius is preserved")
-  func cornerRadius_isPreserved() {
+  @Test func cornerRadius_isPreserved() {
     let modifier = WLCardSurface(
       translucentFill: AnyShapeStyle(Color.red),
       cornerRadius: 18,
@@ -21,24 +20,7 @@ struct WLSurfaceModifierTests {
     #expect(modifier.cornerRadius == 18)
   }
 
-  @Test("Stroke defaults to nil via the View extension")
-  func stroke_defaultsToNil() {
-    let view = Color.clear.wlCardSurface(Color.red, cornerRadius: 12)
-    // The extension returns a ModifiedContent whose modifier carries the
-    // defaults; constructing the modifier directly mirrors that default.
-    let modifier = WLCardSurface(
-      translucentFill: AnyShapeStyle(Color.red),
-      cornerRadius: 12,
-      stroke: nil,
-      strokeWidth: 0.5
-    )
-    #expect(modifier.stroke == nil)
-    #expect(modifier.strokeWidth == 0.5)
-    _ = view
-  }
-
-  @Test("Stroke color is preserved")
-  func stroke_isPreserved() {
+  @Test func stroke_isPreserved() {
     let modifier = WLCardSurface(
       translucentFill: AnyShapeStyle(Color.green),
       cornerRadius: 10,
@@ -49,8 +31,7 @@ struct WLSurfaceModifierTests {
     #expect(modifier.strokeWidth == 2)
   }
 
-  @Test("A gradient fill is accepted without a stroke")
-  func gradientFill_isAccepted() {
+  @Test func gradientFill_withoutStroke_isAccepted() {
     let gradient = LinearGradient(
       colors: [.purple, .indigo],
       startPoint: .top,

--- a/frontend/WavelengthWatch/run-tests-individually.sh
+++ b/frontend/WavelengthWatch/run-tests-individually.sh
@@ -76,6 +76,7 @@ ALL_SUITES=(
   "WLSpacingTokensTests"
   "WLTypographyTokensTests"
   "WLGlassModifierTests"
+  "WLSurfaceModifierTests"
   "WLCardModifierTests"
   "WLButtonStyleTests"
 )


### PR DESCRIPTION
## Summary

Completes the **code-level** follow-ups deferred from Phase 6b (#302): the remaining custom translucent surfaces now degrade to a solid opaque fill under **Reduce Transparency**, and the decorative navigation morphing now respects **Reduce Motion**. This finishes the agent-actionable Phase 6b work; the issue stays open for the on-device/Instruments sign-off that can't be done in CI.

## Changes

**Design system**
- Generalize `wlCardSurface` to accept any `ShapeStyle` fill (flat `Color` *or* `LinearGradient`) plus an optional `Color` stroke + `strokeWidth`, type-erasing the fill to `AnyShapeStyle`. Backward compatible with existing flat-color call sites (`RestPeriodHeader`, `EmotionExpressionCard`, `StrategyExpressionCard`). The modifier is now `internal` so it can be property-tested.

**Reduce Transparency adoption**
- `StrategyCard` (flat), `CurriculumCard` (gradient + stroke), `ClearLightEmotionCard` (gradient + stroke) move their translucent backgrounds onto `wlCardSurface`.
- `PhaseCrystalCard` swaps **only** its scrim fill to the opaque surface while keeping its gradient stroke and the two depth shadows — `wlCardSurface` can't express those, so the swap is done inline to avoid regressing the non-reduced look.

**Reduce Motion adoption**
- `LayerCardView` (3D card morph), `LayerSideIndicator` (capsule resize/scale), and `LayerView` (page-dot resize) move `.animation(_:value:)` → the Reduce-Motion-aware `.wlAnimation(_:value:)`.

> Note: `LayerScrollView` had no `.animation(_:value:)` modifier to convert — its motion is imperative scroll-snap + indicator-opacity feedback (not fluid morphing), intentionally retained.

**Tests**
- Add `WLSurfaceModifierTests` (stored-property coverage mirroring `WLGlassModifierTests`) and register it in the `run-tests-individually.sh` suite list.

## Testing
- `swiftformat --lint frontend` → clean
- `run-tests-individually.sh` → build succeeds, all suites pass (incl. new `WLSurfaceModifierTests`)

## Verification note
The non-reduced appearance is unchanged. The degraded (Reduce Transparency / Reduce Motion) appearances are visual and not unit-testable under the project's no-ViewInspector philosophy — they remain on the on-device validation checklist in #302.

Refs #302 · Epic #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
