### PR TITLE
feat(analytics): shared empty-state primitive (#373)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsView.swift
@@ -137,19 +137,11 @@ struct AnalyticsView: View {
   // MARK: - Empty State
 
   var emptyStateView: some View {
-    VStack(spacing: 16) {
-      Image(systemName: "chart.bar")
-        .font(.system(size: 48))
-        .foregroundColor(.blue.opacity(0.6))
-
-      Text("No Data Yet")
-        .font(.headline)
-
-      Text("Start logging your emotions to see insights and patterns.")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
-    }
-    .padding(.top, 40)
+    AnalyticsEmptyView(
+      systemImage: "chart.bar",
+      title: "No Data Yet",
+      message: "Start logging your emotions to see insights and patterns.",
+      prominence: .prominent
+    )
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/DosageDeepDiveView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/DosageDeepDiveView.swift
@@ -11,7 +11,7 @@ struct DosageDeepDiveView: View {
         .foregroundColor(.secondary)
 
       if topEmotions.isEmpty {
-        EmptyStateView()
+        AnalyticsEmptyView(systemImage: "heart.text.square", title: "No emotions tracked")
       } else {
         ScrollView {
           VStack(alignment: .leading, spacing: 16) {
@@ -98,20 +98,5 @@ private struct EmotionRow: View {
     .padding(.horizontal, 8)
     .background(Color.secondary.opacity(0.1))
     .cornerRadius(6)
-  }
-}
-
-private struct EmptyStateView: View {
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "heart.text.square")
-        .font(.title)
-        .foregroundColor(.secondary)
-      Text("No emotions tracked")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 20)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/GrowthIndicatorsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/GrowthIndicatorsView.swift
@@ -11,7 +11,7 @@ struct GrowthIndicatorsView: View {
         .foregroundColor(.secondary)
 
       if isEmpty {
-        EmptyStateView()
+        AnalyticsEmptyView(systemImage: "waveform.path", title: "No activity data yet")
       } else {
         VStack(alignment: .leading, spacing: 8) {
           MedicinalTrendView(
@@ -169,20 +169,5 @@ private struct DiversityCoverageView: View {
       }
     }
     .padding(.top, 4)
-  }
-}
-
-private struct EmptyStateView: View {
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "waveform.path")
-        .font(.title)
-        .foregroundColor(.secondary)
-      Text("No activity data yet")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 20)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryListView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryListView.swift
@@ -64,7 +64,8 @@ struct JournalEntryListView: View {
       } else if let loadError {
         AnalyticsErrorView(message: loadError)
       } else if filteredEntries.isEmpty {
-        JournalEntryListEmptyStateView()
+        AnalyticsEmptyView(systemImage: "tray", title: "No entries yet")
+          .frame(maxHeight: .infinity)
       } else {
         List(filteredEntries) { entry in
           JournalEntryRowView(

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryRowView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/JournalEntryRowView.swift
@@ -45,18 +45,3 @@ struct JournalEntryRowView: View {
     return strategyNameById[sid]
   }
 }
-
-/// Placeholder shown when the drill-down filter matches no journal entries.
-struct JournalEntryListEmptyStateView: View {
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "tray")
-        .font(.title)
-        .foregroundColor(.secondary)
-      Text("No entries yet")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-  }
-}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/ModeDistributionView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/ModeDistributionView.swift
@@ -12,7 +12,7 @@ struct ModeDistributionView: View {
         .foregroundColor(.secondary)
 
       if layerDistribution.isEmpty {
-        EmptyStateView()
+        AnalyticsEmptyView(systemImage: "chart.bar.xaxis", title: "No data")
       } else {
         HorizontalBarChart(items: barChartItems)
       }
@@ -32,21 +32,6 @@ struct ModeDistributionView: View {
         color: Color(hex: layer.color) ?? .gray
       )
     }
-  }
-}
-
-private struct EmptyStateView: View {
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "chart.bar.xaxis")
-        .font(.title)
-        .foregroundColor(.secondary)
-      Text("No data")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 20)
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/PhaseJourneyView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/PhaseJourneyView.swift
@@ -12,7 +12,7 @@ struct PhaseJourneyView: View {
         .foregroundColor(.secondary)
 
       if phaseDistribution.isEmpty {
-        EmptyStateView()
+        AnalyticsEmptyView(systemImage: "chart.line.uptrend.xyaxis", title: "No data")
       } else {
         HorizontalBarChart(items: barChartItems)
       }
@@ -48,20 +48,5 @@ struct PhaseJourneyView: View {
     default:
       .gray // Unknown phases
     }
-  }
-}
-
-private struct EmptyStateView: View {
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "chart.line.uptrend.xyaxis")
-        .font(.title)
-        .foregroundColor(.secondary)
-      Text("No data")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 20)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/StrategyUsageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/StrategyUsageView.swift
@@ -26,7 +26,7 @@ struct StrategyUsageView: View {
         .foregroundColor(.secondary)
 
       if analytics.topStrategies.isEmpty, phaseGroups.isEmpty {
-        EmptyStateView()
+        AnalyticsEmptyView(systemImage: "chart.bar.xaxis", title: "No strategies used yet")
       } else {
         VStack(alignment: .leading, spacing: 12) {
           // Overall diversity
@@ -190,20 +190,5 @@ private struct StrategyCardView: View {
         .fontWeight(.medium)
         .foregroundColor(.secondary)
     }
-  }
-}
-
-private struct EmptyStateView: View {
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "chart.bar.xaxis")
-        .font(.title)
-        .foregroundColor(.secondary)
-      Text("No strategies used yet")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 20)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/TemporalPatternsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/TemporalPatternsView.swift
@@ -38,7 +38,7 @@ struct TemporalPatternsView: View {
         .foregroundColor(.secondary)
 
       if patterns.hourlyDistribution.isEmpty {
-        EmptyStateView()
+        AnalyticsEmptyView(systemImage: "clock", title: "No rhythm data yet")
       } else {
         VStack(alignment: .leading, spacing: 6) {
           ForEach(hourlySummaries, id: \.hour) { summary in
@@ -164,20 +164,5 @@ private struct HourlyRow: View {
         .foregroundColor(.secondary)
         .frame(width: 20, alignment: .trailing)
     }
-  }
-}
-
-private struct EmptyStateView: View {
-  var body: some View {
-    VStack(spacing: 8) {
-      Image(systemName: "clock")
-        .font(.title)
-        .foregroundColor(.secondary)
-      Text("No rhythm data yet")
-        .font(.caption)
-        .foregroundColor(.secondary)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 20)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsEmptyView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/AnalyticsEmptyView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// Reusable empty-state placeholder for analytics screens: an icon, a title,
+/// and an optional supporting message.
+///
+/// Two prominence levels consolidate the previously per-file empty states:
+/// `.compact` for the inline per-section "no data" placeholders, and
+/// `.prominent` for the top-level overview "start logging" state (larger icon,
+/// headline title, accent tint). ViewModel-free; the icon + text read as a
+/// single VoiceOver element.
+struct AnalyticsEmptyView: View {
+  enum Prominence {
+    case compact
+    case prominent
+  }
+
+  let systemImage: String
+  let title: String
+  let message: String?
+  let prominence: Prominence
+
+  init(
+    systemImage: String,
+    title: String,
+    message: String? = nil,
+    prominence: Prominence = .compact
+  ) {
+    self.systemImage = systemImage
+    self.title = title
+    self.message = message
+    self.prominence = prominence
+  }
+
+  var body: some View {
+    VStack(spacing: spacing) {
+      Image(systemName: systemImage)
+        .font(iconFont)
+        .foregroundColor(iconColor)
+        .accessibilityHidden(true)
+
+      Text(title)
+        .font(titleFont)
+        .foregroundColor(titleColor)
+
+      if let message {
+        Text(message)
+          .font(.caption)
+          .foregroundColor(WLColorTokens.labelText)
+          .multilineTextAlignment(.center)
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.top, topPadding)
+    .padding(.bottom, bottomPadding)
+    .accessibilityElement(children: .combine)
+  }
+
+  // MARK: - Prominence-driven styling
+
+  private var spacing: CGFloat {
+    prominence == .prominent ? WLSpacingTokens.paddingL : WLSpacingTokens.paddingS
+  }
+
+  private var iconFont: Font {
+    prominence == .prominent ? .system(size: 48) : .title
+  }
+
+  private var iconColor: Color {
+    prominence == .prominent
+      ? WLColorTokens.interactiveAccent.opacity(0.6)
+      : WLColorTokens.labelText
+  }
+
+  private var titleFont: Font {
+    prominence == .prominent ? .headline : .caption
+  }
+
+  private var titleColor: Color {
+    prominence == .prominent ? WLColorTokens.primaryText : WLColorTokens.labelText
+  }
+
+  private var topPadding: CGFloat {
+    prominence == .prominent ? 40 : WLSpacingTokens.paddingXL
+  }
+
+  private var bottomPadding: CGFloat {
+    prominence == .prominent ? 0 : WLSpacingTokens.paddingXL
+  }
+}
+
+// MARK: - Previews
+
+#Preview("Compact") {
+  AnalyticsEmptyView(systemImage: "chart.bar.xaxis", title: "No data")
+}
+
+#Preview("Compact with message") {
+  AnalyticsEmptyView(
+    systemImage: "tray",
+    title: "No entries yet",
+    message: "Logged entries that match this filter will appear here."
+  )
+}
+
+#Preview("Prominent") {
+  AnalyticsEmptyView(
+    systemImage: "chart.bar",
+    title: "No Data Yet",
+    message: "Start logging your emotions to see insights and patterns.",
+    prominence: .prominent
+  )
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsEmptyViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsEmptyViewTests.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Stored-property tests for `AnalyticsEmptyView`. The icon/title/message and
+/// prominence are the inputs that drive the rendered layout; the layout itself
+/// is visual and covered by previews.
+struct AnalyticsEmptyViewTests {
+  @Test func storesIconTitleAndMessage() {
+    let view = AnalyticsEmptyView(
+      systemImage: "tray",
+      title: "No entries yet",
+      message: "Nothing here yet."
+    )
+
+    #expect(view.systemImage == "tray")
+    #expect(view.title == "No entries yet")
+    #expect(view.message == "Nothing here yet.")
+  }
+
+  @Test func messageDefaultsToNil() {
+    let view = AnalyticsEmptyView(systemImage: "tray", title: "Empty")
+
+    #expect(view.message == nil)
+  }
+
+  @Test func prominenceDefaultsToCompact() {
+    let view = AnalyticsEmptyView(systemImage: "tray", title: "Empty")
+
+    #expect(view.prominence == .compact)
+  }
+
+  @Test func prominenceIsPreserved() {
+    let view = AnalyticsEmptyView(
+      systemImage: "chart.bar",
+      title: "No Data Yet",
+      prominence: .prominent
+    )
+
+    #expect(view.prominence == .prominent)
+  }
+}

--- a/frontend/WavelengthWatch/run-tests-individually.sh
+++ b/frontend/WavelengthWatch/run-tests-individually.sh
@@ -61,6 +61,7 @@ ALL_SUITES=(
   "JournalReviewViewTests"
   "CircularProgressViewTests"
   "AnalyticsErrorViewTests"
+  "AnalyticsEmptyViewTests"
   "StreakDisplayViewTests"
   "HorizontalBarChartTests"
   "AnalyticsViewModelTests"


### PR DESCRIPTION
## Summary

Final PR in the #373 decomposition (Liquid Glass analytics primitives) — the **empty state**. Consolidates **eight** per-file empty-state implementations into one reusable, ViewModel-free primitive and migrates every analytics consumer. After this lands, #373's primitive set (progress · bar chart · loading · error · empty) is complete.

## Changes

**Primitive (`Views/Components`)**
- **`AnalyticsEmptyView(systemImage:title:message:prominence:)`** — icon + title + optional message. Two prominence levels: `.compact` (inline per-section "no data" placeholders) and `.prominent` (the top-level overview "start logging" state — larger icon, headline title, accent tint). Tokenized fonts/colors/spacing; the icon + text read as a single VoiceOver element (decorative icon hidden).

**Migrations — all bespoke empty states removed**
- Six private `EmptyStateView` structs (`StrategyUsage`, `DosageDeepDive`, `TemporalPatterns`, `ModeDistribution`, `GrowthIndicators`, `PhaseJourney`) and `JournalEntryListEmptyStateView` now call `AnalyticsEmptyView(...)` with their own icon/title; the structs are deleted.
- `AnalyticsView.emptyStateView` uses `.prominent`, preserving its larger treatment + subtitle.
- Renamed `JournalEntryListView+States.swift` → `JournalEntryRowView.swift` — with the error/empty states moved to shared primitives (the error one in #396), the file holds only the row view, so the `+States` name was stale.

## Tests
- `AnalyticsEmptyViewTests` covers the icon/title/message + prominence contract; registered in the runner.
- `run-tests-individually.sh` → build green, all 46 suites pass; swiftformat clean.

## Notes
- Each migrated empty state keeps its original icon and copy; only the rendering is now shared and consistent.
- Per the #396 review note about the journal drill-down skeleton shape: the loading skeleton there is still the generic analytics one. It reads acceptably as a placeholder; a journal-row-shaped skeleton can be a small follow-up if it looks off on-device (flagging rather than speculatively parameterizing).

## Verification note
Rendering is visual and not unit-testable under the no-ViewInspector philosophy; covered by previews + the stored-property contract tests.

Closes #373 · epic #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
