### PR TITLE
Triple self-care curriculum with phase-aligned strategies

### DIFF
--- a/backend/data/a-w-strategies.csv
+++ b/backend/data/a-w-strategies.csv
@@ -51,3 +51,107 @@ Hot Beverages,Purple,Diminishing
 Walking,Red,Diminishing
 Journaling,Green,Diminishing
 Cleaning,Green,Diminishing
+Wrapping in a Blanket,Beige,Bottoming Out
+Eating a Warm Meal,Beige,Bottoming Out
+Taking a Nap,Beige,Bottoming Out
+Feeling Your Feet on the Floor,Beige,Bottoming Out
+Lighting a Candle,Purple,Bottoming Out
+Holding a Warm Mug,Purple,Bottoming Out
+Watching the Rain,Purple,Bottoming Out
+Sitting in the Dark,Purple,Bottoming Out
+Gentle Stretching,Red,Bottoming Out
+Texting a Friend,Blue,Bottoming Out
+Asking for Help,Blue,Bottoming Out
+Receiving Comfort,Blue,Bottoming Out
+Letting Yourself Cry,Green,Bottoming Out
+Self-Compassion Break,Green,Bottoming Out
+Surrendering to the Cycle,Teal,Bottoming Out
+Resting in Awareness,Ultraviolet,Bottoming Out
+Making the Bed,Beige,Restoration
+Tidying One Surface,Beige,Restoration
+Drinking a Smoothie,Beige,Restoration
+Gratitude Ritual,Purple,Restoration
+Tending a Plant,Purple,Restoration
+Spending Time Outdoors,Purple,Restoration
+Gentle Yoga Flow,Red,Restoration
+Going for a Swim,Red,Restoration
+Nature Walk,Red,Restoration
+Calling a Loved One,Blue,Restoration
+Sharing a Meal,Blue,Restoration
+Planning the Week,Orange,Restoration
+Reintroducing Routine,Orange,Restoration
+Setting a Small Goal,Orange,Restoration
+Gardening,Green,Restoration
+Cooking Something Nourishing,Green,Restoration
+Reflecting on Lessons Learned,Yellow,Restoration
+Setting an Intention,Teal,Restoration
+Morning Sunlight,Beige,Rising
+Energizing Breakfast,Beige,Rising
+Setting an Altar,Purple,Rising
+Dawn Walk,Purple,Rising
+Going for a Run,Red,Rising
+Strength Training,Red,Rising
+Power Posing,Red,Rising
+Reaching Out to a Mentor,Blue,Rising
+Joining a Cause,Blue,Rising
+Learning a New Skill,Orange,Rising
+Brainstorming,Orange,Rising
+Setting Ambitious Goals,Orange,Rising
+Cooking a New Recipe,Orange,Rising
+Painting,Green,Rising
+Singing,Green,Rising
+Reading Poetry,Green,Rising
+Mapping a Project,Yellow,Rising
+Flow State Practice,Teal,Rising
+Savoring the Moment,Beige,Peaking
+Mindful Eating,Beige,Peaking
+Celebratory Ritual,Purple,Peaking
+Ecstatic Dance,Red,Peaking
+Public Speaking,Red,Peaking
+Athletic Challenge,Red,Peaking
+Celebrating with Friends,Blue,Peaking
+Mentoring Someone,Blue,Peaking
+Sharing Joy,Blue,Peaking
+Sharing Your Work,Orange,Peaking
+Teaching What You Know,Orange,Peaking
+Gratitude Journaling,Green,Peaking
+Equanimity Practice,Yellow,Peaking
+Presence Practice,Yellow,Peaking
+Non-Grasping Practice,Teal,Peaking
+Metta for All Beings,Ultraviolet,Peaking
+Drinking Herbal Tea,Beige,Withdrawal
+Putting Feet Up,Beige,Withdrawal
+Weighted Blanket,Beige,Withdrawal
+Slow Breathing,Beige,Withdrawal
+Self-Soothing Touch,Beige,Withdrawal
+Calming Music,Purple,Withdrawal
+Aromatherapy,Purple,Withdrawal
+Shaking It Out,Red,Withdrawal
+Gentle Walk,Red,Withdrawal
+Confiding in a Friend,Blue,Withdrawal
+Being Held,Blue,Withdrawal
+Naming the Pattern,Orange,Withdrawal
+Researching What You Feel,Orange,Withdrawal
+Worry Journaling,Green,Withdrawal
+Expressing Feelings,Green,Withdrawal
+Time in Nature,Green,Withdrawal
+Observing Thoughts,Yellow,Withdrawal
+Labeling Emotions,Yellow,Withdrawal
+Grounding Meditation,Yellow,Withdrawal
+Letting Go Meditation,Ultraviolet,Withdrawal
+Decluttering,Beige,Diminishing
+Resting,Beige,Diminishing
+Comfort Food,Beige,Diminishing
+Comfort Movie,Purple,Diminishing
+Nostalgic Music,Purple,Diminishing
+Easy Listening,Purple,Diminishing
+Slow Stretching,Red,Diminishing
+Going Outside,Red,Diminishing
+Low-Key Time with Friends,Blue,Diminishing
+Asking for Support,Blue,Diminishing
+Lowering the Bar,Orange,Diminishing
+Breaking Tasks Down,Orange,Diminishing
+Drawing,Green,Diminishing
+Self-Forgiveness,Green,Diminishing
+Accepting the Season,Yellow,Diminishing
+Practicing Surrender,Teal,Diminishing

--- a/backend/tools/data/strategy.csv
+++ b/backend/tools/data/strategy.csv
@@ -51,3 +51,107 @@ id,strategy,layer_id,color_layer_id,phase_id
 50,Walking,0,3,4
 51,Journaling,0,6,4
 52,Cleaning,0,6,4
+53,Wrapping in a Blanket,0,1,5
+54,Eating a Warm Meal,0,1,5
+55,Taking a Nap,0,1,5
+56,Feeling Your Feet on the Floor,0,1,5
+57,Lighting a Candle,0,2,5
+58,Holding a Warm Mug,0,2,5
+59,Watching the Rain,0,2,5
+60,Sitting in the Dark,0,2,5
+61,Gentle Stretching,0,3,5
+62,Texting a Friend,0,4,5
+63,Asking for Help,0,4,5
+64,Receiving Comfort,0,4,5
+65,Letting Yourself Cry,0,6,5
+66,Self-Compassion Break,0,6,5
+67,Surrendering to the Cycle,0,8,5
+68,Resting in Awareness,0,9,5
+69,Making the Bed,0,1,6
+70,Tidying One Surface,0,1,6
+71,Drinking a Smoothie,0,1,6
+72,Gratitude Ritual,0,2,6
+73,Tending a Plant,0,2,6
+74,Spending Time Outdoors,0,2,6
+75,Gentle Yoga Flow,0,3,6
+76,Going for a Swim,0,3,6
+77,Nature Walk,0,3,6
+78,Calling a Loved One,0,4,6
+79,Sharing a Meal,0,4,6
+80,Planning the Week,0,5,6
+81,Reintroducing Routine,0,5,6
+82,Setting a Small Goal,0,5,6
+83,Gardening,0,6,6
+84,Cooking Something Nourishing,0,6,6
+85,Reflecting on Lessons Learned,0,7,6
+86,Setting an Intention,0,8,6
+87,Morning Sunlight,0,1,1
+88,Energizing Breakfast,0,1,1
+89,Setting an Altar,0,2,1
+90,Dawn Walk,0,2,1
+91,Going for a Run,0,3,1
+92,Strength Training,0,3,1
+93,Power Posing,0,3,1
+94,Reaching Out to a Mentor,0,4,1
+95,Joining a Cause,0,4,1
+96,Learning a New Skill,0,5,1
+97,Brainstorming,0,5,1
+98,Setting Ambitious Goals,0,5,1
+99,Cooking a New Recipe,0,5,1
+100,Painting,0,6,1
+101,Singing,0,6,1
+102,Reading Poetry,0,6,1
+103,Mapping a Project,0,7,1
+104,Flow State Practice,0,8,1
+105,Savoring the Moment,0,1,2
+106,Mindful Eating,0,1,2
+107,Celebratory Ritual,0,2,2
+108,Ecstatic Dance,0,3,2
+109,Public Speaking,0,3,2
+110,Athletic Challenge,0,3,2
+111,Celebrating with Friends,0,4,2
+112,Mentoring Someone,0,4,2
+113,Sharing Joy,0,4,2
+114,Sharing Your Work,0,5,2
+115,Teaching What You Know,0,5,2
+116,Gratitude Journaling,0,6,2
+117,Equanimity Practice,0,7,2
+118,Presence Practice,0,7,2
+119,Non-Grasping Practice,0,8,2
+120,Metta for All Beings,0,9,2
+121,Drinking Herbal Tea,0,1,3
+122,Putting Feet Up,0,1,3
+123,Weighted Blanket,0,1,3
+124,Slow Breathing,0,1,3
+125,Self-Soothing Touch,0,1,3
+126,Calming Music,0,2,3
+127,Aromatherapy,0,2,3
+128,Shaking It Out,0,3,3
+129,Gentle Walk,0,3,3
+130,Confiding in a Friend,0,4,3
+131,Being Held,0,4,3
+132,Naming the Pattern,0,5,3
+133,Researching What You Feel,0,5,3
+134,Worry Journaling,0,6,3
+135,Expressing Feelings,0,6,3
+136,Time in Nature,0,6,3
+137,Observing Thoughts,0,7,3
+138,Labeling Emotions,0,7,3
+139,Grounding Meditation,0,7,3
+140,Letting Go Meditation,0,9,3
+141,Decluttering,0,1,4
+142,Resting,0,1,4
+143,Comfort Food,0,1,4
+144,Comfort Movie,0,2,4
+145,Nostalgic Music,0,2,4
+146,Easy Listening,0,2,4
+147,Slow Stretching,0,3,4
+148,Going Outside,0,3,4
+149,Low-Key Time with Friends,0,4,4
+150,Asking for Support,0,4,4
+151,Lowering the Bar,0,5,4
+152,Breaking Tasks Down,0,5,4
+153,Drawing,0,6,4
+154,Self-Forgiveness,0,6,4
+155,Accepting the Season,0,7,4
+156,Practicing Surrender,0,8,4


### PR DESCRIPTION
Expand the bundled self-care strategy catalog from 52 to 156 entries
(exactly 3x), adding 104 new high-level strategies. Each new strategy is
color-coded to the developmental energy of an Archetypal Wavelength stage
and placed in the phase whose felt-energy it serves:

- Bottoming Out: rest, coziness, receptivity (gentle body care, comfort,
  surrender)
- Restoration: renewal and gentle re-activation (light movement,
  nourishment, new routines)
- Rising: surge and momentum (activation, building, learning, creation)
- Peaking: savoring without grasping (sharing, presence, equanimity)
- Withdrawal: soothing agitation (grounding, breath, co-regulation,
  introspection)
- Diminishing: welcoming contraction with grace (low-effort maintenance,
  comfort, surrender)

Both source-of-truth files stay in lockstep: backend/data/a-w-strategies.csv
feeds the bundled watch JSON, and backend/tools/data/strategy.csv seeds the
database (ids 53-156, layer_id 0, color_layer_id/phase_id matching the CSV).
Verified the new rows seed and serve via /api/v1/catalog and /api/v1/strategy.

https://claude.ai/code/session_01TQAQZ1iYpH21rto86TsovV