### PR TITLE
feat(navigation): phase-driven chevron visibility, delete hide timers (fixes B1)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -3,23 +3,17 @@ import SwiftUI
 /// Vertical layer scroller — the outer axis of the dual-axis navigation.
 ///
 /// Renders the filtered layers from `ContentViewModel` as full-screen
-/// `LayerCardView` pages, hosts the digital-crown / drag-gesture / scroll
-/// position bindings, and owns the auto-hiding side indicator.
-///
-/// The indicator state (visibility + hide-after task) lives here rather
-/// than on `ContentView` because it's a property of the scroll surface
-/// itself: every interaction that nudges the layer selection on this
-/// view flashes the indicator and re-arms the auto-hide.
+/// `LayerCardView` pages and hosts the digital-crown / drag-gesture /
+/// scroll-position bindings. The directional chevrons and the position rail
+/// are always present — a missing chevron means "you're at that edge" — and
+/// their emphasis follows the live scroll phase rather than a timer, so they
+/// can never disappear mid-scroll.
 struct LayerScrollView: View {
   @ObservedObject var viewModel: ContentViewModel
   @Binding var layerSelection: Int
   @Binding var phaseSelection: Int
 
-  @State private var showIndicator = false
-  @State private var hideIndicatorTask: Task<Void, Never>?
-  /// Edge-availability model backing the directional chevrons. Currently
-  /// gated at parity with the existing indicator (via `showIndicator`);
-  /// chevron visibility will later be driven by its `isInteracting` flag.
+  /// Edge availability + interaction state backing the directional chevrons.
   @StateObject private var affordanceModel = ScrollAffordanceModel()
 
   /// Clamps `layerSelection` to the current filtered range so bindings
@@ -43,6 +37,12 @@ struct LayerScrollView: View {
               }
             }
           ))
+          // Live scroll phase drives chevron emphasis — true for the whole
+          // duration of a gesture (user drag, crown, or momentum), so the
+          // chevrons stay prominent until the scroll actually settles.
+          .onScrollPhaseChange { _, newPhase in
+            affordanceModel.setInteracting(newPhase.isScrolling)
+          }
           .digitalCrownRotation(
             Binding<Double>(
               get: { Double(clampedSelection) },
@@ -68,7 +68,6 @@ struct LayerScrollView: View {
             withAnimation(.easeInOut(duration: 0.3)) {
               proxy.scrollTo(newValue, anchor: .center)
             }
-            flashIndicator()
             updateAffordances()
           }
           .onChange(of: viewModel.filteredLayers.count) { _, _ in
@@ -81,23 +80,16 @@ struct LayerScrollView: View {
             guard !viewModel.filteredLayers.isEmpty,
                   layerSelection < viewModel.filteredLayers.count else { return }
             proxy.scrollTo(layerSelection, anchor: .center)
-            flashIndicator()
             updateAffordances()
-          }
-          .onDisappear {
-            // Mirror the LayerView pattern: any pending hide task that
-            // outlives the view would later try to mutate state on a
-            // detached view via `MainActor.run`.
-            hideIndicatorTask?.cancel()
           }
           .overlay(alignment: .trailing) {
             sideIndicator(in: geometry.size)
           }
-          // Directional chevrons, gated at parity with the side indicator
-          // for now; visibility will later track live scroll state + edges.
           .overlay {
-            ScrollAffordanceView(affordances: affordanceModel.affordances)
-              .opacity(showIndicator ? 1 : 0)
+            ScrollAffordanceView(
+              affordances: affordanceModel.affordances,
+              isInteracting: affordanceModel.isInteracting
+            )
           }
           // DragGesture writes raw `layerSelection`; the bounds check uses
           // `filteredLayers.count` since reads downstream are clamped via
@@ -113,7 +105,6 @@ struct LayerScrollView: View {
                 {
                   layerSelection += 1
                 }
-                flashIndicator()
               }
           )
       }
@@ -124,9 +115,7 @@ struct LayerScrollView: View {
 
   private func scrollView(geometry: GeometryProxy) -> some View {
     // Zero spacing + per-page `containerRelativeFrame` (in LayerCardView) +
-    // `.paging` give exact, non-overlapping pages. The previous negative
-    // spacing was half of the B3 bump; the depth transforms were the other
-    // half (both removed — depth returns in #409 via scrollTransition).
+    // `.paging` give exact, non-overlapping pages with no resting offset.
     ScrollView(.vertical, showsIndicators: false) {
       LazyVStack(spacing: 0) {
         ForEach(viewModel.filteredLayers.indices, id: \.self) { index in
@@ -144,17 +133,16 @@ struct LayerScrollView: View {
     }
   }
 
+  /// Minimal, always-visible position rail (which layer of how many). Held
+  /// at a low opacity so it reads as ambient context and never competes with
+  /// the content; it no longer hides on a timer.
   private func sideIndicator(in size: CGSize) -> some View {
-    // The indicator stays in the hierarchy at all times — visibility is
-    // driven by opacity, animated through the `withAnimation` blocks in
-    // `flashIndicator()` / `scheduleHide()`. No `.transition(.opacity)`
-    // since the view is never inserted/removed.
     LayerSideIndicator(
       layers: viewModel.filteredLayers,
       selection: clampedSelection,
       size: size
     )
-    .opacity(showIndicator ? 1 : 0)
+    .opacity(0.35)
   }
 
   // MARK: - Affordances
@@ -165,25 +153,5 @@ struct LayerScrollView: View {
       layerCount: viewModel.filteredLayers.count,
       phaseCount: viewModel.phaseOrder.count
     )
-  }
-
-  // MARK: - Indicator lifecycle
-
-  private func flashIndicator() {
-    showIndicator = true
-    scheduleHide()
-  }
-
-  private func scheduleHide() {
-    hideIndicatorTask?.cancel()
-    hideIndicatorTask = Task {
-      try? await Task.sleep(nanoseconds: 1_000_000_000)
-      guard !Task.isCancelled else { return }
-      await MainActor.run {
-        withAnimation(.easeOut(duration: 0.3)) {
-          showIndicator = false
-        }
-      }
-    }
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -16,6 +16,9 @@ struct LayerScrollView: View {
   /// Edge availability + interaction state backing the directional chevrons.
   @StateObject private var affordanceModel = ScrollAffordanceModel()
 
+  /// Ambient opacity for the always-visible layer position rail.
+  private let sideRailAmbientOpacity: Double = 0.35
+
   /// Clamps `layerSelection` to the current filtered range so bindings
   /// can never read an out-of-range index — important during filter-mode
   /// transitions where `layerSelection` may be stale for one render.
@@ -142,7 +145,7 @@ struct LayerScrollView: View {
       selection: clampedSelection,
       size: size
     )
-    .opacity(0.35)
+    .opacity(sideRailAmbientOpacity)
   }
 
   // MARK: - Affordances

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
@@ -6,8 +6,6 @@ struct LayerView: View {
   @Binding var selection: Int
   let screenWidth: CGFloat // Stable width from parent GeometryReader
   @EnvironmentObject private var viewModel: ContentViewModel
-  @State private var showPageIndicator = false
-  @State private var hideIndicatorTask: Task<Void, Never>?
 
   var body: some View {
     TabView(selection: $selection) {
@@ -35,22 +33,16 @@ struct LayerView: View {
       }
       let normalized = PhaseNavigator.normalizedIndex(adjusted, phaseCount: phaseCount)
       viewModel.selectedPhaseIndex = normalized
-      showIndicator()
     }
     .overlay(alignment: .bottom) {
-      if showPageIndicator {
+      if phaseCount > 1 {
         pageIndicator
-          .transition(.opacity)
       }
-    }
-    .onAppear {
-      showIndicator()
-    }
-    .onDisappear {
-      hideIndicatorTask?.cancel()
     }
   }
 
+  /// Minimal, always-visible phase position rail (which phase of how many).
+  /// Held at a low opacity as ambient context; it no longer hides on a timer.
   private var pageIndicator: some View {
     HStack(spacing: 4) {
       ForEach(0 ..< phaseCount, id: \.self) { index in
@@ -73,21 +65,6 @@ struct LayerView: View {
         )
     )
     .padding(.bottom, 8)
-  }
-
-  private func showIndicator() {
-    withAnimation(.easeIn(duration: 0.2)) {
-      showPageIndicator = true
-    }
-    hideIndicatorTask?.cancel()
-    hideIndicatorTask = Task {
-      try? await Task.sleep(nanoseconds: 1_000_000_000)
-      guard !Task.isCancelled else { return }
-      await MainActor.run {
-        withAnimation(.easeOut(duration: 0.3)) {
-          showPageIndicator = false
-        }
-      }
-    }
+    .opacity(0.5)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerView.swift
@@ -7,6 +7,9 @@ struct LayerView: View {
   let screenWidth: CGFloat // Stable width from parent GeometryReader
   @EnvironmentObject private var viewModel: ContentViewModel
 
+  /// Ambient opacity for the always-visible phase position rail.
+  private let pageDotsAmbientOpacity: Double = 0.5
+
   var body: some View {
     TabView(selection: $selection) {
       ForEach(0 ..< (phaseCount + 2), id: \.self) { index in
@@ -65,6 +68,6 @@ struct LayerView: View {
         )
     )
     .padding(.bottom, 8)
-    .opacity(0.5)
+    .opacity(pageDotsAmbientOpacity)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -4,11 +4,13 @@ import SwiftUI
 /// is rendered for a direction only when movement that way is possible, so
 /// the absence of a chevron is itself the "you're at the edge" signal.
 ///
-/// Purely an affordance hint — it never intercepts touches, so it can't
-/// interfere with the scroll/crown gestures underneath. Overall visibility
-/// is controlled by the caller.
+/// The chevrons are always present; their overall emphasis is full while a
+/// scroll is in progress and de-emphasized at rest, so the edge cue never
+/// disappears mid-gesture. Purely an affordance hint — it never intercepts
+/// touches, so it can't interfere with the scroll/crown gestures underneath.
 struct ScrollAffordanceView: View {
   let affordances: ScrollAffordances
+  let isInteracting: Bool
 
   var body: some View {
     ZStack {
@@ -18,13 +20,22 @@ struct ScrollAffordanceView: View {
       if affordances.canGoRight { chevron("chevron.right", alignment: .trailing) }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .opacity(Self.chevronOpacity(isInteracting: isInteracting))
+    .animation(.easeInOut(duration: 0.2), value: isInteracting)
     .allowsHitTesting(false)
+  }
+
+  /// Full while a scroll is in progress, de-emphasized at rest. Never zero —
+  /// an available-direction chevron is always at least faintly visible, which
+  /// is what keeps it from ever disappearing on a timer.
+  static func chevronOpacity(isInteracting: Bool) -> Double {
+    isInteracting ? 0.9 : 0.35
   }
 
   private func chevron(_ systemName: String, alignment: Alignment) -> some View {
     Image(systemName: systemName)
       .font(.system(size: 12, weight: .semibold))
-      .foregroundStyle(.white.opacity(0.5))
+      .foregroundStyle(.white)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
       .padding(4)
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -25,11 +25,16 @@ struct ScrollAffordanceView: View {
     .allowsHitTesting(false)
   }
 
-  /// Full while a scroll is in progress, de-emphasized at rest. Never zero —
-  /// an available-direction chevron is always at least faintly visible, which
-  /// is what keeps it from ever disappearing on a timer.
+  /// Emphasis while a scroll is in progress.
+  private static let interactingOpacity: Double = 0.9
+  /// Ambient emphasis at rest — quiet but never zero, so an
+  /// available-direction chevron is always at least faintly visible.
+  private static let restingOpacity: Double = 0.35
+
+  /// Full while a scroll is in progress, de-emphasized at rest. Never zero,
+  /// which is what keeps a chevron from ever disappearing on a timer.
   static func chevronOpacity(isInteracting: Bool) -> Double {
-    isInteracting ? 0.9 : 0.35
+    isInteracting ? interactingOpacity : restingOpacity
   }
 
   private func chevron(_ systemName: String, alignment: Alignment) -> some View {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
@@ -19,4 +19,11 @@ struct ScrollAffordanceViewTests {
   func atRest_isNonZero() {
     #expect(ScrollAffordanceView.chevronOpacity(isInteracting: false) > 0)
   }
+
+  @Test("interacting opacity is a valid opacity value (never above 1.0)")
+  func interacting_isValidOpacity() {
+    let interacting = ScrollAffordanceView.chevronOpacity(isInteracting: true)
+    #expect(interacting > 0)
+    #expect(interacting <= 1.0)
+  }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Tests for `ScrollAffordanceView`'s emphasis policy. Visibility itself is
+/// edge-driven (covered by `ScrollAffordanceModelTests`); this pins the
+/// opacity contract that replaced the old timer — an available-direction
+/// chevron is emphasized while scrolling and merely de-emphasized at rest,
+/// never hidden (the structural guarantee against B1).
+struct ScrollAffordanceViewTests {
+  @Test("chevrons are more emphasized while interacting than at rest")
+  func interacting_isMoreEmphasizedThanRest() {
+    let interacting = ScrollAffordanceView.chevronOpacity(isInteracting: true)
+    let atRest = ScrollAffordanceView.chevronOpacity(isInteracting: false)
+
+    #expect(interacting > atRest)
+  }
+
+  @Test("chevrons stay visible at rest — opacity is never zero")
+  func atRest_isNonZero() {
+    #expect(ScrollAffordanceView.chevronOpacity(isInteracting: false) > 0)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes **B1** — directional indicators that vanished mid-scroll. Root cause (SPEC §2 B1): visibility was flipped on by discrete selection events and forced off by a blind 1-second `Task.sleep`, so a slow/paused scroll raced the timer and the indicators faded out under the user's finger. This replaces the timer with edge-availability + live scroll phase, so the chevrons can never disappear while you're scrolling.

- **Chevrons gated on edges + scroll phase, never time.** `LayerScrollView` feeds `ScrollAffordanceModel.setInteracting(...)` from `onScrollPhaseChange` (`ScrollPhase.isScrolling`), true for the *entire* duration of a gesture (drag, crown, momentum). A direction's chevron renders iff that move is possible (a missing chevron *is* the edge cue); `ScrollAffordanceView` emphasizes them fully while interacting and keeps them de-emphasized — but always visible (opacity never 0) — at rest.
- **Both blind hide-timers deleted.** Removed `flashIndicator`/`scheduleHide`/`showIndicator`/`hideIndicatorTask` from `LayerScrollView` and the `showPageIndicator`/`Task.sleep` path from `LayerView`. No code path now hides an available-direction affordance based on elapsed time.
- **Minimal, non-disappearing position rails retained** (SPEC §11 Q3): the right-edge layer rail (`LayerSideIndicator`) and the bottom phase dots are now always visible at a low, ambient opacity instead of flashing and timing out.

### Decisions (SPEC §11)
Q1: de-emphasized at rest, full during interaction. Q3: minimal position rails kept. Both axes covered (vertical layer edges; horizontal phase via infinite-wrap-aware left/right).

## Test plan
- **New `ScrollAffordanceViewTests`**: the emphasis contract that replaced the timer — interacting opacity > rest opacity, and rest opacity is **never zero** (the B1 "never hidden" guarantee, in test form). Edge-driven *which*-chevron-shows logic is covered by `ScrollAffordanceModelTests` (#410).
- `frontend/WavelengthWatch/run-tests-individually.sh` — full suite, build + all suites green (incl. nav guards; the horizontal `PhaseNavigator` wrap logic in `LayerView` is unchanged).
- `swiftformat --lint frontend` + `pre-commit` clean.
- **Unverifiable on-device behavior flagged (the B1 acceptance):** the load-bearing logic (edge math + opacity contract) is unit-tested, but "chevrons remain visible for the entire duration of a slow/paused scroll, suppress at the first/last layer, and the rails read as quiet ambient context" are visual/interaction properties. The reviewer should scroll slowly and pause mid-scroll on-device to confirm the chevrons never fade out, and check both axes, before merge.

Closes #411
Refs #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
