### PR TITLE
chore(design-system): tokenize PhaseCrystalCard corner radius (#393)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLSpacingTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLSpacingTokens.swift
@@ -18,6 +18,9 @@ enum WLSpacingTokens {
   static let cardCornerRadius: CGFloat = 12
   static let cardCornerRadiusSmall: CGFloat = 8
   static let cardCornerRadiusCompact: CGFloat = 6
+  /// Larger radius for the hero phase "crystal" card, which is visually
+  /// bigger than the standard cards.
+  static let cardCornerRadiusLarge: CGFloat = 16
   static let cardBorderWidth: CGFloat = 0.5
   static let cardPaddingStandard: CGFloat = 12
   static let cardPaddingCompact: CGFloat = 8

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -140,10 +140,10 @@ struct PhaseCrystalCard: View {
   }
 
   private var cardBackground: some View {
-    RoundedRectangle(cornerRadius: 16)
+    RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
       .fill(cardFill)
       .overlay(
-        RoundedRectangle(cornerRadius: 16)
+        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
           .stroke(
             LinearGradient(
               gradient: Gradient(colors: [


### PR DESCRIPTION
## Summary
Closes #393 (follow-up filed during the #392 review).

`PhaseCrystalCard.cardBackground` used a hardcoded `cornerRadius: 16` (twice — fill + stroke overlay) rather than a design-system token. Adds `WLSpacingTokens.cardCornerRadiusLarge = 16` (the hero crystal card is intentionally larger than the standard 12pt cards) and replaces both literals with it.

**No visual change** — same radius, now tokenized.

## Tests
Build green; swiftformat clean. No behavior to test (constant substitution).

Closes #393 · epic #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)