### PR TITLE
feat(analytics): tokenize HorizontalBarChart + Reduce Motion/Transparency (#373)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/HorizontalBarChart.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/HorizontalBarChart.swift
@@ -34,8 +34,10 @@ struct HorizontalBarChart: View {
   /// The items to display in the chart
   let items: [BarChartItem]
 
-  /// The maximum width available for bars (calculated from geometry)
-  private let barSpacing: CGFloat = 4
+  // Component geometry. Row height and the label/value column widths are
+  // chart-specific layout (not global spacing), so they stay local; the
+  // inter-row gap reuses the shared spacing scale.
+  private let barSpacing = WLSpacingTokens.paddingXS
   private let rowHeight: CGFloat = 20
 
   var body: some View {
@@ -55,25 +57,31 @@ private struct BarRow: View {
   let rowHeight: CGFloat
 
   @State private var animatedPercentage: Double = 0
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+  private let labelWidth: CGFloat = 50
+  private let valueWidth: CGFloat = 35
+  private let barCornerRadius: CGFloat = 3
 
   var body: some View {
-    HStack(spacing: 8) {
+    HStack(spacing: WLSpacingTokens.paddingS) {
       // Label
       Text(item.label)
-        .font(.caption2)
+        .font(WLTypographyTokens.tag)
         .lineLimit(1)
-        .frame(width: 50, alignment: .leading)
+        .frame(width: labelWidth, alignment: .leading)
 
       // Bar with background and foreground
       GeometryReader { geometry in
         ZStack(alignment: .leading) {
           // Background track
-          RoundedRectangle(cornerRadius: 3)
-            .fill(Color.secondary.opacity(0.2))
+          RoundedRectangle(cornerRadius: barCornerRadius)
+            .fill(trackColor)
             .frame(height: rowHeight)
 
           // Foreground bar
-          RoundedRectangle(cornerRadius: 3)
+          RoundedRectangle(cornerRadius: barCornerRadius)
             .fill(item.color)
             .frame(
               width: barWidth(
@@ -88,18 +96,30 @@ private struct BarRow: View {
 
       // Percentage
       Text(formattedPercentage(item.percentage))
-        .font(.caption2)
-        .foregroundColor(.secondary)
-        .frame(width: 35, alignment: .trailing)
+        .font(WLTypographyTokens.tag)
+        .foregroundColor(WLColorTokens.secondaryText)
+        .frame(width: valueWidth, alignment: .trailing)
     }
     .onAppear {
-      withAnimation(.easeOut(duration: 0.6)) {
+      // Animate the bar growing in — but Reduce Motion shows the final
+      // width immediately rather than the decorative sweep.
+      if reduceMotion {
         animatedPercentage = item.percentage
+      } else {
+        withAnimation(.easeOut(duration: 0.6)) {
+          animatedPercentage = item.percentage
+        }
       }
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel("\(item.label): \(formattedPercentage(item.percentage))")
     .accessibilityValue("Bar chart showing \(formattedPercentage(item.percentage))")
+  }
+
+  /// Track (unfilled) bar color. Holds more contrast under Reduce
+  /// Transparency so the track stays visible without faint translucency.
+  private var trackColor: Color {
+    Color.secondary.opacity(reduceTransparency ? 0.4 : 0.2)
   }
 
   /// Calculates the bar width based on percentage
@@ -108,12 +128,14 @@ private struct BarRow: View {
     return availableWidth * (clampedPercentage / 100.0)
   }
 
-  /// Formats the percentage for display
+  /// Formats the percentage for display, clamped to 0–100 so the label can't
+  /// disagree with the bar width (which clamps via `barWidth`).
   private func formattedPercentage(_ percentage: Double) -> String {
-    if percentage.truncatingRemainder(dividingBy: 1) == 0 {
-      "\(Int(percentage))%"
+    let clamped = min(max(percentage, 0), 100)
+    if clamped.truncatingRemainder(dividingBy: 1) == 0 {
+      return "\(Int(clamped))%"
     } else {
-      String(format: "%.1f%%", percentage)
+      return String(format: "%.1f%%", clamped)
     }
   }
 }
@@ -166,7 +188,6 @@ extension HorizontalBarChart {
     ])
   }
   .padding()
-  .previewDisplayName("Mode Distribution")
 }
 
 #Preview("Edge Cases") {
@@ -181,13 +202,11 @@ extension HorizontalBarChart {
     ])
   }
   .padding()
-  .previewDisplayName("Edge Cases")
 }
 
 #Preview("Empty State") {
   HorizontalBarChart(items: [])
     .padding()
-    .previewDisplayName("Empty")
 }
 
 #Preview("Many Items") {
@@ -211,5 +230,4 @@ extension HorizontalBarChart {
     }
     .padding()
   }
-  .previewDisplayName("Many Items")
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/HorizontalBarChart.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/HorizontalBarChart.swift
@@ -111,9 +111,11 @@ private struct BarRow: View {
         }
       }
     }
+    // Single self-sufficient label (e.g. "Green: 24%"); the chart context is
+    // already conveyed by the parent. No separate accessibilityValue, which
+    // would otherwise double-announce the percentage.
     .accessibilityElement(children: .combine)
     .accessibilityLabel("\(item.label): \(formattedPercentage(item.percentage))")
-    .accessibilityValue("Bar chart showing \(formattedPercentage(item.percentage))")
   }
 
   /// Track (unfilled) bar color. Holds more contrast under Reduce


### PR DESCRIPTION
## Summary

Second of three PRs decomposing #373 (Liquid Glass analytics primitives). Brings **`HorizontalBarChart`** in line with the design system and accessibility settings. The data model and both call sites (`ModeDistributionView`, `PhaseJourneyView`) are unchanged.

## Changes
- **Design tokens** — labels/values use `WLTypographyTokens.tag`; value color uses `WLColorTokens.secondaryText`; inter-row gap uses `WLSpacingTokens.paddingXS` and row spacing `paddingS`. Chart-specific geometry (row height, label/value column widths, bar corner radius) stays as named local constants — it's component layout, not global spacing.
- **Reduce Transparency** — track holds more contrast (0.4 vs 0.2) so the unfilled bar stays legible without faint translucency.
- **Reduce Motion** — the appear-grow animation is skipped (final width shown immediately) when Reduce Motion is on.
- **Label clamp** — the value label is clamped to 0–100 so it can't disagree with the bar width (which already clamps), matching the progress-indicator fix from #394.
- **Preview cleanup** — removed redundant `.previewDisplayName(...)` calls (the `#Preview` macro already names each), clearing the compiler warnings.

## Tests
- Existing `HorizontalBarChartTests` (data-model + order-preservation + edge cases) unchanged and green.
- `run-tests-individually.sh HorizontalBarChartTests ModeDistributionViewTests PhaseJourneyViewTests` → build green, all pass; swiftformat clean.

## Verification note
Token/spacing and a11y degradation are visual and not unit-testable under the no-ViewInspector philosophy; the data-model/order contract remains covered by the existing suite.

Part of #373 · epic #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
