### PR TITLE
feat(journal): parameterize StrategyExpressionCard label (#372)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
@@ -16,9 +16,6 @@ struct StrategyExpressionCard: View {
   let label: String
   let strategy: CatalogStrategyModel
 
-  /// - Parameters:
-  ///   - label: Section label rendered above the strategy name (defaults to "Strategy").
-  ///   - strategy: The strategy to render.
   init(label: String = "Strategy", strategy: CatalogStrategyModel) {
     self.label = label
     self.strategy = strategy

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
@@ -13,11 +13,21 @@ import SwiftUI
 /// `Curriculum/StrategyCard` (a tap-action wrapper) and
 /// `Components/StrategySummaryCard` (an analytics aggregate).
 struct StrategyExpressionCard: View {
+  let label: String
   let strategy: CatalogStrategyModel
+
+  /// - Parameters:
+  ///   - label: Section label above the strategy (default "Strategy"), for
+  ///     parity with `EmotionExpressionCard`'s `label`.
+  ///   - strategy: The strategy to render.
+  init(label: String = "Strategy", strategy: CatalogStrategyModel) {
+    self.label = label
+    self.strategy = strategy
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
-      Text("Strategy")
+      Text(label)
         .font(.caption)
         .foregroundStyle(.secondary)
         .textCase(.uppercase)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Components/StrategyExpressionCard.swift
@@ -17,8 +17,7 @@ struct StrategyExpressionCard: View {
   let strategy: CatalogStrategyModel
 
   /// - Parameters:
-  ///   - label: Section label above the strategy (default "Strategy"), for
-  ///     parity with `EmotionExpressionCard`'s `label`.
+  ///   - label: Section label rendered above the strategy name (defaults to "Strategy").
   ///   - strategy: The strategy to render.
   init(label: String = "Strategy", strategy: CatalogStrategyModel) {
     self.label = label

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/StrategyExpressionCardTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/StrategyExpressionCardTests.swift
@@ -26,4 +26,20 @@ struct StrategyExpressionCardTests {
 
     #expect(card.strategy.id == 7)
   }
+
+  @Test("card label defaults to Strategy")
+  func card_labelDefaultsToStrategy() {
+    let strategy = CatalogStrategyModel(id: 1, strategy: "Take a deep breath", color: "Blue")
+    let card = StrategyExpressionCard(strategy: strategy)
+
+    #expect(card.label == "Strategy")
+  }
+
+  @Test("card preserves a custom label")
+  func card_preservesCustomLabel() {
+    let strategy = CatalogStrategyModel(id: 1, strategy: "Take a deep breath", color: "Blue")
+    let card = StrategyExpressionCard(label: "Coping Strategy", strategy: strategy)
+
+    #expect(card.label == "Coping Strategy")
+  }
 }

--- a/frontend/WavelengthWatch/run-tests-individually.sh
+++ b/frontend/WavelengthWatch/run-tests-individually.sh
@@ -53,6 +53,8 @@ ALL_SUITES=(
   "MysticalJournalIconTests"
   "LayerFilterModeTests"
   "EmotionSummaryCardTests"
+  "EmotionExpressionCardTests"
+  "StrategyExpressionCardTests"
   "ContentViewFilteringTests"
   "JournalFlowViewModelTests"
   "JournalQueueTests"


### PR DESCRIPTION
## Summary

Closes #372 (follow-up from the #371 review).

- **Item 1 — parameterize the label.** `StrategyExpressionCard` hardcoded `Text("Strategy")` while its sibling `EmotionExpressionCard` takes a `label`. Added a `label` init parameter (default `"Strategy"`), so a second caller can render e.g. "Coping Strategy" without forking the view. The only call site (`FlowReviewSheet`) uses the default and is unchanged.
- **Item 2 — already resolved.** The issue asked to replace deprecated `.cornerRadius(10)` with a `RoundedRectangle` background. Both expression cards now use `.wlCardSurface(...)`, which renders a `RoundedRectangle(cornerRadius:).fill(...)` background internally — there are no `.cornerRadius` calls left in `Views/Components`. Verified via grep.

## Drive-by fix
`EmotionExpressionCardTests` and `StrategyExpressionCardTests` existed but were **not** in the runner's `ALL_SUITES`, so they never executed. Registered both (the new label tests would otherwise have been dead).

## Tests
- New: `card_labelDefaultsToStrategy`, `card_preservesCustomLabel`.
- `run-tests-individually.sh EmotionExpressionCardTests StrategyExpressionCardTests` → build green, all pass; swiftformat clean.

Closes #372 · epic #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
