### PR TITLE
feat(design-system): apply wlGlass to selector card + affordances

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLSpacingTokens.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/DesignSystem/Theme/WLSpacingTokens.swift
@@ -24,6 +24,10 @@ enum WLSpacingTokens {
   static let cardBorderWidth: CGFloat = 0.5
   static let cardPaddingStandard: CGFloat = 12
   static let cardPaddingCompact: CGFloat = 8
+  /// Effectively-circular radius for small "pill" chips (e.g. the glass
+  /// chips behind the affordance chevrons): any value past half the chip's
+  /// size yields a capsule/circle.
+  static let pillCornerRadius: CGFloat = 99
 
   // MARK: - Indicator Sizes
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -55,8 +55,7 @@ struct PhaseCrystalCard: View {
     .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
     .wlGlass(.regular, tint: color, cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
     .overlay(crystalStroke)
-    .shadow(color: color.opacity(0.2), radius: 8)
-    .shadow(color: .black.opacity(0.3), radius: 4)
+    .modifier(CardDepthShadow(color: color))
   }
 
   private var layerContext: some View {
@@ -137,6 +136,25 @@ struct PhaseCrystalCard: View {
         ),
         lineWidth: 1
       )
+  }
+}
+
+/// Depth shadow for the crystal card, scoped by OS so the glass surface
+/// isn't double-shadowed. On watchOS 26 the `glassEffect` material renders
+/// its own depth, so only a single light separation shadow is added; the
+/// pre-26 fallback is a flat tinted surface and needs the fuller two-shadow
+/// stack to read as a floating card.
+private struct CardDepthShadow: ViewModifier {
+  let color: Color
+
+  func body(content: Content) -> some View {
+    if #available(watchOS 26, *) {
+      content.shadow(color: .black.opacity(0.25), radius: 4)
+    } else {
+      content
+        .shadow(color: color.opacity(0.2), radius: 8)
+        .shadow(color: .black.opacity(0.3), radius: 4)
+    }
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -11,7 +11,6 @@ struct PhaseCrystalCard: View {
   let phase: CatalogPhaseModel
   let color: Color
   let scale: CGFloat
-  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
   var body: some View {
     ZStack {
@@ -54,7 +53,13 @@ struct PhaseCrystalCard: View {
     // Fixed: content is a fixed visual height; scaling this pad only pushes the orb out.
     .padding(.vertical, 16)
     .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
-    .background(cardBackground)
+    // Liquid Glass surface (real `glassEffect` on watchOS 26, translucent
+    // fallback below, solid surface under Reduce Transparency — all handled
+    // by `wlGlass`). The crystal stroke and depth shadows stay as decoration.
+    .wlGlass(.regular, tint: color, cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
+    .overlay(crystalStroke)
+    .shadow(color: color.opacity(0.2), radius: 8)
+    .shadow(color: .black.opacity(0.3), radius: 4)
   }
 
   private var layerContext: some View {
@@ -119,46 +124,22 @@ struct PhaseCrystalCard: View {
     }
   }
 
-  /// Translucent dark scrim normally; a solid opaque surface when "Reduce
-  /// Transparency" is on so the layer-tinted page can't bleed through and
-  /// reduce legibility. The gradient stroke and depth shadows are preserved
-  /// in both modes.
-  private var cardFill: AnyShapeStyle {
-    if reduceTransparency {
-      return AnyShapeStyle(WLColorTokens.opaqueSurface)
-    }
-    return AnyShapeStyle(
-      LinearGradient(
-        gradient: Gradient(colors: [
-          Color.black.opacity(0.4),
-          Color.black.opacity(0.6),
-        ]),
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-      )
-    )
-  }
-
-  private var cardBackground: some View {
+  /// The crystalline gradient edge that gives the card its identity, layered
+  /// over the glass surface.
+  private var crystalStroke: some View {
     RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
-      .fill(cardFill)
-      .overlay(
-        RoundedRectangle(cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
-          .stroke(
-            LinearGradient(
-              gradient: Gradient(colors: [
-                color.opacity(0.3),
-                Color.white.opacity(0.1),
-                color.opacity(0.2),
-              ]),
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            ),
-            lineWidth: 1
-          )
+      .stroke(
+        LinearGradient(
+          gradient: Gradient(colors: [
+            color.opacity(0.3),
+            Color.white.opacity(0.1),
+            color.opacity(0.2),
+          ]),
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        ),
+        lineWidth: 1
       )
-      .shadow(color: color.opacity(0.2), radius: 8)
-      .shadow(color: .black.opacity(0.3), radius: 4)
   }
 }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -53,9 +53,6 @@ struct PhaseCrystalCard: View {
     // Fixed: content is a fixed visual height; scaling this pad only pushes the orb out.
     .padding(.vertical, 16)
     .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
-    // Liquid Glass surface (real `glassEffect` on watchOS 26, translucent
-    // fallback below, solid surface under Reduce Transparency — all handled
-    // by `wlGlass`). The crystal stroke and depth shadows stay as decoration.
     .wlGlass(.regular, tint: color, cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
     .overlay(crystalStroke)
     .shadow(color: color.opacity(0.2), radius: 8)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -20,10 +20,6 @@ struct ScrollAffordanceView: View {
   /// available-direction chevron is always at least faintly visible.
   private static let restingOpacity: Double = 0.35
 
-  /// Corner radius of the small glass chip behind each chevron; large enough
-  /// to read as a pill/circle at chip size.
-  private let chipCornerRadius: CGFloat = 99
-
   var body: some View {
     chevronLayer
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -32,9 +28,8 @@ struct ScrollAffordanceView: View {
       .allowsHitTesting(false)
   }
 
-  /// Groups the chevrons' glass effects so they blend correctly on
-  /// watchOS 26; older versions render the same chevrons with the `wlGlass`
-  /// fallback (no container needed).
+  /// `GlassEffectContainer` is required (not just nice-to-have) for multiple
+  /// glass elements to blend correctly on watchOS 26.
   @ViewBuilder
   private var chevronLayer: some View {
     if #available(watchOS 26, *) {
@@ -64,7 +59,7 @@ struct ScrollAffordanceView: View {
       .font(.system(size: 12, weight: .semibold))
       .foregroundStyle(.white)
       .padding(5)
-      .wlGlass(.regular, cornerRadius: chipCornerRadius)
+      .wlGlass(.regular, cornerRadius: WLSpacingTokens.pillCornerRadius)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
       .padding(4)
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -6,30 +6,52 @@ import SwiftUI
 ///
 /// The chevrons are always present; their overall emphasis is full while a
 /// scroll is in progress and de-emphasized at rest, so the edge cue never
-/// disappears mid-gesture. Purely an affordance hint — it never intercepts
-/// touches, so it can't interfere with the scroll/crown gestures underneath.
+/// disappears mid-gesture. Each sits on a Liquid Glass chip (grouped in a
+/// `GlassEffectContainer` so they blend correctly on watchOS 26). Purely an
+/// affordance hint — it never intercepts touches, so it can't interfere with
+/// the scroll/crown gestures underneath.
 struct ScrollAffordanceView: View {
   let affordances: ScrollAffordances
   let isInteracting: Bool
-
-  var body: some View {
-    ZStack {
-      if affordances.canGoUp { chevron("chevron.up", alignment: .top) }
-      if affordances.canGoDown { chevron("chevron.down", alignment: .bottom) }
-      if affordances.canGoLeft { chevron("chevron.left", alignment: .leading) }
-      if affordances.canGoRight { chevron("chevron.right", alignment: .trailing) }
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .opacity(Self.chevronOpacity(isInteracting: isInteracting))
-    .animation(.easeInOut(duration: 0.2), value: isInteracting)
-    .allowsHitTesting(false)
-  }
 
   /// Emphasis while a scroll is in progress.
   private static let interactingOpacity: Double = 0.9
   /// Ambient emphasis at rest — quiet but never zero, so an
   /// available-direction chevron is always at least faintly visible.
   private static let restingOpacity: Double = 0.35
+
+  /// Corner radius of the small glass chip behind each chevron; large enough
+  /// to read as a pill/circle at chip size.
+  private let chipCornerRadius: CGFloat = 99
+
+  var body: some View {
+    chevronLayer
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .opacity(Self.chevronOpacity(isInteracting: isInteracting))
+      .animation(.easeInOut(duration: 0.2), value: isInteracting)
+      .allowsHitTesting(false)
+  }
+
+  /// Groups the chevrons' glass effects so they blend correctly on
+  /// watchOS 26; older versions render the same chevrons with the `wlGlass`
+  /// fallback (no container needed).
+  @ViewBuilder
+  private var chevronLayer: some View {
+    if #available(watchOS 26, *) {
+      GlassEffectContainer { chevrons }
+    } else {
+      chevrons
+    }
+  }
+
+  private var chevrons: some View {
+    ZStack {
+      if affordances.canGoUp { chevron("chevron.up", alignment: .top) }
+      if affordances.canGoDown { chevron("chevron.down", alignment: .bottom) }
+      if affordances.canGoLeft { chevron("chevron.left", alignment: .leading) }
+      if affordances.canGoRight { chevron("chevron.right", alignment: .trailing) }
+    }
+  }
 
   /// Full while a scroll is in progress, de-emphasized at rest. Never zero,
   /// which is what keeps a chevron from ever disappearing on a timer.
@@ -41,6 +63,8 @@ struct ScrollAffordanceView: View {
     Image(systemName: systemName)
       .font(.system(size: 12, weight: .semibold))
       .foregroundStyle(.white)
+      .padding(5)
+      .wlGlass(.regular, cornerRadius: chipCornerRadius)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
       .padding(4)
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -54,6 +54,8 @@ struct ScrollAffordanceView: View {
     isInteracting ? interactingOpacity : restingOpacity
   }
 
+  /// Chips are intentionally untinted (neutral glass) so the chevrons stay
+  /// layer-agnostic, unlike the layer-tinted card.
   private func chevron(_ systemName: String, alignment: Alignment) -> some View {
     Image(systemName: systemName)
       .font(.system(size: 12, weight: .semibold))


### PR DESCRIPTION
## Summary

Epic 4 (Refs #404): makes Liquid Glass actually visible on the primary selector by applying the existing `wlGlass()` bridge to the rebuilt main card and the affordance chevrons. Closes the perception gap from the spec ("I don't really see how Liquid Glass has been implemented") — `WLGlassModifier` wraps the real `glassEffect` (watchOS 26) + fallback + Reduce-Transparency opaque path, but nothing on this screen was calling it.

- **`PhaseCrystalCard`**: replaced the hand-rolled `cardFill`/`cardBackground` (a black gradient scrim + manual Reduce-Transparency branch) with `.wlGlass(.regular, tint: color, cornerRadius: …Large)`. `wlGlass` now owns the surface across all three rendering modes; the distinctive crystalline gradient stroke and depth shadows are kept as overlays. The card's own `accessibilityReduceTransparency` handling is removed (the modifier owns it now).
- **`ScrollAffordanceView`**: each chevron now sits on a subtle `wlGlass` chip, grouped in a `GlassEffectContainer` (watchOS 26) so the glass blends correctly; pre-26 renders the same chevrons via the `wlGlass` fallback. Visibility/opacity behavior is unchanged.

### Scope
Styling only — no layout or behavior change. The B1/B2/B3 fixes, navigation, and the affordance/edge logic are untouched.

## Test plan
- `frontend/WavelengthWatch/run-tests-individually.sh` — full suite, build + all suites green. The `WLGlassModifier` and `ScrollAffordanceView` opacity contracts are already unit-tested and unaffected.
- `swiftformat --lint frontend` + `pre-commit` clean.
- **Unverifiable on-device behavior flagged (the whole point of this PR):** glass is a visual material — its actual appearance can only be judged on-device. The build confirms the API wiring across the availability branches, but the reviewer / on-device QA (#413) should verify on **watchOS 26** (real glass on the card + chevrons), on the **pre-26 fallback**, and with **Reduce Transparency** on (solid, legible card; chevrons legible), and confirm the chevron glass chips don't read as too heavy against the content. This is the canonical "OK to ship unverifiable UI if flagged" case; #413 is the dedicated cross-size/accessibility QA pass.

Closes #412
Refs #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
