### PR TITLE
fix(journal): make error-alert Cancel back out of the flow (#339)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -86,8 +86,6 @@ struct FlowReviewSheet: View {
         Button("Cancel", role: .cancel) {
           // Back out of the flow entirely (mirrors the toolbar Cancel) so the
           // user isn't stranded on the review sheet after dismissing the error.
-          // The presenter binding's `currentStep == .review` guard then keeps
-          // the sheet's swipe-dismiss path from firing a second cancel. (#339)
           flowCoordinator.cancel()
         }
       } message: {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Journal/FlowReviewSheet.swift
@@ -83,7 +83,13 @@ struct FlowReviewSheet: View {
         Button("Retry") {
           submitEntry()
         }
-        Button("Cancel", role: .cancel) {}
+        Button("Cancel", role: .cancel) {
+          // Back out of the flow entirely (mirrors the toolbar Cancel) so the
+          // user isn't stranded on the review sheet after dismissing the error.
+          // The presenter binding's `currentStep == .review` guard then keeps
+          // the sheet's swipe-dismiss path from firing a second cancel. (#339)
+          flowCoordinator.cancel()
+        }
       } message: {
         Text(errorMessage)
       }


### PR DESCRIPTION
## Summary

Closes #339. The submit-error alert's **Cancel** button was a literal no-op (`Button("Cancel", role: .cancel) {}`), so a user who cancelled after a failed submit was left on the review sheet with no signposted next action.

## Change
Cancel now calls `flowCoordinator.cancel()` — the issue's **option 1** ("Cancel = back out of the flow"). This resets the flow to `.idle`, which dismisses the sheet and returns the user to browsing. The existing **Retry** button still covers "re-attempt," so the two alert actions are now both definitive: Retry = try again, Cancel = give up.

This mirrors the two other dismissal paths already in `FlowReviewSheet` — the toolbar **Cancel** (line 69-70) and the success-alert **OK** (line 76-77) — both of which already call `cancel()`.

## Why option 1 (and not the "add inline retry/cancel affordances" alternative)
The review sheet already provides those affordances — a toolbar Cancel and the Submit button (= retry). The only actual defect was the dead alert-Cancel. Option 1 is the minimal, semantically-consistent fix; I'm flagging the choice here in case you'd prefer the friendlier inline-affordance direction instead.

## No double-cancel (the #336 interaction the AC asks to verify)
`cancel()` sets `currentStep = .idle`. When SwiftUI subsequently writes the sheet's `isPresented = false`, `MainContentDialogsModifier.flowReviewPresenter`'s setter guard — `if !isPresented, currentStep == .review` — is already false, so the swipe-dismiss path can't fire a second `cancel()`.

## Tests
- `cancel()`'s reset-to-idle + clear-selections behavior is already covered by `FlowCoordinatorTests.cancel_resetsState` and `flowCancellation_resetsState`.
- The alert-button → action wiring is a visual change, not unit-testable under the project's no-ViewInspector philosophy (flagged per convention).
- `run-tests-individually.sh FlowCoordinatorTests SubmitTimeoutTests` → build green, all pass; swiftformat clean.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
