### PR TITLE
feat(journal): present log-confirmation immediately via root host (fixes B2)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// A request to show the "Would you like to log …?" confirmation for a
+/// journal entry, carried as the payload of
+/// `PresentationCoordinator.ActivePresentation.logConfirmation`.
+///
+/// Leaf cards (`CurriculumCard`, `StrategyCard`, `StrategyListView`) used
+/// to own this as local `@State` + a `.alert` rendered from inside a
+/// pushed `navigationDestination`, which is exactly why the confirmation
+/// was deferred until the user backed out (B2 in
+/// `prompts/claude-comm/spec-primary-selector-rebuild.md` §2). Hoisting it
+/// here lets `RootPresentationHost`, anchored above the navigation push,
+/// present it immediately. The request carries the verbatim alert copy so
+/// the host renders it without re-deriving strings, and an `Action`
+/// describing what "Yes" should do.
+struct LogConfirmationRequest: Equatable {
+  /// Alert title, verbatim (e.g. "Log Medicinal", "Log Strategy").
+  let alertTitle: String
+  /// Alert message, verbatim (e.g. `Would you like to log "Grounded"?`).
+  let message: String
+  /// What tapping "Yes" performs.
+  let action: Action
+
+  /// The two journal-logging shapes a confirmation can resolve to. The
+  /// branching mirrors the leaf cards' former `handleLogAction` exactly;
+  /// see `LogConfirmationHandler`.
+  enum Action: Equatable {
+    /// Log a curriculum entry (`CurriculumCard`).
+    case curriculum(entry: CatalogCurriculumEntryModel)
+    /// Log a strategy against a curriculum id (`StrategyCard`,
+    /// `StrategyListView`). `curriculumID` is nil when no curriculum entry
+    /// is available to log against — valid only inside the
+    /// strategy-selection flow.
+    case strategy(strategy: CatalogStrategyModel, curriculumID: Int?)
+  }
+}
+
+/// Performs the journal-logging action behind a `LogConfirmationRequest`.
+///
+/// This is the single home for the branching the three leaf cards used to
+/// each duplicate in their private `handleLogAction`. The behavior is
+/// preserved exactly — flow-selection steps capture into `FlowCoordinator`,
+/// every other step logs directly via `ContentViewModel.journal`. `perform`
+/// is `async` so the direct-log path can `await` the journal call (the
+/// cards previously wrapped it in a fire-and-forget `Task`); the
+/// flow-capture paths are synchronous and complete before the first await.
+@MainActor
+struct LogConfirmationHandler {
+  let flowCoordinator: FlowCoordinator
+  let viewModel: ContentViewModel
+
+  func perform(_ action: LogConfirmationRequest.Action) async {
+    switch action {
+    case let .curriculum(entry):
+      switch flowCoordinator.currentStep {
+      case .selectingPrimary:
+        flowCoordinator.capturePrimary(entry)
+      case .selectingSecondary:
+        flowCoordinator.captureSecondary(entry)
+      case .idle:
+        // Auto-start the flow when logging from normal browsing.
+        flowCoordinator.startPrimarySelection()
+        flowCoordinator.capturePrimary(entry)
+      default:
+        // Confirming / review / selectingStrategy: immediate logging.
+        await viewModel.journal(curriculumID: entry.id)
+      }
+    case let .strategy(strategy, curriculumID):
+      if flowCoordinator.currentStep == .selectingStrategy {
+        flowCoordinator.captureStrategy(strategy)
+      } else if let curriculumID {
+        await viewModel.journal(curriculumID: curriculumID, strategyID: strategy.id)
+      }
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
@@ -66,5 +66,8 @@ final class PresentationCoordinator: ObservableObject {
     case menu
     case onboarding
     case storageError
+    /// The "Would you like to log …?" journal confirmation, carrying the
+    /// alert copy and the action to perform on "Yes".
+    case logConfirmation(LogConfirmationRequest)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/CurriculumCard.swift
@@ -6,9 +6,7 @@ struct CurriculumCard: View {
   let accent: Color
   let actionTitle: String
   let entry: CatalogCurriculumEntryModel
-  @EnvironmentObject private var viewModel: ContentViewModel
-  @EnvironmentObject private var flowCoordinator: FlowCoordinator
-  @State private var showingJournalConfirmation = false
+  @EnvironmentObject private var presentationCoordinator: PresentationCoordinator
 
   var body: some View {
     ZStack(alignment: .topTrailing) {
@@ -34,23 +32,15 @@ struct CurriculumCard: View {
         stroke: accent.opacity(0.5)
       )
       .onTapGesture {
-        showingJournalConfirmation = true
+        presentationCoordinator.request(logRequest)
       }
 
       MysticalJournalIcon(color: accent)
         .padding(.top, 8)
         .padding(.trailing, 12)
         .onTapGesture {
-          showingJournalConfirmation = true
+          presentationCoordinator.request(logRequest)
         }
-    }
-    .alert("Log \(title.capitalized)", isPresented: $showingJournalConfirmation) {
-      Button("Yes") {
-        handleLogAction()
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("Would you like to log \"\(expression)\"?")
     }
     // The card is tapped via onTapGesture, which SwiftUI does not expose as a
     // VoiceOver action; present it as one labeled button instead.
@@ -58,22 +48,17 @@ struct CurriculumCard: View {
     .accessibilityAddTraits(.isButton)
     .accessibilityLabel("\(title): \(expression)")
     .accessibilityHint("Logs this entry")
-    .accessibilityAction { showingJournalConfirmation = true }
+    .accessibilityAction { presentationCoordinator.request(logRequest) }
   }
 
-  private func handleLogAction() {
-    switch flowCoordinator.currentStep {
-    case .selectingPrimary:
-      flowCoordinator.capturePrimary(entry)
-    case .selectingSecondary:
-      flowCoordinator.captureSecondary(entry)
-    case .idle:
-      // Auto-start flow when logging from normal mode
-      flowCoordinator.startPrimarySelection()
-      flowCoordinator.capturePrimary(entry)
-    default:
-      // Other states (confirming, review, selectingStrategy): immediate logging
-      Task { await viewModel.journal(curriculumID: entry.id) }
-    }
+  /// The confirmation request this card surfaces; the root host renders it
+  /// and `LogConfirmationHandler` performs the same branching the card's
+  /// former `handleLogAction` did.
+  private var logRequest: PresentationCoordinator.ActivePresentation {
+    .logConfirmation(LogConfirmationRequest(
+      alertTitle: "Log \(title.capitalized)",
+      message: "Would you like to log \"\(expression)\"?",
+      action: .curriculum(entry: entry)
+    ))
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyCard.swift
@@ -4,9 +4,8 @@ struct StrategyCard: View {
   let strategy: CatalogStrategyModel
   let color: Color
   let phase: CatalogPhaseModel
-  @EnvironmentObject private var viewModel: ContentViewModel
   @EnvironmentObject private var flowCoordinator: FlowCoordinator
-  @State private var showingJournalConfirmation = false
+  @EnvironmentObject private var presentationCoordinator: PresentationCoordinator
 
   private var primaryID: Int? {
     phase.medicinal.first?.id ?? phase.toxic.first?.id
@@ -38,7 +37,7 @@ struct StrategyCard: View {
       )
       .onTapGesture {
         if isActionable {
-          showingJournalConfirmation = true
+          presentationCoordinator.request(logRequest)
         }
       }
 
@@ -47,17 +46,9 @@ struct StrategyCard: View {
           .padding(.top, 6)
           .padding(.trailing, 8)
           .onTapGesture {
-            showingJournalConfirmation = true
+            presentationCoordinator.request(logRequest)
           }
       }
-    }
-    .alert("Log Strategy", isPresented: $showingJournalConfirmation) {
-      Button("Yes") {
-        handleLogAction()
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("Would you like to log \"\(strategy.strategy)\"?")
     }
     // Tapped via onTapGesture; expose as one labeled VoiceOver element. Only
     // advertise the button trait / action when a tap would actually log
@@ -68,22 +59,18 @@ struct StrategyCard: View {
     .accessibilityHint(isActionable ? "Logs this strategy" : "")
     .accessibilityAction {
       guard isActionable else { return }
-      showingJournalConfirmation = true
+      presentationCoordinator.request(logRequest)
     }
   }
 
-  private func handleLogAction() {
-    if flowCoordinator.currentStep == .selectingStrategy {
-      flowCoordinator.captureStrategy(strategy)
-    } else {
-      if let primaryID {
-        Task {
-          await viewModel.journal(
-            curriculumID: primaryID,
-            strategyID: strategy.id
-          )
-        }
-      }
-    }
+  /// The confirmation request this card surfaces; the root host renders it
+  /// and `LogConfirmationHandler` performs the same branching the card's
+  /// former `handleLogAction` did.
+  private var logRequest: PresentationCoordinator.ActivePresentation {
+    .logConfirmation(LogConfirmationRequest(
+      alertTitle: "Log Strategy",
+      message: "Would you like to log \"\(strategy.strategy)\"?",
+      action: .strategy(strategy: strategy, curriculumID: primaryID)
+    ))
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/StrategyListView.swift
@@ -4,10 +4,8 @@ struct StrategyListView: View {
   let phase: CatalogPhaseModel
   let color: Color
   @EnvironmentObject private var viewModel: ContentViewModel
-  @EnvironmentObject private var flowCoordinator: FlowCoordinator
+  @EnvironmentObject private var presentationCoordinator: PresentationCoordinator
   @Environment(\.isShowingDetailView) private var isShowingDetailView
-  @State private var showingJournalConfirmation = false
-  @State private var selectedStrategy: CatalogStrategyModel?
 
   /// For strategies-only phases, find a curriculum ID from any available layer/phase
   private var fallbackCurriculumID: Int? {
@@ -63,8 +61,7 @@ struct StrategyListView: View {
               )
               .onTapGesture {
                 if fallbackCurriculumID != nil {
-                  selectedStrategy = item
-                  showingJournalConfirmation = true
+                  presentationCoordinator.request(logRequest(for: item))
                 }
               }
 
@@ -73,8 +70,7 @@ struct StrategyListView: View {
                   .padding(.top, 8)
                   .padding(.trailing, 12)
                   .onTapGesture {
-                    selectedStrategy = item
-                    showingJournalConfirmation = true
+                    presentationCoordinator.request(logRequest(for: item))
                   }
               }
             }
@@ -87,8 +83,7 @@ struct StrategyListView: View {
             .accessibilityHint(fallbackCurriculumID != nil ? "Logs this strategy" : "")
             .accessibilityAction {
               guard fallbackCurriculumID != nil else { return }
-              selectedStrategy = item
-              showingJournalConfirmation = true
+              presentationCoordinator.request(logRequest(for: item))
             }
           }
         }
@@ -97,14 +92,6 @@ struct StrategyListView: View {
       .padding(.vertical, 16)
     }
     .background(WLColorTokens.pageBackground())
-    .alert("Log Strategy", isPresented: $showingJournalConfirmation) {
-      Button("Yes") {
-        handleLogAction()
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("Would you like to log \"\(selectedStrategy?.strategy ?? "")\"?")
-    }
     .onAppear {
       isShowingDetailView.wrappedValue = true
     }
@@ -113,18 +100,14 @@ struct StrategyListView: View {
     }
   }
 
-  private func handleLogAction() {
-    if flowCoordinator.currentStep == .selectingStrategy {
-      flowCoordinator.captureStrategy(selectedStrategy)
-    } else {
-      if let curriculumID = fallbackCurriculumID, let strategy = selectedStrategy {
-        Task {
-          await viewModel.journal(
-            curriculumID: curriculumID,
-            strategyID: strategy.id
-          )
-        }
-      }
-    }
+  /// The confirmation request for a tapped strategy row; the root host
+  /// renders it and `LogConfirmationHandler` performs the same branching
+  /// the view's former `handleLogAction` did.
+  private func logRequest(for strategy: CatalogStrategyModel) -> PresentationCoordinator.ActivePresentation {
+    .logConfirmation(LogConfirmationRequest(
+      alertTitle: "Log Strategy",
+      message: "Would you like to log \"\(strategy.strategy)\"?",
+      action: .strategy(strategy: strategy, curriculumID: fallbackCurriculumID)
+    ))
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootPresentationHost.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootPresentationHost.swift
@@ -13,6 +13,8 @@ import SwiftUI
 /// feedback and flow review onto the host too.
 struct RootPresentationHost: ViewModifier {
   @ObservedObject var coordinator: PresentationCoordinator
+  @EnvironmentObject private var flowCoordinator: FlowCoordinator
+  @EnvironmentObject private var viewModel: ContentViewModel
 
   func body(content: Content) -> some View {
     content
@@ -24,6 +26,42 @@ struct RootPresentationHost: ViewModifier {
       } message: {
         Text("Your journal couldn't be opened, so entries logged this session won't be saved. Please reopen the app; if the problem continues, contact support.")
       }
+      // The journal log-confirmation, hoisted above the navigation push so
+      // it presents immediately rather than waiting for a back-out (B2).
+      .alert(
+        logConfirmation?.alertTitle ?? "",
+        isPresented: logConfirmationPresented
+      ) {
+        Button("Yes") {
+          if let action = logConfirmation?.action {
+            Task { await handler.perform(action) }
+          }
+        }
+        Button("Cancel", role: .cancel) {}
+      } message: {
+        Text(logConfirmation?.message ?? "")
+      }
+  }
+
+  /// The active log-confirmation request, if one is presented.
+  private var logConfirmation: LogConfirmationRequest? {
+    if case let .logConfirmation(request) = coordinator.active { return request }
+    return nil
+  }
+
+  /// Presentation binding for the log-confirmation alert. Any dismissal
+  /// (Yes, Cancel, or swipe) writes `false`, which clears the coordinator.
+  private var logConfirmationPresented: Binding<Bool> {
+    Binding(
+      get: { logConfirmation != nil },
+      set: { isPresented in
+        if !isPresented { coordinator.dismiss() }
+      }
+    )
+  }
+
+  private var handler: LogConfirmationHandler {
+    LogConfirmationHandler(flowCoordinator: flowCoordinator, viewModel: viewModel)
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LogConfirmationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LogConfirmationTests.swift
@@ -1,0 +1,140 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Tests for the journal log-confirmation migration (#406, fixes B2).
+///
+/// Two layers under test: the coordinator's intent→presentation mapping
+/// for `.logConfirmation`, and `LogConfirmationHandler`'s branching, which
+/// must reproduce exactly what the three leaf cards' former
+/// `handleLogAction` did — flow-selection steps capture into
+/// `FlowCoordinator`; every other step logs directly via `journal`.
+@MainActor
+struct LogConfirmationTests {
+  private func setup() async -> (ContentViewModel, FlowCoordinator, JournalClientMock, CatalogResponseModel) {
+    let catalog = CatalogTestHelper.createTestCatalog()
+    let repository = CatalogRepositoryMock(cached: catalog, result: .success(catalog))
+    let journalClient = JournalClientMock()
+    let viewModel = ContentViewModel(
+      catalogRepository: repository,
+      journalRepository: InMemoryJournalRepository(),
+      journalClient: journalClient
+    )
+    await viewModel.loadCatalog()
+    let coordinator = FlowCoordinator(contentViewModel: viewModel)
+    return (viewModel, coordinator, journalClient, catalog)
+  }
+
+  // MARK: - Coordinator mapping
+
+  @Test("request(.logConfirmation) activates the confirmation with its payload")
+  func request_logConfirmation_activates() {
+    let coordinator = PresentationCoordinator()
+    let request = LogConfirmationRequest(
+      alertTitle: "Log Strategy",
+      message: "Would you like to log \"Deep Breathing\"?",
+      action: .strategy(
+        strategy: CatalogStrategyModel(id: 1, strategy: "Deep Breathing", color: "Blue"),
+        curriculumID: 10
+      )
+    )
+
+    coordinator.request(.logConfirmation(request))
+    #expect(coordinator.active == .logConfirmation(request))
+
+    coordinator.dismiss()
+    #expect(coordinator.active == .idle)
+  }
+
+  // MARK: - Handler: curriculum
+
+  @Test("curriculum action from idle auto-starts the flow and captures primary")
+  func handler_curriculum_fromIdle_startsAndCaptures() async {
+    let (viewModel, flow, _, catalog) = await setup()
+    let entry = catalog.layers[1].phases[0].medicinal[0]
+    let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
+
+    await handler.perform(.curriculum(entry: entry))
+
+    #expect(flow.currentStep == .confirmingPrimary)
+    #expect(flow.selections.primary == entry)
+    #expect(viewModel.layerFilterMode == .emotionsOnly)
+  }
+
+  @Test("curriculum action while selectingPrimary captures primary")
+  func handler_curriculum_selectingPrimary_captures() async {
+    let (viewModel, flow, _, catalog) = await setup()
+    let entry = catalog.layers[1].phases[0].medicinal[0]
+    flow.startPrimarySelection()
+    let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
+
+    await handler.perform(.curriculum(entry: entry))
+
+    #expect(flow.currentStep == .confirmingPrimary)
+    #expect(flow.selections.primary == entry)
+  }
+
+  @Test("curriculum action while selectingSecondary captures secondary")
+  func handler_curriculum_selectingSecondary_captures() async {
+    let (viewModel, flow, _, catalog) = await setup()
+    let entry = catalog.layers[2].phases[0].medicinal[0]
+    flow.promptForSecondary()
+    let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
+
+    await handler.perform(.curriculum(entry: entry))
+
+    #expect(flow.currentStep == .confirmingSecondary)
+    #expect(flow.selections.secondary == entry)
+  }
+
+  @Test("curriculum action in a non-selecting step logs directly")
+  func handler_curriculum_default_logs() async {
+    let (viewModel, flow, journalClient, catalog) = await setup()
+    let entry = catalog.layers[1].phases[0].medicinal[0]
+    flow.showReview() // a "default"-branch step
+
+    let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
+    await handler.perform(.curriculum(entry: entry))
+
+    #expect(journalClient.submissions.count == 1)
+  }
+
+  // MARK: - Handler: strategy
+
+  @Test("strategy action while selectingStrategy captures the strategy")
+  func handler_strategy_selectingStrategy_captures() async {
+    let (viewModel, flow, journalClient, catalog) = await setup()
+    let strategy = catalog.layers[0].phases[0].strategies[0]
+    flow.promptForStrategy()
+    let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
+
+    await handler.perform(.strategy(strategy: strategy, curriculumID: nil))
+
+    #expect(flow.currentStep == .confirmingStrategy)
+    #expect(flow.selections.strategy == strategy)
+    #expect(journalClient.submissions.isEmpty)
+  }
+
+  @Test("strategy action with a curriculum id logs directly when not selecting")
+  func handler_strategy_withCurriculumID_logs() async {
+    let (viewModel, flow, journalClient, catalog) = await setup()
+    let strategy = catalog.layers[0].phases[0].strategies[0]
+    let curriculumID = catalog.layers[1].phases[0].medicinal[0].id
+    let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
+
+    await handler.perform(.strategy(strategy: strategy, curriculumID: curriculumID))
+
+    #expect(journalClient.submissions.count == 1)
+  }
+
+  @Test("strategy action without a curriculum id and not selecting is a no-op")
+  func handler_strategy_noCurriculumID_isNoOp() async {
+    let (viewModel, flow, journalClient, catalog) = await setup()
+    let strategy = catalog.layers[0].phases[0].strategies[0]
+    let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
+
+    await handler.perform(.strategy(strategy: strategy, curriculumID: nil))
+
+    #expect(journalClient.submissions.isEmpty)
+    #expect(flow.currentStep == .idle)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes **B2** — the journal log-confirmation that only appeared after backing out of a curriculum/strategy detail view. Root cause (per `prompts/claude-comm/spec-primary-selector-rebuild.md` §2): the confirmation was leaf-owned `@State` + `.alert` rendered from inside a pushed `navigationDestination`, so watchOS deferred it behind the NavigationStack root's presentations until navigation re-evaluated. This moves it onto the `PresentationCoordinator` (from #405), rendered by `RootPresentationHost` above the push, so it presents immediately.

- **New `LogConfirmationRequest`** (+ `Action`): carries the verbatim alert copy and what "Yes" performs — `.curriculum(entry:)` or `.strategy(strategy:curriculumID:)`. Added as the `.logConfirmation(LogConfirmationRequest)` case on `ActivePresentation`.
- **New `LogConfirmationHandler`**: the single home for the branching the three cards each duplicated in `handleLogAction` — flow-selection steps capture into `FlowCoordinator`; every other step logs via `ContentViewModel.journal`. Behavior is preserved exactly; `perform` is `async` so the direct-log path `await`s the journal call (the cards previously used a fire-and-forget `Task`) and is deterministically testable.
- **`CurriculumCard` / `StrategyCard` / `StrategyListView`**: dropped local `showingJournalConfirmation`/`selectedStrategy` `@State` and the `.alert`; tap + accessibility actions now call `presentationCoordinator.request(.logConfirmation(...))`. Each card's existing actionability guard (`isActionable`, `fallbackCurriculumID != nil`) is unchanged. Unused env objects removed where the handler relocation freed them.
- **`RootPresentationHost`**: renders the confirmation alert above the push and routes "Yes" through `LogConfirmationHandler`.

### Scope (per issue)
No single-active queue/replace policy and no `FlowSubmissionPresenter` retarget — that's #407. `FlowCoordinator` flow-step logic, Models, Services, and backend are untouched.

## Test plan
- New `LogConfirmationTests` (Swift Testing): coordinator `.logConfirmation` mapping (activate + dismiss); handler branches — curriculum from idle (auto-start + capture primary + `.emotionsOnly`), selectingPrimary, selectingSecondary, non-selecting → direct log (`submissions == 1`); strategy selectingStrategy → capture (no log), with curriculum id → direct log, nil id + not selecting → no-op.
- `frontend/WavelengthWatch/run-tests-individually.sh` — full suite, build + all suites green (incl. `CurriculumCardTests`, `FlowCoordinatorTests`, `PresentationCoordinatorTests`).
- `swiftformat --lint frontend` clean; `pre-commit` clean.
- **Unverifiable on-device behavior flagged:** the immediate-presentation fix and copy parity were validated by construction + the handler/coordinator unit tests, not an on-device run. The reviewer should confirm on-device that tapping a curriculum item or strategy inside a pushed detail view shows the confirmation **without** a back-out, and that "Yes" logs/advances exactly as before.

Closes #406
Refs #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
