### PR TITLE
feat(analytics): rebuild progress indicator without performance grading (#373)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/CircularProgressView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/CircularProgressView.swift
@@ -1,58 +1,62 @@
 import SwiftUI
 
-/// A reusable circular progress indicator with percentage display and color coding.
+/// A reusable circular progress indicator with a centered percentage label.
 ///
-/// This component displays progress in a circular format with a centered percentage value.
-/// The color automatically adjusts based on the percentage value:
-/// - Green: >70% (high performance)
-/// - Yellow: 50-70% (medium performance)
-/// - Orange: <50% (low performance)
+/// The ring renders in a single `tint` color (default
+/// `WLColorTokens.interactiveAccent`) and never derives its color from the
+/// value — progress is shown descriptively, not graded good/bad. The previous
+/// green/yellow/orange "performance grading" was removed per #281.
+///
+/// The track holds more contrast under Reduce Transparency so the unfilled
+/// portion stays legible, and the fill animation is suppressed under Reduce
+/// Motion via `wlAnimation`.
 ///
 /// ## Usage
 /// ```swift
-/// // Default size (100pt)
-/// CircularProgressView(percentage: 75.0)
-///
-/// // Custom size
-/// CircularProgressView(percentage: 60.0, size: 120.0)
-///
-/// // With animation
-/// @State private var progress: Double = 0
-/// CircularProgressView(percentage: progress)
-///   .onAppear {
-///     withAnimation {
-///       progress = 75.0
-///     }
-///   }
+/// CircularProgressView(percentage: 75.0)                       // default tint + size
+/// CircularProgressView(percentage: 60.0, size: 120.0)          // custom size
+/// CircularProgressView(percentage: 40.0, tint: WLColorTokens.teal)
 /// ```
 struct CircularProgressView: View {
-  /// The percentage value to display (0-100)
+  /// The percentage value to display (0–100).
   let percentage: Double
 
-  /// The size of the circular progress view in points
+  /// The diameter of the ring in points.
   let size: CGFloat
 
-  /// Creates a new circular progress view
+  /// The ring's fill color. Neutral by default; callers may pass a section or
+  /// layer accent, but the component never derives color from the value.
+  let tint: Color
+
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+  /// Creates a new circular progress view.
   /// - Parameters:
-  ///   - percentage: The percentage value to display (0-100)
-  ///   - size: The size of the view in points (default: 100)
-  init(percentage: Double, size: CGFloat = 100.0) {
+  ///   - percentage: The percentage value to display (0–100).
+  ///   - size: The diameter of the view in points (default: 100).
+  ///   - tint: The ring fill color (default: `WLColorTokens.interactiveAccent`).
+  init(
+    percentage: Double,
+    size: CGFloat = 100.0,
+    tint: Color = WLColorTokens.interactiveAccent
+  ) {
     self.percentage = percentage
     self.size = size
+    self.tint = tint
   }
 
   var body: some View {
     ZStack {
-      // Background circle
+      // Track circle
       Circle()
-        .stroke(Color.secondary.opacity(0.2), lineWidth: strokeWidth)
+        .stroke(trackColor, lineWidth: strokeWidth)
         .frame(width: size, height: size)
 
       // Progress circle
       Circle()
         .trim(from: 0, to: clampedProgress)
         .stroke(
-          progressColor,
+          tint,
           style: StrokeStyle(
             lineWidth: strokeWidth,
             lineCap: .round
@@ -60,30 +64,19 @@ struct CircularProgressView: View {
         )
         .frame(width: size, height: size)
         .rotationEffect(.degrees(-90)) // Start from top
-        .animation(.easeInOut(duration: 0.5), value: percentage)
+        .wlAnimation(.easeInOut(duration: 0.5), value: percentage)
 
       // Percentage text
       Text(formattedPercentage)
         .font(percentageFontSize)
         .fontWeight(.bold)
-        .foregroundColor(progressColor)
+        .foregroundColor(WLColorTokens.primaryText)
     }
   }
 
   // MARK: - Computed Properties
 
-  /// Returns the progress color based on percentage thresholds
-  var progressColor: Color {
-    if percentage > 70 {
-      .green
-    } else if percentage >= 50 {
-      .yellow
-    } else {
-      .orange
-    }
-  }
-
-  /// Returns the formatted percentage string
+  /// Returns the formatted percentage string.
   var formattedPercentage: String {
     // Show one decimal place if needed, otherwise show whole number
     if percentage.truncatingRemainder(dividingBy: 1) == 0 {
@@ -93,17 +86,24 @@ struct CircularProgressView: View {
     }
   }
 
-  /// Clamps the progress value between 0 and 1 for the trim modifier
+  /// Track (unfilled) ring color. Holds more contrast under Reduce
+  /// Transparency so the ring stays visible without relying on faint
+  /// translucency.
+  private var trackColor: Color {
+    Color.secondary.opacity(reduceTransparency ? 0.4 : 0.2)
+  }
+
+  /// Clamps the progress value between 0 and 1 for the trim modifier.
   private var clampedProgress: CGFloat {
     min(max(percentage / 100.0, 0.0), 1.0)
   }
 
-  /// Calculates the stroke width based on size
+  /// Calculates the stroke width based on size (10% of the diameter).
   private var strokeWidth: CGFloat {
-    size * 0.1 // 10% of the size
+    size * 0.1
   }
 
-  /// Calculates the font size based on size
+  /// Adapts the centered label font to the ring size.
   private var percentageFontSize: Font {
     if size < 80 {
       .caption
@@ -117,50 +117,40 @@ struct CircularProgressView: View {
 
 // MARK: - Previews
 
-#Preview("High Progress (85%)") {
-  CircularProgressView(percentage: 85.0)
-    .padding()
-    .previewDisplayName("Green - High")
+#Preview("Default tint") {
+  VStack(spacing: 20) {
+    CircularProgressView(percentage: 85.0)
+    CircularProgressView(percentage: 35.0)
+  }
+  .padding()
 }
 
-#Preview("Medium Progress (60%)") {
-  CircularProgressView(percentage: 60.0)
-    .padding()
-    .previewDisplayName("Yellow - Medium")
+#Preview("Custom tints") {
+  VStack(spacing: 20) {
+    CircularProgressView(percentage: 70.0, tint: WLColorTokens.teal)
+    CircularProgressView(percentage: 45.0, tint: WLColorTokens.purple)
+  }
+  .padding()
 }
 
-#Preview("Low Progress (35%)") {
-  CircularProgressView(percentage: 35.0)
-    .padding()
-    .previewDisplayName("Orange - Low")
+#Preview("Sizes") {
+  VStack(spacing: 20) {
+    CircularProgressView(percentage: 75.0, size: 150.0)
+    CircularProgressView(percentage: 45.0, size: 60.0)
+  }
+  .padding()
 }
 
-#Preview("Custom Size (150pt)") {
-  CircularProgressView(percentage: 75.0, size: 150.0)
-    .padding()
-    .previewDisplayName("Large Size")
-}
-
-#Preview("Small Size (60pt)") {
-  CircularProgressView(percentage: 45.0, size: 60.0)
-    .padding()
-    .previewDisplayName("Small Size")
-}
-
-#Preview("Edge Cases") {
+#Preview("Edge cases") {
   VStack(spacing: 20) {
     CircularProgressView(percentage: 0.0)
     CircularProgressView(percentage: 100.0)
-    CircularProgressView(percentage: 50.0)
-    CircularProgressView(percentage: 70.0)
   }
   .padding()
-  .previewDisplayName("Edge Cases")
 }
 
 #Preview("Animation Demo") {
   AnimatedProgressPreview()
-    .previewDisplayName("Animated")
 }
 
 /// Helper view for animation preview

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/CircularProgressView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/CircularProgressView.swift
@@ -76,13 +76,16 @@ struct CircularProgressView: View {
 
   // MARK: - Computed Properties
 
-  /// Returns the formatted percentage string.
+  /// Returns the formatted percentage string, clamped to 0–100 so the label
+  /// can't disagree with the ring fill (which clamps via `clampedProgress`).
+  /// `internal` for test access.
   var formattedPercentage: String {
+    let clamped = min(max(percentage, 0), 100)
     // Show one decimal place if needed, otherwise show whole number
-    if percentage.truncatingRemainder(dividingBy: 1) == 0 {
-      "\(Int(percentage))%"
+    if clamped.truncatingRemainder(dividingBy: 1) == 0 {
+      return "\(Int(clamped))%"
     } else {
-      String(format: "%.1f%%", percentage)
+      return String(format: "%.1f%%", clamped)
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CircularProgressViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CircularProgressViewTests.swift
@@ -92,22 +92,20 @@ struct CircularProgressViewTests {
 
   // MARK: - Edge Case Tests
 
-  @Test("view handles percentage over 100")
+  @Test("view stores raw over-100 percentage but clamps the label to 100%")
   func view_handlesPercentageOver100() {
     let view = CircularProgressView(percentage: 150.0)
 
-    // Should clamp display to 100%
     #expect(view.percentage == 150.0)
-    // Visual clamping happens in the view rendering
+    #expect(view.formattedPercentage == "100%")
   }
 
-  @Test("view handles negative percentage")
+  @Test("view stores raw negative percentage but clamps the label to 0%")
   func view_handlesNegativePercentage() {
     let view = CircularProgressView(percentage: -10.0)
 
-    // Should clamp display to 0%
     #expect(view.percentage == -10.0)
-    // Visual clamping happens in the view rendering
+    #expect(view.formattedPercentage == "0%")
   }
 
   // MARK: - Animation Tests

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CircularProgressViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CircularProgressViewTests.swift
@@ -63,62 +63,31 @@ struct CircularProgressViewTests {
     #expect(view.size == 200.0)
   }
 
-  // MARK: - Color Tests
+  // MARK: - Tint Tests
 
-  @Test("green color for high percentage (>70%)")
-  func greenColor_forHighPercentage() {
+  // Color is no longer derived from the value (the green/yellow/orange
+  // "performance grading" was removed per #281); the tint is a fixed input.
+
+  @Test("view uses the neutral interactive accent tint by default")
+  func view_usesDefaultTint() {
     let view = CircularProgressView(percentage: 85.0)
 
-    #expect(view.progressColor == .green)
+    #expect(view.tint == WLColorTokens.interactiveAccent)
   }
 
-  @Test("green color for exactly 71%")
-  func greenColor_forExactly71Percent() {
-    let view = CircularProgressView(percentage: 71.0)
+  @Test("default tint does not depend on the percentage value")
+  func view_defaultTintIsValueIndependent() {
+    let low = CircularProgressView(percentage: 10.0)
+    let high = CircularProgressView(percentage: 95.0)
 
-    #expect(view.progressColor == .green)
+    #expect(low.tint == high.tint)
   }
 
-  @Test("yellow color for medium percentage (50-70%)")
-  func yellowColor_forMediumPercentage() {
-    let view = CircularProgressView(percentage: 60.0)
+  @Test("view preserves a custom tint")
+  func view_preservesCustomTint() {
+    let view = CircularProgressView(percentage: 50.0, tint: WLColorTokens.teal)
 
-    #expect(view.progressColor == .yellow)
-  }
-
-  @Test("yellow color for exactly 70%")
-  func yellowColor_forExactly70Percent() {
-    let view = CircularProgressView(percentage: 70.0)
-
-    #expect(view.progressColor == .yellow)
-  }
-
-  @Test("yellow color for exactly 50%")
-  func yellowColor_forExactly50Percent() {
-    let view = CircularProgressView(percentage: 50.0)
-
-    #expect(view.progressColor == .yellow)
-  }
-
-  @Test("orange color for low percentage (<50%)")
-  func orangeColor_forLowPercentage() {
-    let view = CircularProgressView(percentage: 30.0)
-
-    #expect(view.progressColor == .orange)
-  }
-
-  @Test("orange color for exactly 49%")
-  func orangeColor_forExactly49Percent() {
-    let view = CircularProgressView(percentage: 49.0)
-
-    #expect(view.progressColor == .orange)
-  }
-
-  @Test("orange color for 0%")
-  func orangeColor_for0Percent() {
-    let view = CircularProgressView(percentage: 0.0)
-
-    #expect(view.progressColor == .orange)
+    #expect(view.tint == WLColorTokens.teal)
   }
 
   // MARK: - Edge Case Tests
@@ -191,12 +160,13 @@ struct CircularProgressViewTests {
   func view_worksWithAllParameters() {
     let view = CircularProgressView(
       percentage: 85.5,
-      size: 150.0
+      size: 150.0,
+      tint: WLColorTokens.purple
     )
 
     #expect(view.percentage == 85.5)
     #expect(view.size == 150.0)
-    #expect(view.progressColor == .green)
+    #expect(view.tint == WLColorTokens.purple)
     #expect(view.formattedPercentage == "85.5%")
   }
 }


### PR DESCRIPTION
## Summary

First of three PRs decomposing #373 (Liquid Glass analytics primitives). Rebuilds the **progress indicator**.

`CircularProgressView` previously colored its ring green/yellow/orange by value as a "performance grade." Per #373 and #281, that value-judgment coloring is removed — the ring is now descriptive, not prescriptive.

## Changes
- **Remove performance grading** — deleted the `progressColor` threshold logic. The ring renders in a single `tint` color and never derives color from the percentage. (Resolves the consistency-score color-coding concern tracked in #281.)
- **Add `tint` parameter** — defaults to the neutral `WLColorTokens.interactiveAccent`; callers may pass a section/layer accent.
- **Design tokens + accessibility** — label uses `WLColorTokens.primaryText`; the track ring holds more contrast under Reduce Transparency; the fill animation routes through `wlAnimation` (suppressed under Reduce Motion).
- **Previews** refreshed to show tints/sizes/edge cases rather than grading tiers.

## Tests
- Replaced the color-threshold assertions with tint coverage: default tint is **value-independent** (a low and a high percentage produce the same tint) and a custom tint is preserved. Percentage/size/formatting/edge/integration coverage retained.
- `run-tests-individually.sh` → build green, all 44 suites pass; swiftformat clean.

## Call-site impact
The only consumer (`AnalyticsViewSections.emotionalHealthSection`, medicinal-ratio ring) keeps the default tint, so its appearance becomes a single neutral accent instead of a graded color.

## Verification note
Ring rendering / accessibility degradation is visual and not unit-testable under the project's no-ViewInspector philosophy; covered by stored-property tests + previews.

Part of #373 · epic #187 · resolves the color-coding ask in #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
