### PR TITLE
feat(presentation): single-active presentation policy + flow display retarget

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowSubmissionPresenter.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/FlowSubmissionPresenter.swift
@@ -1,17 +1,19 @@
 import Foundation
 
-/// Bridges `FlowCoordinator.submit()` to `ContentViewModel.journalFeedback`.
+/// Bridges `FlowCoordinator.submit()` to user-visible journal feedback.
 ///
 /// The two flow-confirmation alerts (primary, secondary) share identical
 /// queued / failure handling — only the failure-prefix copy varies.
 /// Centralising the logic here keeps `ContentView` focused on view
 /// composition and preserves `FlowCoordinator`'s "pure state management,
 /// no UI" boundary; this presenter is the explicit seam where flow
-/// submission becomes user-visible feedback.
+/// submission becomes user-visible feedback. Feedback is routed through the
+/// `PresentationCoordinator` (#407) so it queues behind interactive
+/// presentations rather than racing them.
 @MainActor
 struct FlowSubmissionPresenter {
   let flowCoordinator: FlowCoordinator
-  let viewModel: ContentViewModel
+  let presentationCoordinator: PresentationCoordinator
 
   /// Submits the current flow entry and renders the appropriate feedback.
   /// - Parameter failurePrefix: Copy shown before the underlying error
@@ -22,14 +24,14 @@ struct FlowSubmissionPresenter {
       try await flowCoordinator.submit()
       flowCoordinator.reset()
     } catch JournalError.queuedForRetry {
-      viewModel.journalFeedback = .init(
+      presentationCoordinator.request(.journalFeedback(.init(
         kind: .queued("Saved offline. Will sync automatically.")
-      )
+      )))
       flowCoordinator.reset()
     } catch {
-      viewModel.journalFeedback = .init(
+      presentationCoordinator.request(.journalFeedback(.init(
         kind: .failure("\(failurePrefix): \(error.localizedDescription)")
-      )
+      )))
     }
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
@@ -13,52 +13,91 @@ import SwiftUI
 /// host, anchored above the navigation push, render exactly one
 /// presentation at a time.
 ///
-/// This skeleton (issue #405) owns the three presentations that were
-/// previously plain local `@State` booleans on the shell — `menu`,
-/// `onboarding`, and `storageError`. The publisher-driven surfaces
-/// (journal feedback, flow review) and the leaf log-confirmation migrate
-/// onto the same coordinator in #406 / #407 as their owners are
-/// retargeted, at which point the conflict policy graduates from the
-/// simple "replace" used here to the queue/priority rules in #407.
+/// The coordinator owns every transient root presentation: the shell's
+/// former local-`@State` surfaces (`menu`, `onboarding`, `storageError`),
+/// the leaf log-confirmation (#406), and the previously publisher-driven
+/// journal feedback and flow review (#407). When two presentations contend,
+/// the priority/queue policy on `request`/`dismiss` decides ordering —
+/// informational feedback queues behind interactive presentations rather
+/// than racing them.
 @MainActor
 final class PresentationCoordinator: ObservableObject {
   /// The presentation currently requested for display, or `.idle`.
   @Published private(set) var active: ActivePresentation = .idle
 
-  /// Requests that `presentation` become the active presentation.
+  /// Presentations queued behind the active one, awaiting `dismiss()`.
+  private var pending: [ActivePresentation] = []
+
+  /// Requests that `presentation` be shown.
   ///
-  /// Skeleton policy: a new request replaces whatever is active. Issue
-  /// #407 refines this into a priority/queue policy so that, e.g., a
-  /// data-loss `storageError` is never silently dropped by a lower-value
-  /// request.
+  /// Single-active policy (#407, SPEC §11 Q4): exactly one presentation is
+  /// visible at a time. A request of strictly higher priority than the
+  /// active one preempts it — the displaced presentation is queued, never
+  /// dropped — while an equal- or lower-priority request waits in the
+  /// queue. `dismiss()` then promotes the highest-priority queued
+  /// presentation. This is what lets informational journal feedback queue
+  /// politely behind an interactive confirmation instead of racing it.
   func request(_ presentation: ActivePresentation) {
-    active = presentation
+    guard presentation != .idle else { return }
+    if active == .idle {
+      active = presentation
+    } else if Self.priority(of: presentation) > Self.priority(of: active) {
+      pending.append(active)
+      active = presentation
+    } else {
+      pending.append(presentation)
+    }
   }
 
-  /// Dismisses the active presentation, returning to `.idle`.
+  /// Dismisses the active presentation and promotes the highest-priority
+  /// queued one (earliest-queued wins ties), or returns to `.idle` when the
+  /// queue is empty.
   func dismiss() {
-    active = .idle
+    guard !pending.isEmpty else {
+      active = .idle
+      return
+    }
+    var bestIndex = pending.startIndex
+    for index in pending.indices
+      where Self.priority(of: pending[index]) > Self.priority(of: pending[bestIndex])
+    {
+      bestIndex = index
+    }
+    active = pending.remove(at: bestIndex)
   }
 
   /// A two-way `Bool` binding suitable for `.sheet(isPresented:)` /
   /// `.alert(isPresented:)`. Reads `true` while `presentation` is active;
-  /// writing `false` (a "Done" button or a swipe-dismiss) clears it,
-  /// preserving the self-dismiss behavior the migrated sheets relied on.
+  /// writing `true` requests it and writing `false` (a "Done" button or a
+  /// swipe-dismiss) dismisses it through the queue policy, preserving the
+  /// self-dismiss behavior the migrated sheets relied on.
   func isPresented(for presentation: ActivePresentation) -> Binding<Bool> {
     Binding(
       get: { self.active == presentation },
       set: { isPresented in
         if isPresented {
-          self.active = presentation
+          self.request(presentation)
         } else if self.active == presentation {
-          self.active = .idle
+          self.dismiss()
         }
       }
     )
   }
 
+  /// Relative display priority; higher wins. A data-loss `storageError`
+  /// outranks interactive surfaces, which outrank informational
+  /// `journalFeedback`.
+  private static func priority(of presentation: ActivePresentation) -> Int {
+    switch presentation {
+    case .idle: -1
+    case .journalFeedback: 0
+    case .menu, .onboarding, .logConfirmation, .flowReview: 1
+    case .storageError: 2
+    }
+  }
+
   /// The set of mutually exclusive root presentations the coordinator can
-  /// surface. Cases are added here as later issues fold their owners in.
+  /// surface.
   enum ActivePresentation: Equatable {
     /// Nothing is presented. Named `idle` rather than `none` to avoid
     /// visual collision with `Optional.none` at call sites.
@@ -69,5 +108,11 @@ final class PresentationCoordinator: ObservableObject {
     /// The "Would you like to log …?" journal confirmation, carrying the
     /// alert copy and the action to perform on "Yes".
     case logConfirmation(LogConfirmationRequest)
+    /// Journal-entry feedback (success / queued / failure …), routed here
+    /// so it queues behind interactive presentations instead of racing
+    /// them.
+    case journalFeedback(ContentViewModel.JournalFeedback)
+    /// The flow review sheet (`FlowCoordinator.currentStep == .review`).
+    case flowReview
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/JournalFlowAlertsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/JournalFlowAlertsModifier.swift
@@ -1,27 +1,18 @@
 import SwiftUI
 
-/// Bundles the two top-level alert surfaces the main shell presents:
+/// Applies the primary / secondary flow-confirmation alerts, owned by
+/// `FlowCoordinator` and routed through `FlowSubmissionPresenter` so the
+/// queued / failure copy lives in one place.
 ///
-/// 1. `journalFeedback` — driven by `ContentViewModel`'s journal feedback
-///    item, dismissed by clearing the published value.
-/// 2. `flowConfirmationAlerts` — the primary / secondary submission
-///    confirmation, owned by `FlowCoordinator` and routed through
-///    `FlowSubmissionPresenter` so the queued / failure copy lives in
-///    one place.
-///
-/// Extracting both keeps ContentView focused on lifecycle and composition;
-/// the modifier is small enough that the alert plumbing reads as one
-/// concept rather than two adjacent chains.
+/// The journal-feedback alert that used to live here moved onto
+/// `RootPresentationHost` in #407, where the coordinator's priority policy
+/// queues it behind any interactive presentation.
 struct JournalFlowAlertsModifier: ViewModifier {
-  @ObservedObject var viewModel: ContentViewModel
   @ObservedObject var flowCoordinator: FlowCoordinator
   let flowSubmissionPresenter: FlowSubmissionPresenter
 
   func body(content: Content) -> some View {
     content
-      .alert(item: $viewModel.journalFeedback) { feedback in
-        JournalFeedbackAlert.make(feedback) { viewModel.journalFeedback = nil }
-      }
       .flowConfirmationAlerts(
         flowCoordinator: flowCoordinator,
         onPrimarySubmit: {
@@ -37,17 +28,15 @@ struct JournalFlowAlertsModifier: ViewModifier {
 // MARK: - View Extension
 
 extension View {
-  /// Applies the journal-feedback alert plus the primary/secondary flow
-  /// confirmation alerts, routing submission through the supplied
-  /// presenter so callers don't repeat the queued/failure copy.
+  /// Applies the primary/secondary flow confirmation alerts, routing
+  /// submission through the supplied presenter so callers don't repeat the
+  /// queued/failure copy.
   func journalFlowAlerts(
-    viewModel: ContentViewModel,
     flowCoordinator: FlowCoordinator,
     flowSubmissionPresenter: FlowSubmissionPresenter
   ) -> some View {
     modifier(
       JournalFlowAlertsModifier(
-        viewModel: viewModel,
         flowCoordinator: flowCoordinator,
         flowSubmissionPresenter: flowSubmissionPresenter
       )

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
@@ -47,9 +47,6 @@ struct MainContentDialogsModifier: ViewModifier {
       }
       .sheet(isPresented: $showingMenu) { menuSheet }
       .sheet(isPresented: $showingOnboarding) { onboardingSheet }
-      .sheet(isPresented: Self.flowReviewPresenter(for: flowCoordinator)) {
-        FlowReviewSheet(flowCoordinator: flowCoordinator)
-      }
       .task {
         if !syncSettingsViewModel.hasCompletedOnboarding {
           showingOnboarding = true
@@ -83,27 +80,6 @@ struct MainContentDialogsModifier: ViewModifier {
       isPresented: $showingOnboarding
     )
     .interactiveDismissDisabled()
-  }
-
-  // MARK: - Bindings
-
-  /// Read-write binding for the flow-review sheet. Like
-  /// `FlowConfirmationAlertsModifier.presenter(for:)`, the write side
-  /// treats `isPresented = false` (system swipe-dismiss) as an
-  /// implicit cancel — the buttons inside `FlowReviewSheet` already
-  /// transition the coordinator off `.review` explicitly, so this only
-  /// fires when neither button was tapped and the user closed via the
-  /// swipe gesture. The step guard prevents a spurious cancel if the
-  /// coordinator has already moved on by the time SwiftUI writes false.
-  static func flowReviewPresenter(for flowCoordinator: FlowCoordinator) -> Binding<Bool> {
-    Binding(
-      get: { flowCoordinator.currentStep == .review },
-      set: { isPresented in
-        if !isPresented, flowCoordinator.currentStep == .review {
-          flowCoordinator.cancel()
-        }
-      }
-    )
   }
 
   // MARK: - Navigation

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootPresentationHost.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootPresentationHost.swift
@@ -4,42 +4,94 @@ import SwiftUI
 /// NavigationStack push so the presentations it renders are never deferred
 /// behind an in-flight navigation transaction.
 ///
-/// In this skeleton (issue #405) the host owns the `storageError` alert —
-/// the simplest fully self-contained surface — proving the
-/// coordinator-driven host renders end-to-end. The `menu` and `onboarding`
-/// sheets are coordinator-driven from this same `PresentationCoordinator`
-/// but still presented from `MainContentDialogsModifier` for now; #406 /
-/// #407 relocate their content here and fold the publisher-driven journal
-/// feedback and flow review onto the host too.
+/// The host renders the `storageError` alert, the journal log-confirmation
+/// (#406, B2), the journal feedback alert, and the flow review sheet — all
+/// driven by the coordinator's single `active` slot. Two bridges keep the
+/// coordinator in sync with state that still lives on its original owner:
+/// `ContentViewModel.journalFeedback` (the direct-log path) and
+/// `FlowCoordinator.currentStep == .review`.
 struct RootPresentationHost: ViewModifier {
   @ObservedObject var coordinator: PresentationCoordinator
   @EnvironmentObject private var flowCoordinator: FlowCoordinator
   @EnvironmentObject private var viewModel: ContentViewModel
 
+  /// The presentation chain is staged through `some View` helpers: each
+  /// erases the upstream modifier complexity so Swift's type-checker can
+  /// resolve the body without timing out (same approach as RootShellView).
   func body(content: Content) -> some View {
-    content
-      .alert(
-        "Storage Error",
-        isPresented: coordinator.isPresented(for: .storageError)
-      ) {
-        Button("OK", role: .cancel) {}
-      } message: {
-        Text("Your journal couldn't be opened, so entries logged this session won't be saved. Please reopen the app; if the problem continues, contact support.")
-      }
-      // The journal log-confirmation, hoisted above the navigation push so
-      // it presents immediately rather than waiting for a back-out (B2).
-      .alert(
-        logConfirmation?.alertTitle ?? "",
-        isPresented: logConfirmationPresented
-      ) {
-        Button("Yes") {
-          if let action = logConfirmation?.action {
-            Task { await handler.perform(action) }
-          }
+    let withStorage = storageErrorAlert(content)
+    let withLog = logConfirmationAlert(withStorage)
+    let withFeedback = journalFeedbackAlert(withLog)
+    let withReview = flowReviewSheet(withFeedback)
+    return bridges(withReview)
+  }
+
+  // MARK: - Presentation surfaces
+
+  private func storageErrorAlert(_ view: some View) -> some View {
+    view.alert(
+      "Storage Error",
+      isPresented: coordinator.isPresented(for: .storageError)
+    ) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text("Your journal couldn't be opened, so entries logged this session won't be saved. Please reopen the app; if the problem continues, contact support.")
+    }
+  }
+
+  /// The journal log-confirmation, hoisted above the navigation push so it
+  /// presents immediately rather than waiting for a back-out (B2).
+  private func logConfirmationAlert(_ view: some View) -> some View {
+    view.alert(
+      logConfirmation?.alertTitle ?? "",
+      isPresented: logConfirmationPresented
+    ) {
+      Button("Yes") {
+        if let action = logConfirmation?.action {
+          Task { await handler.perform(action) }
         }
-        Button("Cancel", role: .cancel) {}
-      } message: {
-        Text(logConfirmation?.message ?? "")
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text(logConfirmation?.message ?? "")
+    }
+  }
+
+  /// Journal feedback (success / queued / failure), queued behind any
+  /// interactive presentation by the coordinator's priority policy.
+  private func journalFeedbackAlert(_ view: some View) -> some View {
+    view.alert(item: journalFeedbackItem) { feedback in
+      JournalFeedbackAlert.make(feedback) { coordinator.dismiss() }
+    }
+  }
+
+  /// The flow review sheet, driven by the coordinator.
+  private func flowReviewSheet(_ view: some View) -> some View {
+    view.sheet(isPresented: flowReviewPresented) {
+      FlowReviewSheet(flowCoordinator: flowCoordinator)
+    }
+  }
+
+  // MARK: - Coordinator bridges
+
+  /// Keeps the coordinator in sync with state that still lives on its
+  /// original owner: ContentViewModel's direct-log feedback (consumed
+  /// one-shot, since ContentViewModel must not depend on the coordinator)
+  /// and FlowCoordinator's review step.
+  private func bridges(_ view: some View) -> some View {
+    view
+      .onChange(of: viewModel.journalFeedback) { _, newValue in
+        if let feedback = newValue {
+          coordinator.request(.journalFeedback(feedback))
+          viewModel.journalFeedback = nil
+        }
+      }
+      .onChange(of: flowCoordinator.currentStep) { _, newStep in
+        if newStep == .review {
+          coordinator.request(.flowReview)
+        } else if coordinator.active == .flowReview {
+          coordinator.dismiss()
+        }
       }
   }
 
@@ -56,6 +108,48 @@ struct RootPresentationHost: ViewModifier {
       get: { logConfirmation != nil },
       set: { isPresented in
         if !isPresented { coordinator.dismiss() }
+      }
+    )
+  }
+
+  /// Optional binding for the journal-feedback `.alert(item:)`. Reads the
+  /// active feedback; clearing it (alert dismissed) advances the coordinator.
+  private var journalFeedbackItem: Binding<ContentViewModel.JournalFeedback?> {
+    Binding(
+      get: {
+        if case let .journalFeedback(feedback) = coordinator.active { return feedback }
+        return nil
+      },
+      set: { newValue in
+        if newValue == nil, case .journalFeedback = coordinator.active {
+          coordinator.dismiss()
+        }
+      }
+    )
+  }
+
+  private var flowReviewPresented: Binding<Bool> {
+    Self.flowReviewPresented(coordinator: coordinator, flowCoordinator: flowCoordinator)
+  }
+
+  /// Presentation binding for the flow review sheet. A swipe-dismiss cancels
+  /// the flow, mirroring the prior `MainContentDialogsModifier.flowReviewPresenter`
+  /// behavior; the sheet's own buttons transition `currentStep` explicitly,
+  /// and the `currentStep` bridge then dismisses this presentation. `static`
+  /// with explicit dependencies so the get/set contract is unit-testable
+  /// without rendering the host.
+  static func flowReviewPresented(
+    coordinator: PresentationCoordinator,
+    flowCoordinator: FlowCoordinator
+  ) -> Binding<Bool> {
+    Binding(
+      get: { coordinator.active == .flowReview },
+      set: { isPresented in
+        guard !isPresented else { return }
+        coordinator.dismiss()
+        if flowCoordinator.currentStep == .review {
+          flowCoordinator.cancel()
+        }
       }
     )
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
@@ -37,7 +37,10 @@ struct RootShellView: View {
   @State private var didSurfaceStorageWarning = false
 
   private var flowSubmissionPresenter: FlowSubmissionPresenter {
-    FlowSubmissionPresenter(flowCoordinator: flowCoordinator, viewModel: viewModel)
+    FlowSubmissionPresenter(
+      flowCoordinator: flowCoordinator,
+      presentationCoordinator: presentationCoordinator
+    )
   }
 
   var body: some View {
@@ -85,7 +88,6 @@ struct RootShellView: View {
   private var contentWithDialogs: some View {
     contentWithEvents
       .journalFlowAlerts(
-        viewModel: viewModel,
         flowCoordinator: flowCoordinator,
         flowSubmissionPresenter: flowSubmissionPresenter
       )

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowSubmissionPresenterTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/FlowSubmissionPresenterTests.swift
@@ -28,44 +28,66 @@ struct FlowSubmissionPresenterTests {
     return (viewModel, coordinator)
   }
 
-  @Test("successful submit resets the flow to idle")
+  /// Pulls the `JournalFeedback.Kind` off the coordinator's active
+  /// presentation, or nil if the active presentation isn't journal feedback.
+  private func feedbackKind(
+    _ presentation: PresentationCoordinator
+  ) -> ContentViewModel.JournalFeedback.Kind? {
+    if case let .journalFeedback(feedback) = presentation.active { return feedback.kind }
+    return nil
+  }
+
+  @Test("successful submit resets the flow and surfaces no feedback")
   func submit_success_resetsFlow() async {
-    let (viewModel, coordinator) = await makeSetup()
-    let presenter = FlowSubmissionPresenter(flowCoordinator: coordinator, viewModel: viewModel)
+    let (_, coordinator) = await makeSetup()
+    let presentation = PresentationCoordinator()
+    let presenter = FlowSubmissionPresenter(
+      flowCoordinator: coordinator,
+      presentationCoordinator: presentation
+    )
 
     await presenter.submit(failurePrefix: "Failed to log emotion")
 
     #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
     #expect(coordinator.selections.primary == nil)
+    #expect(presentation.active == .idle)
   }
 
-  @Test("queued submit shows queued feedback and resets the flow")
+  @Test("queued submit routes queued feedback to the coordinator and resets the flow")
   func submit_queued_showsQueuedFeedbackAndResets() async {
-    let (viewModel, coordinator) = await makeSetup(shouldQueue: true)
-    let presenter = FlowSubmissionPresenter(flowCoordinator: coordinator, viewModel: viewModel)
+    let (_, coordinator) = await makeSetup(shouldQueue: true)
+    let presentation = PresentationCoordinator()
+    let presenter = FlowSubmissionPresenter(
+      flowCoordinator: coordinator,
+      presentationCoordinator: presentation
+    )
 
     await presenter.submit(failurePrefix: "Failed to log emotion")
 
-    if case .queued = viewModel.journalFeedback?.kind {
+    if case .queued = feedbackKind(presentation) {
       // Reaching this branch is the assertion.
     } else {
-      Issue.record("Expected queued feedback, got \(String(describing: viewModel.journalFeedback?.kind))")
+      Issue.record("Expected queued feedback, got \(String(describing: feedbackKind(presentation)))")
     }
     #expect(coordinator.currentStep == FlowCoordinator.FlowStep.idle)
     #expect(coordinator.selections.primary == nil)
   }
 
-  @Test("failed submit shows prefixed failure feedback and preserves state for retry")
+  @Test("failed submit routes prefixed failure feedback and preserves state for retry")
   func submit_failure_showsFailureAndPreservesState() async {
-    let (viewModel, coordinator) = await makeSetup(shouldFail: true)
-    let presenter = FlowSubmissionPresenter(flowCoordinator: coordinator, viewModel: viewModel)
+    let (_, coordinator) = await makeSetup(shouldFail: true)
+    let presentation = PresentationCoordinator()
+    let presenter = FlowSubmissionPresenter(
+      flowCoordinator: coordinator,
+      presentationCoordinator: presentation
+    )
 
     await presenter.submit(failurePrefix: "Failed to log emotion")
 
-    if case let .failure(message) = viewModel.journalFeedback?.kind {
+    if case let .failure(message) = feedbackKind(presentation) {
       #expect(message.contains("Failed to log emotion"))
     } else {
-      Issue.record("Expected failure feedback, got \(String(describing: viewModel.journalFeedback?.kind))")
+      Issue.record("Expected failure feedback, got \(String(describing: feedbackKind(presentation)))")
     }
     // On unrecoverable failure the flow is NOT reset, so the user can retry.
     #expect(coordinator.currentStep != FlowCoordinator.FlowStep.idle)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/MainContentDialogsModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/MainContentDialogsModifierTests.swift
@@ -1,9 +1,11 @@
 import Testing
 @testable import WavelengthWatch_Watch_App
 
-/// Regression coverage for `MainContentDialogsModifier.flowReviewPresenter(for:)`
+/// Regression coverage for `RootPresentationHost.flowReviewPresented(coordinator:flowCoordinator:)`
 /// — the derived `Binding<Bool>` that maps a system swipe-dismiss of the
-/// flow-review sheet onto `FlowCoordinator.cancel()` (filed from #336 review).
+/// flow-review sheet onto `FlowCoordinator.cancel()` (originally #336;
+/// relocated from `MainContentDialogsModifier` onto the presentation host
+/// in #407).
 @MainActor
 struct MainContentDialogsModifierTests {
   private func makeCoordinator() async -> (FlowCoordinator, CatalogResponseModel) {
@@ -20,48 +22,65 @@ struct MainContentDialogsModifierTests {
 
   // MARK: - Getter
 
-  @Test("getter is true only while the coordinator is in .review")
-  func getter_isTrueOnlyInReview() async {
-    let (coordinator, _) = await makeCoordinator()
-    let binding = MainContentDialogsModifier.flowReviewPresenter(for: coordinator)
+  @Test("getter is true only while the coordinator's active presentation is .flowReview")
+  func getter_isTrueOnlyInFlowReview() async {
+    let (flowCoordinator, _) = await makeCoordinator()
+    let presentation = PresentationCoordinator()
+    let binding = RootPresentationHost.flowReviewPresented(
+      coordinator: presentation,
+      flowCoordinator: flowCoordinator
+    )
 
     #expect(binding.wrappedValue == false)
 
-    coordinator.startPrimarySelection()
+    presentation.request(.menu)
     #expect(binding.wrappedValue == false)
 
-    coordinator.showReview()
+    presentation.dismiss()
+    presentation.request(.flowReview)
     #expect(binding.wrappedValue == true)
   }
 
   // MARK: - Setter — implicit cancel
 
-  @Test("writing false while in .review cancels the flow")
+  @Test("writing false while the flow is in .review cancels the flow and dismisses")
   func setterFalse_inReview_cancelsFlow() async {
-    let (coordinator, catalog) = await makeCoordinator()
-    coordinator.capturePrimary(catalog.layers[1].phases[0].medicinal[0])
-    coordinator.showReview()
-    let binding = MainContentDialogsModifier.flowReviewPresenter(for: coordinator)
+    let (flowCoordinator, catalog) = await makeCoordinator()
+    flowCoordinator.capturePrimary(catalog.layers[1].phases[0].medicinal[0])
+    flowCoordinator.showReview()
+    let presentation = PresentationCoordinator()
+    presentation.request(.flowReview)
+    let binding = RootPresentationHost.flowReviewPresented(
+      coordinator: presentation,
+      flowCoordinator: flowCoordinator
+    )
 
     binding.wrappedValue = false
 
-    #expect(coordinator.currentStep == .idle)
-    #expect(coordinator.selections.primary == nil)
-    #expect(coordinator.contentViewModel.layerFilterMode == .all)
+    #expect(presentation.active == .idle)
+    #expect(flowCoordinator.currentStep == .idle)
+    #expect(flowCoordinator.selections.primary == nil)
+    #expect(flowCoordinator.contentViewModel.layerFilterMode == .all)
   }
 
   // MARK: - Setter — step guard
 
-  @Test("writing false outside .review does not cancel the flow")
+  @Test("writing false while the flow is not in .review dismisses but does not cancel the flow")
   func setterFalse_outsideReview_doesNotCancel() async {
-    let (coordinator, catalog) = await makeCoordinator()
+    let (flowCoordinator, catalog) = await makeCoordinator()
     let primary = catalog.layers[1].phases[0].medicinal[0]
-    coordinator.capturePrimary(primary)
-    let binding = MainContentDialogsModifier.flowReviewPresenter(for: coordinator)
+    flowCoordinator.capturePrimary(primary)
+    let presentation = PresentationCoordinator()
+    presentation.request(.flowReview)
+    let binding = RootPresentationHost.flowReviewPresented(
+      coordinator: presentation,
+      flowCoordinator: flowCoordinator
+    )
 
     binding.wrappedValue = false
 
-    #expect(coordinator.currentStep == .confirmingPrimary)
-    #expect(coordinator.selections.primary == primary)
+    #expect(presentation.active == .idle)
+    #expect(flowCoordinator.currentStep == .confirmingPrimary)
+    #expect(flowCoordinator.selections.primary == primary)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationPolicyTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationPolicyTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Tests for `PresentationCoordinator`'s single-active priority/queue policy
+/// (#407, SPEC §11 Q4): informational feedback queues behind interactive
+/// presentations; a higher-priority request preempts without dropping the
+/// displaced one; `dismiss()` promotes the highest-priority queued item.
+@MainActor
+struct PresentationPolicyTests {
+  private func sampleFeedback() -> ContentViewModel.JournalFeedback {
+    ContentViewModel.JournalFeedback(kind: .success)
+  }
+
+  private func sampleLogConfirmation() -> PresentationCoordinator.ActivePresentation {
+    .logConfirmation(LogConfirmationRequest(
+      alertTitle: "Log Strategy",
+      message: "Would you like to log \"Deep Breathing\"?",
+      action: .strategy(
+        strategy: CatalogStrategyModel(id: 1, strategy: "Deep Breathing", color: "Blue"),
+        curriculumID: 1
+      )
+    ))
+  }
+
+  @Test("lower-priority feedback queues behind an active confirmation")
+  func feedbackQueuesBehindConfirmation() {
+    let coordinator = PresentationCoordinator()
+    let confirmation = sampleLogConfirmation()
+    let feedback = sampleFeedback()
+
+    coordinator.request(confirmation)
+    coordinator.request(.journalFeedback(feedback))
+
+    #expect(coordinator.active == confirmation) // confirmation stays up
+    coordinator.dismiss()
+    #expect(coordinator.active == .journalFeedback(feedback)) // queued feedback surfaces
+    coordinator.dismiss()
+    #expect(coordinator.active == .idle)
+  }
+
+  @Test("higher-priority storage error preempts active feedback without dropping it")
+  func storageErrorPreemptsFeedback() {
+    let coordinator = PresentationCoordinator()
+    let feedback = sampleFeedback()
+
+    coordinator.request(.journalFeedback(feedback))
+    coordinator.request(.storageError)
+
+    #expect(coordinator.active == .storageError) // higher priority shown immediately
+    coordinator.dismiss()
+    #expect(coordinator.active == .journalFeedback(feedback)) // displaced feedback resurfaces
+  }
+
+  @Test("dismiss promotes the highest-priority queued presentation first")
+  func dismissPromotesHighestPriority() {
+    let coordinator = PresentationCoordinator()
+    let feedback = sampleFeedback()
+
+    coordinator.request(.menu) // active (priority 1)
+    coordinator.request(.journalFeedback(feedback)) // queued (priority 0)
+    coordinator.request(.storageError) // preempts menu (priority 2); menu queued
+
+    #expect(coordinator.active == .storageError)
+    coordinator.dismiss()
+    #expect(coordinator.active == .menu) // priority 1 beats queued feedback (0)
+    coordinator.dismiss()
+    #expect(coordinator.active == .journalFeedback(feedback))
+    coordinator.dismiss()
+    #expect(coordinator.active == .idle)
+  }
+
+  @Test("requesting idle is ignored")
+  func requestingIdleIsIgnored() {
+    let coordinator = PresentationCoordinator()
+    coordinator.request(.menu)
+    coordinator.request(.idle)
+    #expect(coordinator.active == .menu)
+  }
+}


### PR DESCRIPTION
## Summary

Completes **Epic #401**: gives `PresentationCoordinator` a single-active priority/queue policy and folds the last two publisher-driven surfaces — journal feedback and flow review — onto the coordinator, so every transient presentation now flows through one host with deterministic ordering (SPEC §4.3, §11 Q4).

- **Priority/queue policy** on `request`/`dismiss`: exactly one presentation is active. A strictly-higher-priority request preempts the active one (the displaced presentation is queued, never dropped); equal/lower-priority requests wait. `dismiss()` promotes the highest-priority queued presentation (FIFO within a priority). Priority: `storageError` (data-loss) > interactive (`menu`/`onboarding`/`logConfirmation`/`flowReview`) > `journalFeedback` (informational). `isPresented(for:)` now routes through `request`/`dismiss`.
- **Journal feedback** → coordinator: `FlowSubmissionPresenter` calls `coordinator.request(.journalFeedback(...))` instead of setting `viewModel.journalFeedback`. `ContentViewModel.journal`'s direct-log feedback is bridged one-shot in `RootPresentationHost` via `.onChange(of: viewModel.journalFeedback)` (ContentViewModel keeps its save logic and does not depend on the coordinator). The feedback alert moved off `JournalFlowAlertsModifier` onto the host.
- **Flow review** → coordinator: `.onChange(of: flowCoordinator.currentStep)` bridges `.review` ↔ `coordinator.active == .flowReview`; the sheet + its swipe-cancel binding moved from `MainContentDialogsModifier` onto the host (`RootPresentationHost.flowReviewPresented`, kept `static` so the get/set contract stays unit-testable).
- Host body staged through `some View` helper functions so the type-checker resolves it (the chain grew past its comfort point — same pattern as `RootShellView`).

### Scope
`FlowCoordinator` flow-step logic, journal save semantics, the offline queue (#186), Models, Services, and backend are untouched. The three flow-confirmation alerts (`confirmingPrimary/Secondary/Strategy`) remain on `FlowConfirmationAlertsModifier` (driven by `currentStep`) — out of scope per the epic's enum.

## Test plan
- **New `PresentationPolicyTests`**: feedback queues behind an active confirmation; `storageError` preempts feedback without dropping it; `dismiss` promotes highest-priority-first across a 3-deep queue; `request(.idle)` is ignored.
- **Updated `FlowSubmissionPresenterTests`**: success surfaces no feedback + resets; queued/failure route `.journalFeedback` to the coordinator (failure preserves flow state).
- **Updated `MainContentDialogsModifierTests`** → now exercise `RootPresentationHost.flowReviewPresented`: getter true only when active is `.flowReview`; swipe-dismiss cancels the flow only while it's genuinely in `.review`, otherwise dismisses without cancelling.
- `frontend/WavelengthWatch/run-tests-individually.sh` — full suite, build + all suites green. `swiftformat --lint frontend` + `pre-commit` clean.
- **Unverifiable on-device behavior flagged:** the alert/sheet presentation parity and the two `onChange` bridges were validated by construction + the policy/binding unit tests, not an on-device run. The reviewer should confirm on-device that journal feedback, the flow review sheet (including swipe-to-cancel), and the menu/onboarding/storage/log-confirmation surfaces all present and dismiss correctly, and never two at once.

Closes #407
Refs #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
