### PR TITLE
feat(analytics): shared loading + error state primitives (#373)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLColorTokens.swift
@@ -64,6 +64,11 @@ enum WLColorTokens {
   /// Negative status (offline, sync failed).
   static let statusNegative: Color = .red
 
+  /// Warning / recoverable-error affordance (e.g. error-state icons). Distinct
+  /// from `statusNegative` — signals "something went wrong, try again" rather
+  /// than a hard failure state.
+  static let warningAccent: Color = .orange
+
   // MARK: - Text Colors
 
   static let primaryText: Color = .white

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsDetailHubView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsDetailHubView.swift
@@ -362,10 +362,3 @@ private struct GrowthIndicatorsDetailView: View {
     }
   }
 }
-
-// MARK: - Shared UI Components
-
-//
-// Loading and error states are now the shared `AnalyticsLoadingView` and
-// `AnalyticsErrorView` primitives (Views/Components), replacing the previous
-// per-file `AnalyticsLoadingStates` enum.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsDetailHubView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsDetailHubView.swift
@@ -204,7 +204,7 @@ private struct SelfCareDetailView: View {
       VStack(spacing: 16) {
         switch viewModel.state {
         case .idle, .loading:
-          AnalyticsLoadingStates.loadingView
+          AnalyticsLoadingView()
         case let .loaded(analytics):
           StrategyUsageView(
             analytics: analytics,
@@ -213,7 +213,7 @@ private struct SelfCareDetailView: View {
           )
           .padding()
         case let .error(message):
-          AnalyticsLoadingStates.errorView(
+          AnalyticsErrorView(
             message: message,
             retry: { await viewModel.retry(limit: AnalyticsDetailHubView.defaultTopStrategiesLimit) }
           )
@@ -267,7 +267,7 @@ private struct TemporalPatternsDetailView: View {
       VStack(spacing: 16) {
         switch viewModel.state {
         case .idle, .loading:
-          AnalyticsLoadingStates.loadingView
+          AnalyticsLoadingView()
         case let .loaded(patterns):
           TemporalPatternsView(
             patterns: patterns,
@@ -277,7 +277,7 @@ private struct TemporalPatternsDetailView: View {
           )
           .padding()
         case let .error(message):
-          AnalyticsLoadingStates.errorView(
+          AnalyticsErrorView(
             message: message,
             retry: {
               await viewModel.retry(
@@ -333,12 +333,12 @@ private struct GrowthIndicatorsDetailView: View {
       VStack(spacing: 16) {
         switch viewModel.state {
         case .idle, .loading:
-          AnalyticsLoadingStates.loadingView
+          AnalyticsLoadingView()
         case let .loaded(indicators):
           GrowthIndicatorsView(indicators: indicators)
             .padding()
         case let .error(message):
-          AnalyticsLoadingStates.errorView(
+          AnalyticsErrorView(
             message: message,
             retry: {
               await viewModel.retry(
@@ -365,43 +365,7 @@ private struct GrowthIndicatorsDetailView: View {
 
 // MARK: - Shared UI Components
 
-/// Shared loading and error states for analytics detail views.
-///
-/// Extracted to avoid duplication across SelfCare, Temporal, and Growth detail views.
-private enum AnalyticsLoadingStates {
-  static var loadingView: some View {
-    VStack(spacing: 16) {
-      ProgressView()
-        .progressViewStyle(.circular)
-        .tint(.white)
-
-      Text("Loading analytics...")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .padding(.top, 40)
-  }
-
-  static func errorView(message: String, retry: @escaping () async -> Void) -> some View {
-    VStack(spacing: 16) {
-      Image(systemName: "exclamationmark.triangle")
-        .font(.system(size: 40))
-        .foregroundColor(.orange)
-
-      Text("Error")
-        .font(.headline)
-
-      Text(message)
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
-
-      Button("Retry") {
-        Task { await retry() }
-      }
-      .buttonStyle(.borderedProminent)
-    }
-    .padding(.top, 40)
-  }
-}
+//
+// Loading and error states are now the shared `AnalyticsLoadingView` and
+// `AnalyticsErrorView` primitives (Views/Components), replacing the previous
+// per-file `AnalyticsLoadingStates` enum.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryListView+States.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryListView+States.swift
@@ -60,22 +60,3 @@ struct JournalEntryListEmptyStateView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
-
-/// Placeholder shown when entry fetch fails.
-struct JournalEntryListErrorStateView: View {
-  let message: String
-
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "exclamationmark.triangle")
-        .font(.title)
-        .foregroundColor(.orange)
-      Text(message)
-        .font(.caption2)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
-        .padding(.horizontal)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-  }
-}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryListView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryListView.swift
@@ -59,10 +59,10 @@ struct JournalEntryListView: View {
   var body: some View {
     Group {
       if isLoading {
-        ProgressView()
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
+        AnalyticsLoadingView()
+          .padding()
       } else if let loadError {
-        JournalEntryListErrorStateView(message: loadError)
+        AnalyticsErrorView(message: loadError)
       } else if filteredEntries.isEmpty {
         JournalEntryListEmptyStateView()
       } else {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsErrorView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsErrorView.swift
@@ -13,10 +13,8 @@ struct AnalyticsErrorView: View {
   let message: String
   let retry: (() async -> Void)?
 
-  /// Creates an error state.
-  /// - Parameters:
-  ///   - message: The user-facing failure description.
-  ///   - retry: Optional async action; when provided, a "Retry" button is shown.
+  /// Explicit init only so `retry` can default to nil — Swift's synthesized
+  /// memberwise init doesn't add parameter defaults.
   init(message: String, retry: (() async -> Void)? = nil) {
     self.message = message
     self.retry = retry
@@ -24,18 +22,25 @@ struct AnalyticsErrorView: View {
 
   var body: some View {
     VStack(spacing: WLSpacingTokens.paddingL) {
-      Image(systemName: "exclamationmark.triangle")
-        .font(.system(size: 40))
-        .foregroundColor(WLColorTokens.warningAccent)
+      // Icon + heading + message read as one VoiceOver element ("Error,
+      // <message>"); the decorative icon is hidden. The Retry button stays
+      // outside the group so it remains a separate, actionable element.
+      VStack(spacing: WLSpacingTokens.paddingL) {
+        Image(systemName: "exclamationmark.triangle")
+          .font(.system(size: 40))
+          .foregroundColor(WLColorTokens.warningAccent)
+          .accessibilityHidden(true)
 
-      Text("Error")
-        .font(.headline)
-        .foregroundColor(WLColorTokens.primaryText)
+        Text("Error")
+          .font(.headline)
+          .foregroundColor(WLColorTokens.primaryText)
 
-      Text(message)
-        .font(.caption)
-        .foregroundColor(WLColorTokens.secondaryText)
-        .multilineTextAlignment(.center)
+        Text(message)
+          .font(.caption)
+          .foregroundColor(WLColorTokens.secondaryText)
+          .multilineTextAlignment(.center)
+      }
+      .accessibilityElement(children: .combine)
 
       if let retry {
         Button("Retry") {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsErrorView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsErrorView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Reusable error-state primitive for analytics screens: a warning icon, a
+/// short heading, the failure message, and an optional retry action.
+///
+/// ViewModel-free — callers pass the message and (optionally) an async retry
+/// closure. The retry button adopts the Liquid Glass primary button style
+/// (`.glassProminent` on watchOS 26+, a tinted fallback otherwise). When
+/// `retry` is nil the button is omitted, so the same primitive serves both
+/// retryable failures (analytics detail views) and terminal ones (the journal
+/// drill-down list).
+struct AnalyticsErrorView: View {
+  let message: String
+  let retry: (() async -> Void)?
+
+  /// Creates an error state.
+  /// - Parameters:
+  ///   - message: The user-facing failure description.
+  ///   - retry: Optional async action; when provided, a "Retry" button is shown.
+  init(message: String, retry: (() async -> Void)? = nil) {
+    self.message = message
+    self.retry = retry
+  }
+
+  var body: some View {
+    VStack(spacing: WLSpacingTokens.paddingL) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: 40))
+        .foregroundColor(WLColorTokens.warningAccent)
+
+      Text("Error")
+        .font(.headline)
+        .foregroundColor(WLColorTokens.primaryText)
+
+      Text(message)
+        .font(.caption)
+        .foregroundColor(WLColorTokens.secondaryText)
+        .multilineTextAlignment(.center)
+
+      if let retry {
+        Button("Retry") {
+          Task { await retry() }
+        }
+        .wlPrimaryButtonStyle(tint: WLColorTokens.interactiveAccent)
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.top, 40)
+    .padding(.horizontal, WLSpacingTokens.paddingL)
+  }
+}
+
+// MARK: - Previews
+
+#Preview("With retry") {
+  AnalyticsErrorView(message: "Couldn't load your insights.", retry: {})
+}
+
+#Preview("Without retry") {
+  AnalyticsErrorView(message: "No journal entries could be loaded.")
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsLoadingView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsLoadingView.swift
@@ -33,33 +33,43 @@ struct AnalyticsLoadingView: View {
   }
 }
 
-/// A view modifier that adds a shimmer animation effect to loading skeletons
+/// A view modifier that adds a shimmer animation effect to loading skeletons.
+///
+/// The shimmer is a perpetual translucent sweep, so it is suppressed under
+/// either Reduce Motion (no perpetual animation) or Reduce Transparency (no
+/// decorative translucent overlay) — leaving a static skeleton in those modes.
 struct ShimmerModifier: ViewModifier {
   @State private var phase: CGFloat = 0
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
   func body(content: Content) -> some View {
-    content
-      .overlay(
-        GeometryReader { geometry in
-          LinearGradient(
-            gradient: Gradient(colors: [
-              Color.clear,
-              Color.white.opacity(0.3),
-              Color.clear,
-            ]),
-            startPoint: .leading,
-            endPoint: .trailing
-          )
-          .frame(width: geometry.size.width * 2)
-          .offset(x: -geometry.size.width + (geometry.size.width * 2 * phase))
+    if reduceMotion || reduceTransparency {
+      content
+    } else {
+      content
+        .overlay(
+          GeometryReader { geometry in
+            LinearGradient(
+              gradient: Gradient(colors: [
+                Color.clear,
+                Color.white.opacity(0.3),
+                Color.clear,
+              ]),
+              startPoint: .leading,
+              endPoint: .trailing
+            )
+            .frame(width: geometry.size.width * 2)
+            .offset(x: -geometry.size.width + (geometry.size.width * 2 * phase))
+          }
+          .mask(content)
+        )
+        .onAppear {
+          withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+            phase = 1
+          }
         }
-        .mask(content)
-      )
-      .onAppear {
-        withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
-          phase = 1
-        }
-      }
+    }
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsErrorViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsErrorViewTests.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Stored-property tests for `AnalyticsErrorView`. The retry button's
+/// presence is driven entirely by whether a `retry` closure was supplied, so
+/// that branch is the meaningful unit-testable contract; the rendered layout
+/// is visual and covered by previews.
+struct AnalyticsErrorViewTests {
+  @Test func storesMessage() {
+    let view = AnalyticsErrorView(message: "Couldn't load insights.")
+
+    #expect(view.message == "Couldn't load insights.")
+  }
+
+  @Test func retryDefaultsToNil() {
+    let view = AnalyticsErrorView(message: "Boom")
+
+    #expect(view.retry == nil)
+  }
+
+  @Test func retryIsPreservedWhenProvided() {
+    let view = AnalyticsErrorView(message: "Boom", retry: {})
+
+    #expect(view.retry != nil)
+  }
+}

--- a/frontend/WavelengthWatch/run-tests-individually.sh
+++ b/frontend/WavelengthWatch/run-tests-individually.sh
@@ -60,6 +60,7 @@ ALL_SUITES=(
   "MenuViewTests"
   "JournalReviewViewTests"
   "CircularProgressViewTests"
+  "AnalyticsErrorViewTests"
   "StreakDisplayViewTests"
   "HorizontalBarChartTests"
   "AnalyticsViewModelTests"


### PR DESCRIPTION
## Summary

Third PR decomposing #373 (Liquid Glass analytics primitives) — the **loading + error states** (the empty state follows in a final PR). Consolidates the scattered loading/error implementations into two reusable, ViewModel-free primitives and migrates all consumers.

## Changes

**Primitives (`Views/Components`)**
- **`AnalyticsErrorView`** (new) — warning icon + heading + message + *optional* async retry. The retry button now uses `wlPrimaryButtonStyle` (`.glassProminent` on watchOS 26+) instead of the old system `.borderedProminent`. `retry == nil` omits the button, so one primitive serves both retryable failures (detail views) and terminal ones (journal drill-down list).
- **`AnalyticsLoadingView`** — the existing skeleton (previously **unused**) becomes the shared loading primitive. Its shimmer is now suppressed under Reduce Motion (no perpetual sweep) **or** Reduce Transparency (no translucent overlay), leaving a static skeleton in those modes.
- **`WLColorTokens.warningAccent`** — tokenizes the error/warning orange (distinct from `statusNegative` red).

**Migrations**
- The three analytics detail views (Self-Care, Temporal, Growth) use `AnalyticsLoadingView()` / `AnalyticsErrorView(...)`; the duplicated per-file `AnalyticsLoadingStates` enum is **deleted**.
- `JournalEntryListView` loading/error use the shared primitives; the bespoke `JournalEntryListErrorStateView` is **removed**. Its empty state stays for the follow-up PR.

## UX deltas (intentional, visual)
- Analytics detail views show a **skeleton** while loading instead of a centered spinner.
- Retry buttons render as Liquid Glass (`.glassProminent`) rather than `.borderedProminent`.
- The journal drill-down error gains a consistent "Error" heading.

## Tests
- `AnalyticsErrorViewTests` covers the message + retry-presence contract (the button's visibility is driven by whether a retry closure was supplied); registered in the runner.
- `run-tests-individually.sh` → build green, all 45 suites pass; swiftformat clean.

## Verification note
Skeleton/shimmer and retry-button rendering are visual and not unit-testable under the no-ViewInspector philosophy; covered by previews + the stored-property contract test.

Part of #373 · epic #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
