### PR TITLE
feat(navigation): ScrollAffordanceModel + edge-aware chevron view

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Which directions the dual-axis navigation can currently move in.
+///
+/// The vertical layer axis is clamped (`0 ..< layerCount`), so up/down are
+/// genuinely edge-aware. The horizontal phase axis wraps infinitely (the
+/// inner TabView's sentinel pages), so left/right are available whenever
+/// there is more than one phase to wrap between.
+struct ScrollAffordances: Equatable {
+  var canGoUp = false
+  var canGoDown = false
+  var canGoLeft = false
+  var canGoRight = false
+}
+
+/// Derives edge availability and tracks whether a scroll is in progress, so
+/// the affordance chevrons can be shown for exactly the directions that are
+/// possible — and (from #411) kept visible for the whole duration of a
+/// gesture rather than hidden by a blind timer (B1 in
+/// `prompts/claude-comm/spec-primary-selector-rebuild.md`).
+///
+/// Pure state with no view dependency, so the edge math and interaction
+/// transitions are unit-testable without rendering anything.
+@MainActor
+final class ScrollAffordanceModel: ObservableObject {
+  @Published private(set) var affordances = ScrollAffordances()
+
+  /// True while a scroll/crown/drag gesture is in progress. In this skeleton
+  /// (#410) nothing drives it yet; #411 feeds it from the live scroll phase
+  /// and gates chevron visibility on it.
+  @Published private(set) var isInteracting = false
+
+  /// Recomputes edge availability from the current selection and counts.
+  /// Infinite-wrap aware: left/right depend only on whether more than one
+  /// phase exists, never on the phase index.
+  func update(layerSelection: Int, layerCount: Int, phaseCount: Int) {
+    affordances = ScrollAffordances(
+      canGoUp: layerSelection > 0,
+      canGoDown: layerSelection < layerCount - 1,
+      canGoLeft: phaseCount > 1,
+      canGoRight: phaseCount > 1
+    )
+  }
+
+  /// Records whether a scroll interaction is in progress.
+  func setInteracting(_ interacting: Bool) {
+    guard isInteracting != interacting else { return }
+    isInteracting = interacting
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceModel.swift
@@ -15,9 +15,8 @@ struct ScrollAffordances: Equatable {
 
 /// Derives edge availability and tracks whether a scroll is in progress, so
 /// the affordance chevrons can be shown for exactly the directions that are
-/// possible — and (from #411) kept visible for the whole duration of a
-/// gesture rather than hidden by a blind timer (B1 in
-/// `prompts/claude-comm/spec-primary-selector-rebuild.md`).
+/// possible — and kept visible for the whole duration of a gesture rather
+/// than hidden by a timer.
 ///
 /// Pure state with no view dependency, so the edge math and interaction
 /// transitions are unit-testable without rendering anything.
@@ -25,9 +24,9 @@ struct ScrollAffordances: Equatable {
 final class ScrollAffordanceModel: ObservableObject {
   @Published private(set) var affordances = ScrollAffordances()
 
-  /// True while a scroll/crown/drag gesture is in progress. In this skeleton
-  /// (#410) nothing drives it yet; #411 feeds it from the live scroll phase
-  /// and gates chevron visibility on it.
+  /// True while a scroll/crown/drag gesture is in progress. Currently unset;
+  /// callers will drive it from the live scroll phase to gate chevron
+  /// visibility.
   @Published private(set) var isInteracting = false
 
   /// Recomputes edge availability from the current selection and counts.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -17,10 +17,9 @@ struct LayerScrollView: View {
 
   @State private var showIndicator = false
   @State private var hideIndicatorTask: Task<Void, Never>?
-  /// Edge-availability model backing the directional chevrons. Introduced
-  /// in #410 wired at parity with the existing indicator (gated by
-  /// `showIndicator`); #411 drives chevron visibility from its
-  /// `isInteracting` flag and retires the blind hide-timer.
+  /// Edge-availability model backing the directional chevrons. Currently
+  /// gated at parity with the existing indicator (via `showIndicator`);
+  /// chevron visibility will later be driven by its `isInteracting` flag.
   @StateObject private var affordanceModel = ScrollAffordanceModel()
 
   /// Clamps `layerSelection` to the current filtered range so bindings
@@ -75,6 +74,9 @@ struct LayerScrollView: View {
           .onChange(of: viewModel.filteredLayers.count) { _, _ in
             updateAffordances()
           }
+          .onChange(of: viewModel.phaseOrder.count) { _, _ in
+            updateAffordances()
+          }
           .onAppear {
             guard !viewModel.filteredLayers.isEmpty,
                   layerSelection < viewModel.filteredLayers.count else { return }
@@ -92,7 +94,7 @@ struct LayerScrollView: View {
             sideIndicator(in: geometry.size)
           }
           // Directional chevrons, gated at parity with the side indicator
-          // for now; #411 drives them from live scroll state + edges.
+          // for now; visibility will later track live scroll state + edges.
           .overlay {
             ScrollAffordanceView(affordances: affordanceModel.affordances)
               .opacity(showIndicator ? 1 : 0)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -17,6 +17,11 @@ struct LayerScrollView: View {
 
   @State private var showIndicator = false
   @State private var hideIndicatorTask: Task<Void, Never>?
+  /// Edge-availability model backing the directional chevrons. Introduced
+  /// in #410 wired at parity with the existing indicator (gated by
+  /// `showIndicator`); #411 drives chevron visibility from its
+  /// `isInteracting` flag and retires the blind hide-timer.
+  @StateObject private var affordanceModel = ScrollAffordanceModel()
 
   /// Clamps `layerSelection` to the current filtered range so bindings
   /// can never read an out-of-range index — important during filter-mode
@@ -65,12 +70,17 @@ struct LayerScrollView: View {
               proxy.scrollTo(newValue, anchor: .center)
             }
             flashIndicator()
+            updateAffordances()
+          }
+          .onChange(of: viewModel.filteredLayers.count) { _, _ in
+            updateAffordances()
           }
           .onAppear {
             guard !viewModel.filteredLayers.isEmpty,
                   layerSelection < viewModel.filteredLayers.count else { return }
             proxy.scrollTo(layerSelection, anchor: .center)
             flashIndicator()
+            updateAffordances()
           }
           .onDisappear {
             // Mirror the LayerView pattern: any pending hide task that
@@ -80,6 +90,12 @@ struct LayerScrollView: View {
           }
           .overlay(alignment: .trailing) {
             sideIndicator(in: geometry.size)
+          }
+          // Directional chevrons, gated at parity with the side indicator
+          // for now; #411 drives them from live scroll state + edges.
+          .overlay {
+            ScrollAffordanceView(affordances: affordanceModel.affordances)
+              .opacity(showIndicator ? 1 : 0)
           }
           // DragGesture writes raw `layerSelection`; the bounds check uses
           // `filteredLayers.count` since reads downstream are clamped via
@@ -137,6 +153,16 @@ struct LayerScrollView: View {
       size: size
     )
     .opacity(showIndicator ? 1 : 0)
+  }
+
+  // MARK: - Affordances
+
+  private func updateAffordances() {
+    affordanceModel.update(
+      layerSelection: clampedSelection,
+      layerCount: viewModel.filteredLayers.count,
+      phaseCount: viewModel.phaseOrder.count
+    )
   }
 
   // MARK: - Indicator lifecycle

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -6,8 +6,7 @@ import SwiftUI
 ///
 /// Purely an affordance hint — it never intercepts touches, so it can't
 /// interfere with the scroll/crown gestures underneath. Overall visibility
-/// is controlled by the caller (gated at parity with the existing indicator
-/// in #410; driven by live scroll state + edge availability in #411).
+/// is controlled by the caller.
 struct ScrollAffordanceView: View {
   let affordances: ScrollAffordances
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Edge-aware directional chevrons for the dual-axis navigation. A chevron
+/// is rendered for a direction only when movement that way is possible, so
+/// the absence of a chevron is itself the "you're at the edge" signal.
+///
+/// Purely an affordance hint — it never intercepts touches, so it can't
+/// interfere with the scroll/crown gestures underneath. Overall visibility
+/// is controlled by the caller (gated at parity with the existing indicator
+/// in #410; driven by live scroll state + edge availability in #411).
+struct ScrollAffordanceView: View {
+  let affordances: ScrollAffordances
+
+  var body: some View {
+    ZStack {
+      if affordances.canGoUp { chevron("chevron.up", alignment: .top) }
+      if affordances.canGoDown { chevron("chevron.down", alignment: .bottom) }
+      if affordances.canGoLeft { chevron("chevron.left", alignment: .leading) }
+      if affordances.canGoRight { chevron("chevron.right", alignment: .trailing) }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .allowsHitTesting(false)
+  }
+
+  private func chevron(_ systemName: String, alignment: Alignment) -> some View {
+    Image(systemName: systemName)
+      .font(.system(size: 12, weight: .semibold))
+      .foregroundStyle(.white.opacity(0.5))
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
+      .padding(4)
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceModelTests.swift
@@ -61,6 +61,24 @@ struct ScrollAffordanceModelTests {
     #expect(model.affordances.canGoRight == false)
   }
 
+  @Test("zero layers suppresses both up and down")
+  func zeroLayers() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 0, layerCount: 0, phaseCount: 3)
+
+    #expect(model.affordances.canGoUp == false)
+    #expect(model.affordances.canGoDown == false)
+  }
+
+  @Test("zero phases suppresses both left and right")
+  func zeroPhases() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 2, layerCount: 5, phaseCount: 0)
+
+    #expect(model.affordances.canGoLeft == false)
+    #expect(model.affordances.canGoRight == false)
+  }
+
   @Test("isInteracting toggles and ignores redundant writes")
   func interactionTransitions() {
     let model = ScrollAffordanceModel()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceModelTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Tests for `ScrollAffordanceModel`'s edge math and interaction state
+/// (#410). The vertical layer axis is clamped (edge-aware up/down); the
+/// horizontal phase axis wraps infinitely (left/right available whenever
+/// more than one phase exists).
+@MainActor
+struct ScrollAffordanceModelTests {
+  @Test("first layer suppresses up, allows down")
+  func firstLayer() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 0, layerCount: 5, phaseCount: 6)
+
+    #expect(model.affordances.canGoUp == false)
+    #expect(model.affordances.canGoDown == true)
+  }
+
+  @Test("last layer suppresses down, allows up")
+  func lastLayer() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 4, layerCount: 5, phaseCount: 6)
+
+    #expect(model.affordances.canGoUp == true)
+    #expect(model.affordances.canGoDown == false)
+  }
+
+  @Test("a middle layer allows both up and down")
+  func middleLayer() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 2, layerCount: 5, phaseCount: 6)
+
+    #expect(model.affordances.canGoUp == true)
+    #expect(model.affordances.canGoDown == true)
+  }
+
+  @Test("a single layer suppresses both up and down")
+  func singleLayer() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 0, layerCount: 1, phaseCount: 6)
+
+    #expect(model.affordances.canGoUp == false)
+    #expect(model.affordances.canGoDown == false)
+  }
+
+  @Test("multiple phases allow left and right (infinite wrap)")
+  func multiplePhases() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 2, layerCount: 5, phaseCount: 6)
+
+    #expect(model.affordances.canGoLeft == true)
+    #expect(model.affordances.canGoRight == true)
+  }
+
+  @Test("a single phase suppresses left and right")
+  func singlePhase() {
+    let model = ScrollAffordanceModel()
+    model.update(layerSelection: 2, layerCount: 5, phaseCount: 1)
+
+    #expect(model.affordances.canGoLeft == false)
+    #expect(model.affordances.canGoRight == false)
+  }
+
+  @Test("isInteracting toggles and ignores redundant writes")
+  func interactionTransitions() {
+    let model = ScrollAffordanceModel()
+    #expect(model.isInteracting == false)
+
+    model.setInteracting(true)
+    #expect(model.isInteracting == true)
+
+    model.setInteracting(true) // redundant — no change
+    #expect(model.isInteracting == true)
+
+    model.setInteracting(false)
+    #expect(model.isInteracting == false)
+  }
+}


### PR DESCRIPTION
## Summary

Epic 3 skeleton (Refs #403): introduces the testable affordance model and the edge-aware chevron view that the **B1** fix is built on, wired into the scroller at parity with the existing indicator. No behavior change to visibility yet — #411 drives the chevrons from live scroll state and retires the blind hide-timer (the actual B1 fix).

- **New `ScrollAffordanceModel`** (`@MainActor ObservableObject`) + `ScrollAffordances` value type: derives `canGoUp/Down/Left/Right` from selection vs. counts — edge-aware on the clamped vertical layer axis, infinite-wrap-aware on the horizontal phase axis (left/right available whenever `phaseCount > 1`, independent of the phase index). Also exposes an `isInteracting` flag (unused this issue; #411 feeds it from scroll phase).
- **New `ScrollAffordanceView`**: renders a chevron for a direction only when that move is possible (a missing chevron *is* the "at the edge" signal). `allowsHitTesting(false)`, so it never interferes with the scroll/crown gestures underneath.
- **Wired into `LayerScrollView`**: a `@StateObject` model updated on selection / filtered-layer-count / appear, and an overlay rendering the chevrons gated by the existing `showIndicator` opacity — parity with today's indicator. The existing side indicator and its timer are untouched this issue.

### Scope
No timer removal, no `isInteracting`-driven visibility, no `LayerSideIndicator` replacement — all that is #411. No depth (Epic 2, merged), presentation (Epic 1), or glass (Epic 4) changes.

## Test plan
- **New `ScrollAffordanceModelTests`**: first/last/middle/single layer (up/down edges), single vs. multiple phases (left/right via infinite wrap), and `isInteracting` transitions incl. ignoring redundant writes.
- `frontend/WavelengthWatch/run-tests-individually.sh` — full suite, build + all suites green (incl. nav guards).
- `swiftformat --lint frontend` + `pre-commit` clean.
- **Unverifiable on-device behavior flagged:** the chevrons are now rendered (gated at parity), but their placement/look and that they don't visually crowd the existing rail is a visual property best confirmed on-device. The model edge-math (the load-bearing logic) is fully unit-tested; the visual composition is the device-check item.

Closes #410
Refs #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
