### PR TITLE
fix(selector): immediate Clear Light logging, always-visible chevrons, translucent card glass

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -1,12 +1,18 @@
 import SwiftUI
 
-/// Card for displaying emotions in Clear Light view with source layer color coding
+/// Card for displaying emotions in Clear Light view with source layer color coding.
+///
+/// Like `CurriculumCard`/`StrategyCard`, this leaf emits a log-confirmation
+/// *intent* via `PresentationCoordinator` instead of owning a local `.alert`.
+/// The former leaf-local alert was rendered from inside the pushed
+/// `CurriculumDetailView`, so it (and its fire-and-forget journal `Task`) was
+/// deferred behind the navigation context until the user backed out — B2 in
+/// `prompts/claude-comm/spec-primary-selector-rebuild.md`. Routing through the
+/// root-anchored `RootPresentationHost` makes it present (and log) immediately.
 struct ClearLightEmotionCard: View {
   let emotion: LayeredEmotion
   let dosageType: CatalogDosage
-  @EnvironmentObject private var viewModel: ContentViewModel
-  @EnvironmentObject private var flowCoordinator: FlowCoordinator
-  @State private var showingJournalConfirmation = false
+  @EnvironmentObject private var presentationCoordinator: PresentationCoordinator
 
   var body: some View {
     ZStack(alignment: .topTrailing) {
@@ -46,45 +52,38 @@ struct ClearLightEmotionCard: View {
       )
       .padding(.horizontal, 8)
       .onTapGesture {
-        showingJournalConfirmation = true
+        presentationCoordinator.request(logRequest)
       }
 
       MysticalJournalIcon(color: emotion.sourceColor)
         .padding(.top, 8)
         .padding(.trailing, 20)
         .onTapGesture {
-          showingJournalConfirmation = true
+          presentationCoordinator.request(logRequest)
         }
-    }
-    .alert("Log \(dosageType == .medicinal ? "Medicinal" : "Toxic")", isPresented: $showingJournalConfirmation) {
-      Button("Yes") {
-        handleLogAction()
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("Would you like to log \"\(emotion.entry.expression)\"?")
     }
     // Tapped via onTapGesture; expose as one labeled VoiceOver button.
     .accessibilityElement(children: .ignore)
     .accessibilityAddTraits(.isButton)
-    .accessibilityLabel("\(dosageType == .medicinal ? "Medicinal" : "Toxic"): \(emotion.entry.expression), \(emotion.layerTitle)")
+    .accessibilityLabel("\(dosageLabel): \(emotion.entry.expression), \(emotion.layerTitle)")
     .accessibilityHint("Logs this entry")
-    .accessibilityAction { showingJournalConfirmation = true }
+    .accessibilityAction { presentationCoordinator.request(logRequest) }
   }
 
-  private func handleLogAction() {
-    switch flowCoordinator.currentStep {
-    case .selectingPrimary:
-      flowCoordinator.capturePrimary(emotion.entry)
-    case .selectingSecondary:
-      flowCoordinator.captureSecondary(emotion.entry)
-    case .idle:
-      // Auto-start flow when logging from normal mode
-      flowCoordinator.startPrimarySelection()
-      flowCoordinator.capturePrimary(emotion.entry)
-    default:
-      // Other states: immediate logging
-      Task { await viewModel.journal(curriculumID: emotion.entry.id) }
-    }
+  /// Human-readable dosage label used in the alert title and accessibility copy.
+  private var dosageLabel: String {
+    dosageType == .medicinal ? "Medicinal" : "Toxic"
+  }
+
+  /// The confirmation request this card surfaces; the root host renders it and
+  /// `LogConfirmationHandler` performs the same branching the card's former
+  /// `handleLogAction` did (capture into the flow when selecting, log directly
+  /// otherwise).
+  var logRequest: PresentationCoordinator.ActivePresentation {
+    .logConfirmation(LogConfirmationRequest(
+      alertTitle: "Log \(dosageLabel)",
+      message: "Would you like to log \"\(emotion.entry.expression)\"?",
+      action: .curriculum(entry: emotion.entry)
+    ))
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhaseCrystalCard.swift
@@ -12,6 +12,12 @@ struct PhaseCrystalCard: View {
   let color: Color
   let scale: CGFloat
 
+  /// Alpha applied to the layer color before it tints the glass surface. A
+  /// full-saturation tint saturates the glass into a bright, opaque square and
+  /// kills the translucency; damping it lets the Liquid Glass material read as
+  /// a tinted *glass* card rather than a colored block.
+  private static let glassTintOpacity: Double = 0.45
+
   var body: some View {
     ZStack {
       backgroundOrb
@@ -53,7 +59,11 @@ struct PhaseCrystalCard: View {
     // Fixed: content is a fixed visual height; scaling this pad only pushes the orb out.
     .padding(.vertical, 16)
     .frame(minWidth: UIConstants.phaseCardMinWidth * scale)
-    .wlGlass(.regular, tint: color, cornerRadius: WLSpacingTokens.cardCornerRadiusLarge)
+    .wlGlass(
+      .regular,
+      tint: color.opacity(Self.glassTintOpacity),
+      cornerRadius: WLSpacingTokens.cardCornerRadiusLarge
+    )
     .overlay(crystalStroke)
     .modifier(CardDepthShadow(color: color))
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -4,9 +4,11 @@ import SwiftUI
 /// is rendered for a direction only when movement that way is possible, so
 /// the absence of a chevron is itself the "you're at the edge" signal.
 ///
-/// The chevrons are always present; their overall emphasis is full while a
-/// scroll is in progress and de-emphasized at rest, so the edge cue never
-/// disappears mid-gesture. Each sits on a Liquid Glass chip (grouped in a
+/// The chevrons are always clearly visible whenever their direction is
+/// available — full while a scroll is in progress and only slightly calmer at
+/// rest — so the edge cue can never read as "disappeared," including during
+/// the programmatic vertical scroll that doesn't emit a scroll-phase signal.
+/// Each sits on a Liquid Glass chip (grouped in a
 /// `GlassEffectContainer` so they blend correctly on watchOS 26). Purely an
 /// affordance hint — it never intercepts touches, so it can't interfere with
 /// the scroll/crown gestures underneath.
@@ -15,10 +17,15 @@ struct ScrollAffordanceView: View {
   let isInteracting: Bool
 
   /// Emphasis while a scroll is in progress.
-  private static let interactingOpacity: Double = 0.9
-  /// Ambient emphasis at rest — quiet but never zero, so an
-  /// available-direction chevron is always at least faintly visible.
-  private static let restingOpacity: Double = 0.35
+  private static let interactingOpacity: Double = 1.0
+  /// Emphasis at rest. Kept high (not faint) on purpose: vertical navigation
+  /// is programmatic (crown / drag → `scrollTo`), so the scroll-phase
+  /// `isInteracting` signal frequently never fires for vertical moves. If the
+  /// resting state were faint, an available-direction chevron would read as
+  /// "disappeared" on every vertical scroll and only brighten on the native
+  /// horizontal `TabView` swipe — the exact B1 regression. A clearly-visible
+  /// resting state makes the chevron's presence independent of that signal.
+  private static let restingOpacity: Double = 0.85
 
   var body: some View {
     chevronLayer

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CurriculumCardTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CurriculumCardTests.swift
@@ -128,6 +128,44 @@ struct CurriculumCardTests {
     #expect(card.dosageType == .toxic)
   }
 
+  /// B2: tapping a Clear Light emotion must emit a root-level
+  /// `logConfirmation` intent (carrying a `.curriculum` action) rather than a
+  /// leaf-local `.alert`, so the confirmation/log isn't deferred until the
+  /// user backs out of the pushed detail view.
+  @Test("ClearLightEmotionCard emits a curriculum log-confirmation intent (medicinal)")
+  func clearLightCard_emitsMedicinalLogRequest() {
+    let entry = makeMockMedicinalEntry(id: 20, expression: "Connected")
+    let emotion = LayeredEmotion(layerId: 3, entry: entry, layerTitle: "PURPLE", layerColor: "Purple")
+    let card = ClearLightEmotionCard(emotion: emotion, dosageType: .medicinal)
+
+    let expected = PresentationCoordinator.ActivePresentation.logConfirmation(
+      LogConfirmationRequest(
+        alertTitle: "Log Medicinal",
+        message: "Would you like to log \"Connected\"?",
+        action: .curriculum(entry: entry)
+      )
+    )
+
+    #expect(card.logRequest == expected)
+  }
+
+  @Test("ClearLightEmotionCard emits a curriculum log-confirmation intent (toxic)")
+  func clearLightCard_emitsToxicLogRequest() {
+    let entry = makeMockToxicEntry(id: 21, expression: "Dependent")
+    let emotion = LayeredEmotion(layerId: 3, entry: entry, layerTitle: "PURPLE", layerColor: "Purple")
+    let card = ClearLightEmotionCard(emotion: emotion, dosageType: .toxic)
+
+    let expected = PresentationCoordinator.ActivePresentation.logConfirmation(
+      LogConfirmationRequest(
+        alertTitle: "Log Toxic",
+        message: "Would you like to log \"Dependent\"?",
+        action: .curriculum(entry: entry)
+      )
+    )
+
+    #expect(card.logRequest == expected)
+  }
+
   // MARK: - LayeredEmotion derived logic
 
   @Test("LayeredEmotion composes a unique id from layer and entry")

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationCoordinatorTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationCoordinatorTests.swift
@@ -28,13 +28,20 @@ struct PresentationCoordinatorTests {
     #expect(coordinator.active == .menu)
   }
 
-  @Test("a second request replaces the active presentation (skeleton policy)")
-  func request_replacesActivePresentation() {
+  /// `.menu` and `.onboarding` share priority 1, so the second request does
+  /// not preempt the first — it queues behind it (the #407 priority policy;
+  /// the earlier "replace" skeleton policy this test asserted is gone).
+  /// Preemption/queue ordering across priorities lives in
+  /// `PresentationPolicyTests`.
+  @Test("an equal-priority request queues behind the active one")
+  func request_equalPriority_queuesBehindActive() {
     let coordinator = PresentationCoordinator()
 
     coordinator.request(.menu)
     coordinator.request(.onboarding)
 
+    #expect(coordinator.active == .menu)
+    coordinator.dismiss()
     #expect(coordinator.active == .onboarding)
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
@@ -20,6 +20,16 @@ struct ScrollAffordanceViewTests {
     #expect(ScrollAffordanceView.chevronOpacity(isInteracting: false) > 0)
   }
 
+  /// B1 follow-up: vertical navigation is programmatic (crown / drag →
+  /// `scrollTo`), so the scroll-phase `isInteracting` signal often never fires
+  /// for vertical moves. Baseline visibility therefore can't depend on it — an
+  /// available-direction chevron must be *clearly* visible at rest, not merely
+  /// non-zero. Pins resting opacity high enough to read on-device.
+  @Test("chevrons are clearly visible at rest, independent of the scroll-phase signal")
+  func atRest_isClearlyVisible() {
+    #expect(ScrollAffordanceView.chevronOpacity(isInteracting: false) >= 0.8)
+  }
+
   @Test("interacting opacity is a valid opacity value (never above 1.0)")
   func interacting_isValidOpacity() {
     let interacting = ScrollAffordanceView.chevronOpacity(isInteracting: true)

--- a/prompts/claude-comm/RCA_selector_glass_chevrons_clearlight_logging.md
+++ b/prompts/claude-comm/RCA_selector_glass_chevrons_clearlight_logging.md
@@ -1,0 +1,93 @@
+# RCA — Selector glass brightness, chevron visibility, Clear Light logging deferral
+
+**Date:** 2026-06-01
+**Author:** Claude (with Geoff)
+**Related:** #292 (Liquid Glass Rebuild), `spec-primary-selector-rebuild.md` (B1/B2/B3)
+**Branch:** `fix-selector-glass-chevrons-clearlight-logging`
+
+The selector rebuild shipped in #417–#421 implemented spec Phases B (B3 bump — fixed),
+C (B1 chevrons), and D (glass). Phase A (B2 — journal confirmation deferral) was only
+partially landed. This RCA covers three user-reported follow-ups.
+
+---
+
+## Issue 1 — Colored selector card too bright/opaque (feature request)
+
+**Problem.** The phase card reads as a bright, saturated colored square rather than a
+translucent liquid-glass surface.
+
+**Root cause.** `PhaseCrystalCard.cardContent` applies
+`.wlGlass(.regular, tint: color, …)` with the layer's **full-saturation** color
+(`PhaseCrystalCard.swift:56`). On watchOS 26 this becomes
+`glassEffect(style.tint(color), in: shape)` (`WLGlassModifier.swift:71`); a fully
+opaque tint saturates the glass and removes the translucency. (On the pre-26 fallback
+the fill is `color.opacity(surfaceOpacityLow=0.1)`, already subtle.)
+
+**Fix strategy.** Dampen the tint alpha at the call site so the glass tints subtly and
+stays translucent. Pure styling change; flagged as visually unverifiable in CI
+(watch UI), per the project's "ship unverifiable UI if flagged" convention.
+
+---
+
+## Issue 2 — Directional chevrons vanish on vertical scroll (B1 regression)
+
+**Problem (user words).** "The chevrons don't appear until you scroll left/right; on
+every scroll up/down they disappear. They don't load automatically." These are the
+primary visual cue for entering the curriculum/logging screen, so this is P0.
+
+**Root cause.** `ScrollAffordanceView` emphasis is gated on `isInteracting`
+(resting `0.35`, interacting `0.9` — `ScrollAffordanceView.swift`). `isInteracting`
+is fed only by `.onScrollPhaseChange` on the **vertical** `ScrollView`
+(`LayerScrollView.swift:46-48`). But vertical navigation is **programmatic** — the
+digital crown and the drag gesture mutate `layerSelection`, and an `onChange`
+animates `proxy.scrollTo(...)` (`LayerScrollView.swift:49-75`, `100-112`). A
+programmatic `scrollTo` does not reliably emit a user-driven `scrollPhase`, so
+`isInteracting` rarely flips true during vertical moves → chevrons stay at the faint
+`0.35` resting opacity (reads as "disappeared"). The horizontal phase axis is a native
+`TabView(.page)` whose own scroll phase *does* fire, briefly brightening them to `0.9`
+(reads as "they appear when I scroll left/right"). Exactly the reported asymmetry.
+
+**Fix strategy.** Decouple baseline visibility from the unreliable scroll-phase signal:
+raise the resting opacity so an available-direction chevron is **always clearly
+visible**, with interaction remaining a small additional emphasis. This makes B1
+structurally impossible regardless of whether the phase signal fires (spec Principle 4).
+
+---
+
+## Issue 3 — Journal logging deferred until back-out (B2, Clear Light)
+
+**Problem (user words).** "Logging doesn't occur until you hit the back button to leave
+the screen where the emotions are listed. It must be awaiting behind something it
+shouldn't be."
+
+**Root cause.** Phase A migrated `CurriculumCard`, `StrategyCard`, and
+`StrategyListView` off their local confirmation alerts onto
+`PresentationCoordinator.request(.logConfirmation(...))`, rendered by
+`RootPresentationHost` above the navigation push so it presents immediately. But
+**`ClearLightEmotionCard` was never migrated**: it still owns
+`@State private var showingJournalConfirmation` and renders an `.alert` from inside the
+**pushed** `CurriculumDetailView` (`ClearLightEmotionCard.swift:9, 48-66`), and its
+direct-log branch is a fire-and-forget `Task { await viewModel.journal(...) }`
+(`:87`). That is precisely the B2 deferral pattern from the spec §2: a child
+presentation requested inside a pushed destination is serialized behind the root's
+presentation context and only flushes when the navigation state re-evaluates — i.e.
+when the user backs out. The "All Emotions" Clear Light screen is the
+"screen where the emotions are listed" the user describes.
+
+**Fix strategy.** Migrate `ClearLightEmotionCard` to emit
+`presentationCoordinator.request(.logConfirmation(LogConfirmationRequest(... action:
+.curriculum(entry: emotion.entry))))`, exactly mirroring `CurriculumCard`. The
+existing `LogConfirmationHandler.perform` already reproduces the card's former
+`handleLogAction` branching verbatim and `await`s the journal call at the root, so the
+local `.alert`, `@State`, `handleLogAction`, and fire-and-forget `Task` are deleted.
+
+---
+
+## Prevention
+
+- When a spec defines a leaf-card migration set, grep every card that owns a journal
+  `.alert`/`showingJournalConfirmation` before closing the phase — `ClearLightEmotionCard`
+  slipped through because it lives under `Curriculum/` but isn't named `*Card` like the
+  others were inventoried.
+- Affordance/visibility should never depend on a signal that only fires for one of the
+  two navigation axes; prefer always-visible-when-available with interaction as a bonus.


### PR DESCRIPTION
## Summary

Three user-reported follow-ups to the selector rebuild (#417–#421). Two are bugs (spec B1/B2), one is the glass-translucency feature request. Followed the bug-squashing methodology — RCA: `prompts/claude-comm/RCA_selector_glass_chevrons_clearlight_logging.md`.

### 🟥 B2 — Journal logging deferred until back-out (P0, Clear Light)
`ClearLightEmotionCard` was the **one leaf card never migrated** off its local `.alert` + fire-and-forget `Task`. Rendered from inside the pushed `CurriculumDetailView`, that presentation was serialized behind the NavigationStack root and only flushed when the user backed out — the exact B2 pattern the spec fixed for `CurriculumCard`/`StrategyCard`/`StrategyListView`. The "All Emotions" Clear Light screen is the "screen where the emotions are listed" in the report.

**Fix:** emit `presentationCoordinator.request(.logConfirmation(.curriculum(...)))` like the other cards, so the confirmation presents and the entry logs **immediately** via the root-anchored `RootPresentationHost`. Behavior preserved by the existing `LogConfirmationHandler` branching.

### 🟥 B1 — Chevrons vanish on vertical scroll (P0)
Chevron emphasis was gated on the scroll-phase `isInteracting` signal, but vertical navigation is **programmatic** (crown/drag → `scrollTo`), so that signal rarely fires for vertical moves — leaving chevrons at the faint `0.35` resting opacity. Only the native horizontal `TabView` swipe brightened them. That's exactly "they appear when I scroll left/right, disappear on every scroll up/down."

**Fix:** raise resting opacity to `0.85` so an available-direction chevron is **always clearly visible**, independent of the flaky signal (interaction now a small extra emphasis).

### ✨ Glass — colored card too bright/opaque
Dampen the `PhaseCrystalCard` `wlGlass` tint to `color.opacity(0.45)` so the Liquid Glass material reads as a translucent tinted card rather than a saturated block.

### 🧹 Drive-by
Fixed a **pre-existing** stale "skeleton policy" assertion in `PresentationCoordinatorTests` that contradicted the shipped #407 priority/queue policy (same-priority requests queue, not replace). Confirmed it was red on `main` before this branch.

## Testing
- ✅ Full frontend suite (48 suites) green
- ✅ New TDD tests: Clear Light card emits the correct `.logConfirmation` intent (medicinal + toxic); chevron resting opacity is clearly visible (≥ 0.8)
- ✅ SwiftFormat + pre-commit clean

## Notes for reviewer
- **Visually unverifiable in CI** (watch UI): the glass tint value (`0.45`) and chevron resting opacity (`0.85`) are sensible defaults — please eyeball on-device and let me know if you want them tuned.
- The actual tappable entry into the curriculum/logging screen is the bottom-right `chevron.right.circle.fill` button in `PhasePageView` (always present); the edge chevrons are non-interactive directional hints, now reliably visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
