### PR TITLE
feat(navigation): paged layer ScrollView skeleton with identity transforms

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
@@ -1,29 +1,21 @@
 import SwiftUI
 
+/// A single full-screen layer page in the vertical scroller.
+///
+/// Sized to exactly one scroll-container page via `containerRelativeFrame`
+/// and laid out with an identity transform — no `scaleEffect`,
+/// `rotation3DEffect`, or `offset`. The hand-stacked depth transforms that
+/// used to live here (a perspective x-axis rotation over a negative-spacing
+/// `LazyVStack`) re-projected the card's optical center as it animated and
+/// were the source of the "leftward bump" on vertical scroll (B3 in
+/// `prompts/claude-comm/spec-primary-selector-rebuild.md`). Depth returns in
+/// #409 as a single offset-derived `scrollTransition` that resolves to an
+/// exact identity at rest.
 struct LayerCardView: View {
   let layer: CatalogLayerModel
   let phaseCount: Int
   @Binding var selection: Int
-  let layerIndex: Int
-  let selectedLayerIndex: Int
-  let geometry: GeometryProxy
   let screenWidth: CGFloat // Stable width from parent GeometryReader
-  @EnvironmentObject private var viewModel: ContentViewModel
-
-  private var transformEffect: (scale: CGFloat, rotation: Double, offset: CGFloat, opacity: Double) {
-    let distance = layerIndex - selectedLayerIndex
-
-    switch distance {
-    case 0:
-      return (scale: 1.0, rotation: 0, offset: 0, opacity: 1.0)
-    case 1:
-      return (scale: 0.95, rotation: -5, offset: 15, opacity: 0.3)
-    case -1:
-      return (scale: 0.95, rotation: 5, offset: -15, opacity: 0.3)
-    default:
-      return (scale: 0.85, rotation: 0, offset: 0, opacity: 0.0)
-    }
-  }
 
   var body: some View {
     LayerView(
@@ -32,16 +24,6 @@ struct LayerCardView: View {
       selection: $selection,
       screenWidth: screenWidth
     )
-    .frame(width: geometry.size.width, height: geometry.size.height)
-    .scaleEffect(transformEffect.scale)
-    .rotation3DEffect(
-      .degrees(transformEffect.rotation),
-      axis: (x: 1, y: 0, z: 0),
-      perspective: 0.8
-    )
-    .offset(y: transformEffect.offset)
-    .opacity(transformEffect.opacity)
-    .zIndex(layerIndex == selectedLayerIndex ? 10 : Double(10 - abs(layerIndex - selectedLayerIndex)))
-    .wlAnimation(.interactiveSpring(response: 0.4, dampingFraction: 0.8), value: selectedLayerIndex)
+    .containerRelativeFrame([.horizontal, .vertical])
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -30,7 +30,7 @@ struct LayerScrollView: View {
     GeometryReader { geometry in
       ScrollViewReader { proxy in
         scrollView(geometry: geometry)
-          .scrollTargetBehavior(.viewAligned)
+          .scrollTargetBehavior(.paging)
           .scrollPosition(id: Binding<Int?>(
             get: { clampedSelection },
             set: { newId in
@@ -105,17 +105,18 @@ struct LayerScrollView: View {
   // MARK: - Subviews
 
   private func scrollView(geometry: GeometryProxy) -> some View {
+    // Zero spacing + per-page `containerRelativeFrame` (in LayerCardView) +
+    // `.paging` give exact, non-overlapping pages. The previous negative
+    // spacing was half of the B3 bump; the depth transforms were the other
+    // half (both removed — depth returns in #409 via scrollTransition).
     ScrollView(.vertical, showsIndicators: false) {
-      LazyVStack(spacing: -20) {
+      LazyVStack(spacing: 0) {
         ForEach(viewModel.filteredLayers.indices, id: \.self) { index in
           let layer = viewModel.filteredLayers[index]
           LayerCardView(
             layer: layer,
             phaseCount: viewModel.phaseOrder.count,
             selection: $phaseSelection,
-            layerIndex: index,
-            selectedLayerIndex: clampedSelection,
-            geometry: geometry,
             screenWidth: geometry.size.width
           )
           .id(index)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LayerCardViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LayerCardViewTests.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Shallow construction coverage for the rebuilt `LayerCardView` (#408).
+///
+/// The card is now an identity-layout page (no `scaleEffect` /
+/// `rotation3DEffect` / `offset`), sized via `containerRelativeFrame`. Per
+/// the project's view-test philosophy these are construction smoke tests —
+/// they pin the simplified init and guard against a regressed dependency
+/// surface; the visual "no horizontal bump" property is device-verified.
+@MainActor
+struct LayerCardViewTests {
+  @Test("constructs for a curriculum layer without the removed transform inputs")
+  func constructsForCurriculumLayer() {
+    let catalog = CatalogTestHelper.createTestCatalog()
+
+    _ = LayerCardView(
+      layer: catalog.layers[1],
+      phaseCount: catalog.phaseOrder.count,
+      selection: .constant(1),
+      screenWidth: 180
+    )
+  }
+
+  @Test("constructs for the strategies layer")
+  func constructsForStrategiesLayer() {
+    let catalog = CatalogTestHelper.createTestCatalog()
+
+    _ = LayerCardView(
+      layer: catalog.layers[0],
+      phaseCount: catalog.phaseOrder.count,
+      selection: .constant(0),
+      screenWidth: 198
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Epic 2 skeleton (Refs #402): rebuilds the vertical layer scroller as clean, exact pages with **identity transforms**, removing both halves of the B3 "leftward bump" — the hand-stacked depth transforms and the negative `LazyVStack` spacing (SPEC §2 B3, §4.1). Depth returns in #409 as a single offset-derived `scrollTransition`.

- **`LayerCardView`** reduced to an identity-layout page: removed `scaleEffect`, `rotation3DEffect(axis: x, perspective: 0.8)`, `offset(y:)`, `opacity`, `zIndex`, and the selection-driven spring. The card is now sized via `containerRelativeFrame([.horizontal, .vertical])` — exactly one scroll-container page. The transform-only inputs (`layerIndex`, `selectedLayerIndex`, `geometry`) and a genuinely-unused `viewModel` env object are gone.
- **`LayerScrollView`**: `LazyVStack(spacing: -20)` → `spacing: 0`; `.scrollTargetBehavior(.viewAligned)` → `.paging`. The proven navigation machinery is untouched: `scrollPosition`, `scrollTargetLayout`, `ScrollViewReader`/`scrollTo`, `digitalCrownRotation`, and the drag gesture all stay exactly as before, so dual-axis navigation, crown, and infinite phase wrap are unaffected.

### Scope
No `scrollTransition` depth (that's #409). No affordance/indicator changes (Epic 3 — the side indicator and its timer are untouched here), no presentation (Epic 1) or glass (Epic 4) changes. The #119/#158/#165 screen-width/filter-mode fix is preserved: the card still receives the stable `screenWidth` from the parent `GeometryReader`; no nested `GeometryReader` per page.

## Test plan
- **New `LayerCardViewTests`**: shallow construction smoke tests pinning the simplified init for a curriculum layer and the strategies layer.
- `frontend/WavelengthWatch/run-tests-individually.sh` — full suite, build + all suites green, including the navigation guards `PhaseNavigatorTests`, `NavigationViewModelTests`, `LayerFilterModeTests`.
- `swiftformat --lint frontend` + `pre-commit` clean.
- **Unverifiable on-device behavior flagged (this is the key one for B3):** "no horizontal bump on vertical scroll," paging snap feel, and crown/drag parity are visual/interaction properties I can't verify in CI. Removing the perspective rotation + negative spacing eliminates the *cause* of the bump by construction, but the reviewer should scroll the layers on-device — watching the card's left edge against a fixed reference — to confirm the bump is gone and that paging + infinite phase wrap still feel right before merge.

Closes #408
Refs #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
