### PR TITLE
feat(journal): Quick-log on confirm, decoupled from the guided flow (#427)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
@@ -42,10 +42,9 @@ struct LogConfirmationRequest: Equatable {
 /// selection step is active (`selectingPrimary`/`selectingSecondary`/
 /// `selectingStrategy`) the confirmation captures into `FlowCoordinator`;
 /// every other step — including `idle` (a single tap from normal browsing) —
-/// quick-logs directly via `ContentViewModel.journal` (#427,
-/// `SPEC_journal_logging_pipeline.md` §6.1). A tap from idle therefore
-/// persists immediately and shows feedback rather than auto-starting the
-/// multi-step flow. `perform` is `async` so the direct-log path can `await`
+/// quick-logs directly via `ContentViewModel.journal`. A tap from idle
+/// therefore persists immediately and shows feedback rather than auto-starting
+/// the multi-step flow. `perform` is `async` so the direct-log path can `await`
 /// the journal call (the cards previously wrapped it in a fire-and-forget
 /// `Task`); the flow-capture paths are synchronous and complete before the
 /// first await.
@@ -62,11 +61,10 @@ struct LogConfirmationHandler {
         flowCoordinator.capturePrimary(entry)
       case .selectingSecondary:
         flowCoordinator.captureSecondary(entry)
-      default:
-        // Quick-log (#427): a single tap from idle — and confirming / review /
-        // selectingStrategy — persists immediately and renders feedback from
-        // the result via `journal`; it never auto-starts the guided flow or
-        // changes `layerFilterMode`. See SPEC_journal_logging_pipeline.md §6.1.
+      case .idle, .confirmingPrimary, .confirmingSecondary,
+           .selectingStrategy, .confirmingStrategy, .review:
+        // Non-selecting steps persist immediately and render feedback from the
+        // result; they never enter the guided flow or change layerFilterMode.
         await viewModel.journal(curriculumID: entry.id)
       }
     case let .strategy(strategy, curriculumID):

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
@@ -38,12 +38,17 @@ struct LogConfirmationRequest: Equatable {
 /// Performs the journal-logging action behind a `LogConfirmationRequest`.
 ///
 /// This is the single home for the branching the three leaf cards used to
-/// each duplicate in their private `handleLogAction`. The behavior is
-/// preserved exactly — flow-selection steps capture into `FlowCoordinator`,
-/// every other step logs directly via `ContentViewModel.journal`. `perform`
-/// is `async` so the direct-log path can `await` the journal call (the
-/// cards previously wrapped it in a fire-and-forget `Task`); the
-/// flow-capture paths are synchronous and complete before the first await.
+/// each duplicate in their private `handleLogAction`. While a guided-flow
+/// selection step is active (`selectingPrimary`/`selectingSecondary`/
+/// `selectingStrategy`) the confirmation captures into `FlowCoordinator`;
+/// every other step — including `idle` (a single tap from normal browsing) —
+/// quick-logs directly via `ContentViewModel.journal` (#427,
+/// `SPEC_journal_logging_pipeline.md` §6.1). A tap from idle therefore
+/// persists immediately and shows feedback rather than auto-starting the
+/// multi-step flow. `perform` is `async` so the direct-log path can `await`
+/// the journal call (the cards previously wrapped it in a fire-and-forget
+/// `Task`); the flow-capture paths are synchronous and complete before the
+/// first await.
 @MainActor
 struct LogConfirmationHandler {
   let flowCoordinator: FlowCoordinator
@@ -57,12 +62,11 @@ struct LogConfirmationHandler {
         flowCoordinator.capturePrimary(entry)
       case .selectingSecondary:
         flowCoordinator.captureSecondary(entry)
-      case .idle:
-        // Auto-start the flow when logging from normal browsing.
-        flowCoordinator.startPrimarySelection()
-        flowCoordinator.capturePrimary(entry)
       default:
-        // Confirming / review / selectingStrategy: immediate logging.
+        // Quick-log (#427): a single tap from idle — and confirming / review /
+        // selectingStrategy — persists immediately and renders feedback from
+        // the result via `journal`; it never auto-starts the guided flow or
+        // changes `layerFilterMode`. See SPEC_journal_logging_pipeline.md §6.1.
         await viewModel.journal(curriculumID: entry.id)
       }
     case let .strategy(strategy, curriculumID):

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -78,12 +78,10 @@ struct ClearLightEmotionCard: View {
       flowCoordinator.capturePrimary(emotion.entry)
     case .selectingSecondary:
       flowCoordinator.captureSecondary(emotion.entry)
-    case .idle:
-      // Auto-start flow when logging from normal mode
-      flowCoordinator.startPrimarySelection()
-      flowCoordinator.capturePrimary(emotion.entry)
     default:
-      // Other states: immediate logging
+      // Quick-log (#427): a single tap from idle — like the other non-selecting
+      // states — persists immediately and never auto-starts the guided flow.
+      // Mirrors `LogConfirmationHandler`; see SPEC_journal_logging_pipeline.md §6.1.
       Task { await viewModel.journal(curriculumID: emotion.entry.id) }
     }
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -78,10 +78,9 @@ struct ClearLightEmotionCard: View {
       flowCoordinator.capturePrimary(emotion.entry)
     case .selectingSecondary:
       flowCoordinator.captureSecondary(emotion.entry)
-    default:
-      // Quick-log (#427): a single tap from idle — like the other non-selecting
-      // states — persists immediately and never auto-starts the guided flow.
-      // Mirrors `LogConfirmationHandler`; see SPEC_journal_logging_pipeline.md §6.1.
+    case .idle, .confirmingPrimary, .confirmingSecondary,
+         .selectingStrategy, .confirmingStrategy, .review:
+      // Non-selecting steps log immediately; they never enter the guided flow.
       Task { await viewModel.journal(curriculumID: emotion.entry.id) }
     }
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LogConfirmationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LogConfirmationTests.swift
@@ -47,17 +47,20 @@ struct LogConfirmationTests {
 
   // MARK: - Handler: curriculum
 
-  @Test("curriculum action from idle auto-starts the flow and captures primary")
-  func handler_curriculum_fromIdle_startsAndCaptures() async {
-    let (viewModel, flow, _, catalog) = await setup()
+  @Test("curriculum action from idle quick-logs immediately without entering the flow")
+  func handler_curriculum_fromIdle_quickLogsImmediately() async {
+    let (viewModel, flow, journalClient, catalog) = await setup()
     let entry = catalog.layers[1].phases[0].medicinal[0]
     let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
 
     await handler.perform(.curriculum(entry: entry))
 
-    #expect(flow.currentStep == .confirmingPrimary)
-    #expect(flow.selections.primary == entry)
-    #expect(viewModel.layerFilterMode == .emotionsOnly)
+    // Quick-log (#427): one confirm persists exactly one row right now,
+    // and must NOT auto-start the guided flow or change the layer filter.
+    #expect(journalClient.submissions.count == 1)
+    #expect(flow.currentStep == .idle)
+    #expect(flow.selections.primary == nil)
+    #expect(viewModel.layerFilterMode == .all)
   }
 
   @Test("curriculum action while selectingPrimary captures primary")


### PR DESCRIPTION
## Summary

- Confirming a single emotion from **idle** auto-started the multi-step guided
  flow instead of logging, so the SQLite write only happened at flow submit
  (the journal-pipeline defect was *reaching* the save, not the save).
- Route the idle confirmation through the immediate-log path
  (`ContentViewModel.journal`) in `LogConfirmationHandler` **and** the
  `ClearLightEmotionCard` duplicate: one confirm → exactly one row persisted
  now, with success/queued/failure feedback from the result — no flow entry, no
  `layerFilterMode` change.
- The guided flow stays reachable via the explicit `MenuView` entry (tracer
  invariant: quick-log **and** guided flow both work). Implements
  `SPEC_journal_logging_pipeline.md` §6.1.

## Test plan

- **Red → Green (Gate 1):** rewrote `LogConfirmationTests` →
  `handler_curriculum_fromIdle_quickLogsImmediately` to assert one persisted
  row, `currentStep == .idle`, no primary captured, `layerFilterMode == .all`.
  Confirmed it **failed** against the old `.idle` branch, then passed after the
  fix.
- **Full suite:** `frontend/WavelengthWatch/run-tests-individually.sh` — all 48
  suites pass (flow/presentation regression suites green).
- **Gate 2:** `pre-commit run --all-files` clean (SwiftFormat, ruff, mypy,
  bandit, secrets, etc.).
- **Unverifiable on device (flagged):** `ClearLightEmotionCard.handleLogAction`
  is view-private, so its quick-log path can't be unit-tested without
  ViewInspector (which this repo rejects). It mirrors the unit-tested handler
  pattern exactly; per the DoD it needs **on-device QA**: log from a normal
  layer **and** Clear Light — confirm the row saves and feedback shows
  **without backing out**, and that the guided flow still opens from the menu.

## Scope notes

- `ClearLightEmotionCard` isn't in the issue's "Files involved" list, but the
  DoD explicitly requires Clear Light to quick-log, and that card carries an
  identical private `.idle` auto-start bug — so the minimal mirror-fix is
  included here.
- Out of scope (deferred to #428/#429): collapsing the duplicate `currentStep`
  observers, migrating `ClearLightEmotionCard` off its local `.alert` onto the
  hoisted `LogConfirmationRequest` path, and removing the guided-flow
  auto-start plumbing.

Refs #424
Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
