### PR TITLE
feat(navigation): scrollTransition depth, identity-at-rest (fixes B3)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
@@ -8,9 +8,9 @@ import SwiftUI
 /// used to live here (a perspective x-axis rotation over a negative-spacing
 /// `LazyVStack`) re-projected the card's optical center as it animated and
 /// were the source of the "leftward bump" on vertical scroll (B3 in
-/// `prompts/claude-comm/spec-primary-selector-rebuild.md`). Depth returns in
-/// #409 as a single offset-derived `scrollTransition` that resolves to an
-/// exact identity at rest.
+/// `prompts/claude-comm/spec-primary-selector-rebuild.md`). Depth is now a
+/// single offset-derived `scrollTransition` (#409) that resolves to an exact
+/// identity at the resting/centered page, so it can never shift the card.
 struct LayerCardView: View {
   let layer: CatalogLayerModel
   let phaseCount: Int
@@ -25,5 +25,18 @@ struct LayerCardView: View {
       screenWidth: screenWidth
     )
     .containerRelativeFrame([.horizontal, .vertical])
+    // Offset-derived depth (#409, SPEC §4.1): a single center-anchored
+    // scale + opacity + blur the scroll system drives from page geometry.
+    // At `phase.isIdentity` (the resting/centered page) every modifier is
+    // an exact identity (scale 1, opacity 1, blur 0), so the resting card's
+    // center cannot shift — the structural guarantee against B3. Started
+    // flat (no tilt) per SPEC §11 Q2; `scaleEffect`'s default `.center`
+    // anchor keeps the effect symmetric, never translating horizontally.
+    .scrollTransition(.interactive, axis: .vertical) { content, phase in
+      content
+        .opacity(phase.isIdentity ? 1 : 0.35)
+        .scaleEffect(phase.isIdentity ? 1 : 0.95)
+        .blur(radius: phase.isIdentity ? 0 : 1)
+    }
   }
 }


### PR DESCRIPTION
## Summary

Completes the **B3 fix** (Refs #402): adds depth back to the rebuilt layer scroller via a single offset-derived `scrollTransition`, restoring the sense of depth removed in the #408 skeleton — without reintroducing the bump.

- One `scrollTransition(.interactive, axis: .vertical)` on each `LayerCardView`, applying a center-anchored `scaleEffect` + `opacity` + `blur` the scroll system drives from page geometry.
- **Identity-at-rest guarantee:** at `phase.isIdentity` (the resting/centered page) every modifier is an exact identity — scale 1, opacity 1, blur 0 — so the resting card's center is pixel-stable. `scaleEffect`'s default `.center` anchor keeps the effect symmetric and never introduces a horizontal translation. Started flat (no 3D tilt) per SPEC §11 Q2.

Together with #408 (which removed the perspective `rotation3DEffect` and negative spacing), this closes out **B3**: the depth cue is now expressed entirely through a GPU effect that reverts to exact identity at rest, structurally incapable of the "leftward bump."

### Scope
Depth effect only. No change to the scroll container, navigation machinery, affordances (Epic 3), presentation (Epic 1), or glass (Epic 4).

## Test plan
- `frontend/WavelengthWatch/run-tests-individually.sh` — full suite, build + all suites green (incl. `LayerCardViewTests` construction smoke tests and the navigation guards `PhaseNavigatorTests` / `NavigationViewModelTests` / `LayerFilterModeTests`).
- `swiftformat --lint frontend` + `pre-commit` clean.
- **Unverifiable on-device behavior flagged (the B3 acceptance):** `scrollTransition` is a pure GPU view modifier with no logic seam — the "no horizontal bump, symmetric center-anchored depth, exact identity at rest" properties are visual and can't be asserted in CI. The construction is correct by design (identity-at-rest is guaranteed by `phase.isIdentity`), but the reviewer should scroll the layers on-device — watching the card's left edge against a fixed reference through a full scroll-and-settle — to confirm the bump is gone and the depth animation reads well before merge. This is the canonical "OK to ship unverifiable UI if flagged" case.

Closes #409
Refs #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
