### PR TITLE
feat(selector): Auto-hiding directional chevrons — timed reveal + center-anchored placement (#438)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceVisibilityModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceVisibilityModel.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// How a single directional chevron is currently drawn.
+///
+/// `hidden` means the view is removed entirely (the SwiftUI equivalent of
+/// `display: none`), not merely transparent — at rest the chevrons take up no
+/// space and render nothing.
+enum ChevronStyle: Equatable {
+  case lit
+  case visibleUnlit
+  case hidden
+}
+
+/// One of the four dual-axis navigation directions.
+enum ScrollDirection: Equatable {
+  case up
+  case down
+  case left
+  case right
+}
+
+/// The drawn style of all four directional chevrons at a moment in time.
+struct ChevronVisibilityState: Equatable {
+  var up: ChevronStyle = .hidden
+  var down: ChevronStyle = .hidden
+  var left: ChevronStyle = .hidden
+  var right: ChevronStyle = .hidden
+}
+
+/// Drives the directional chevrons' timed reveal: mostly hidden, lit on the
+/// scrolled direction, then a visible-unlit settle window, then hidden again.
+///
+/// Pure, view-independent state with **injectable timing** — transitions are
+/// driven by `advance(by:)` over an elapsed `Duration`, so the whole machine is
+/// unit-testable without wall-clock sleeps. A thin live driver ticks
+/// `advance(by:)` using `nextDeadline`; edge-availability stays the concern of
+/// `ScrollAffordanceModel` and is supplied here, never recomputed.
+@MainActor
+final class ScrollAffordanceVisibilityModel: ObservableObject {
+  /// Lit emphasis on first load.
+  static let loadLitDuration: Duration = .milliseconds(300)
+  /// Visible-unlit settle window after load-lit and after every scroll.
+  static let settleDuration: Duration = .milliseconds(800)
+
+  @Published private(set) var state = ChevronVisibilityState()
+
+  /// Bumped on every external event so a live `.task(id:)` driver restarts its
+  /// sleep loop against the new phase.
+  @Published private(set) var version = 0
+
+  private var availability: ScrollAffordances
+  private var phase: Phase = .hidden
+
+  private enum Phase: Equatable {
+    case hidden
+    case loadLit(remaining: Duration)
+    /// Visible-unlit window (entered after load-lit and after every scroll-end).
+    case settle(remaining: Duration)
+    case scrolling(ScrollDirection)
+  }
+
+  init(availability: ScrollAffordances = ScrollAffordances()) {
+    self.availability = availability
+    recompute()
+  }
+
+  /// Edge availability changed (layer/phase move); restyle without disturbing
+  /// the current timing phase.
+  func updateAvailability(_ availability: ScrollAffordances) {
+    self.availability = availability
+    recompute()
+  }
+
+  /// The navigation screen appeared: lit for `loadLitDuration`, then settle.
+  func appeared() {
+    enter(.loadLit(remaining: Self.loadLitDuration))
+  }
+
+  /// A scroll is in progress toward `direction`: that chevron lights, the rest
+  /// stay visible-unlit, with no timeout until `scrollEnded()`.
+  func scrollStarted(_ direction: ScrollDirection) {
+    enter(.scrolling(direction))
+  }
+
+  /// The scroll settled: all available chevrons are visible-unlit for
+  /// `settleDuration`, then hidden. Restarts the window if already settling.
+  func scrollEnded() {
+    enter(.settle(remaining: Self.settleDuration))
+  }
+
+  /// Advance internal timers by `delta`. Overflow past a timed phase carries
+  /// into the next, so a single large step resolves to the final state.
+  func advance(by delta: Duration) {
+    switch phase {
+    case .hidden, .scrolling:
+      return // no timeout; only an event leaves these phases
+    case let .loadLit(remaining):
+      if delta >= remaining {
+        phase = .settle(remaining: Self.settleDuration)
+        recompute()
+        advance(by: delta - remaining)
+      } else {
+        phase = .loadLit(remaining: remaining - delta)
+        recompute()
+      }
+    case let .settle(remaining):
+      if delta >= remaining {
+        phase = .hidden
+      } else {
+        phase = .settle(remaining: remaining - delta)
+      }
+      recompute()
+    }
+  }
+
+  /// Time until the next automatic transition, or `nil` when the current phase
+  /// waits on an external event (`hidden`, `scrolling`).
+  var nextDeadline: Duration? {
+    switch phase {
+    case .hidden, .scrolling: nil
+    case let .loadLit(remaining): remaining
+    case let .settle(remaining): remaining
+    }
+  }
+
+  private func enter(_ newPhase: Phase) {
+    phase = newPhase
+    version &+= 1
+    recompute()
+  }
+
+  private func recompute() {
+    state = ChevronVisibilityState(
+      up: style(available: availability.canGoUp, direction: .up),
+      down: style(available: availability.canGoDown, direction: .down),
+      left: style(available: availability.canGoLeft, direction: .left),
+      right: style(available: availability.canGoRight, direction: .right)
+    )
+  }
+
+  private func style(available: Bool, direction: ScrollDirection) -> ChevronStyle {
+    guard available else { return .hidden }
+    switch phase {
+    case .hidden: return .hidden
+    case .loadLit: return .lit
+    case .settle: return .visibleUnlit
+    case let .scrolling(scrolled): return scrolled == direction ? .lit : .visibleUnlit
+    }
+  }
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceVisibilityModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ScrollAffordanceVisibilityModel.swift
@@ -97,8 +97,7 @@ final class ScrollAffordanceVisibilityModel: ObservableObject {
     case let .loadLit(remaining):
       if delta >= remaining {
         phase = .settle(remaining: Self.settleDuration)
-        recompute()
-        advance(by: delta - remaining)
+        advance(by: delta - remaining) // recursive call recomputes; no double publish
       } else {
         phase = .loadLit(remaining: remaining - delta)
         recompute()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -50,10 +50,13 @@ struct LayerScrollView: View {
           // Live scroll phase drives chevron emphasis — true for the whole
           // duration of a gesture (user drag, crown, or momentum), so the
           // chevrons stay prominent until the scroll actually settles.
-          .onScrollPhaseChange { _, newPhase in
+          .onScrollPhaseChange { oldPhase, newPhase in
             affordanceModel.setInteracting(newPhase.isScrolling)
-            // Native (horizontal) scroll settling drives the reveal window.
-            if !newPhase.isScrolling { visibilityModel.scrollEnded() }
+            // Only a real scroll->stop transition ends the reveal window, so the
+            // initial layout's idle phase can't cut the first-load sequence short.
+            if oldPhase.isScrolling, !newPhase.isScrolling {
+              visibilityModel.scrollEnded()
+            }
           }
           .digitalCrownRotation(
             Binding<Double>(

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -87,7 +87,7 @@ struct LayerScrollView: View {
             updateAffordances()
           }
           .onChange(of: phaseSelection) { oldValue, newValue in
-            registerScroll(newValue >= oldValue ? .right : .left)
+            registerScroll(newValue > oldValue ? .right : .left)
           }
           .onChange(of: viewModel.filteredLayers.count) { _, _ in
             updateAffordances()
@@ -189,8 +189,9 @@ struct LayerScrollView: View {
     visibilityModel.scrollStarted(direction)
     scrollEndTask?.cancel()
     scrollEndTask = Task { @MainActor in
-      try? await Task.sleep(for: .milliseconds(350))
-      if Task.isCancelled { return }
+      // Catch cancellation directly so scrollEnded() only fires on a clean
+      // wakeup (a rapid follow-up move cancels and supersedes this one).
+      do { try await Task.sleep(for: .milliseconds(350)) } catch { return }
       visibilityModel.scrollEnded()
     }
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -13,8 +13,15 @@ struct LayerScrollView: View {
   @Binding var layerSelection: Int
   @Binding var phaseSelection: Int
 
-  /// Edge availability + interaction state backing the directional chevrons.
+  /// Edge availability backing the directional chevrons.
   @StateObject private var affordanceModel = ScrollAffordanceModel()
+
+  /// Timed reveal (lit / visible-unlit / hidden) for the directional chevrons.
+  @StateObject private var visibilityModel = ScrollAffordanceVisibilityModel()
+
+  /// Synthesises a scroll-end for programmatic moves that emit no reliable
+  /// scroll-phase signal; cancelled/restarted on each new move.
+  @State private var scrollEndTask: Task<Void, Never>?
 
   /// Ambient opacity for the always-visible layer position rail.
   private let sideRailAmbientOpacity: Double = 0.35
@@ -45,6 +52,8 @@ struct LayerScrollView: View {
           // chevrons stay prominent until the scroll actually settles.
           .onScrollPhaseChange { _, newPhase in
             affordanceModel.setInteracting(newPhase.isScrolling)
+            // Native (horizontal) scroll settling drives the reveal window.
+            if !newPhase.isScrolling { visibilityModel.scrollEnded() }
           }
           .digitalCrownRotation(
             Binding<Double>(
@@ -65,13 +74,17 @@ struct LayerScrollView: View {
             isContinuous: false,
             isHapticFeedbackEnabled: true
           )
-          .onChange(of: layerSelection) { _, newValue in
+          .onChange(of: layerSelection) { oldValue, newValue in
             guard !viewModel.filteredLayers.isEmpty,
                   newValue < viewModel.filteredLayers.count else { return }
             withAnimation(.easeInOut(duration: 0.3)) {
               proxy.scrollTo(newValue, anchor: .center)
             }
+            registerScroll(newValue > oldValue ? .down : .up)
             updateAffordances()
+          }
+          .onChange(of: phaseSelection) { oldValue, newValue in
+            registerScroll(newValue >= oldValue ? .right : .left)
           }
           .onChange(of: viewModel.filteredLayers.count) { _, _ in
             updateAffordances()
@@ -84,15 +97,22 @@ struct LayerScrollView: View {
                   layerSelection < viewModel.filteredLayers.count else { return }
             proxy.scrollTo(layerSelection, anchor: .center)
             updateAffordances()
+            visibilityModel.appeared()
+          }
+          .task(id: visibilityModel.version) {
+            // Live driver: sleep to each timed deadline, then advance the pure
+            // state machine. Restarts whenever an event bumps `version`.
+            while let deadline = visibilityModel.nextDeadline {
+              try? await Task.sleep(for: deadline)
+              if Task.isCancelled { return }
+              visibilityModel.advance(by: deadline)
+            }
           }
           .overlay(alignment: .trailing) {
             sideIndicator(in: geometry.size)
           }
           .overlay {
-            ScrollAffordanceView(
-              affordances: affordanceModel.affordances,
-              isInteracting: affordanceModel.isInteracting
-            )
+            ScrollAffordanceView(state: visibilityModel.state)
           }
           // DragGesture writes raw `layerSelection`; the bounds check uses
           // `filteredLayers.count` since reads downstream are clamped via
@@ -156,5 +176,19 @@ struct LayerScrollView: View {
       layerCount: viewModel.filteredLayers.count,
       phaseCount: viewModel.phaseOrder.count
     )
+    visibilityModel.updateAvailability(affordanceModel.affordances)
+  }
+
+  /// Lights the scrolled direction, then synthesises a scroll-end after a
+  /// short window so programmatic vertical moves (which emit no reliable
+  /// scroll-phase signal) still light up and settle. Rapid moves coalesce.
+  private func registerScroll(_ direction: ScrollDirection) {
+    visibilityModel.scrollStarted(direction)
+    scrollEndTask?.cancel()
+    scrollEndTask = Task { @MainActor in
+      try? await Task.sleep(for: .milliseconds(350))
+      if Task.isCancelled { return }
+      visibilityModel.scrollEnded()
+    }
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/ScrollAffordanceView.swift
@@ -1,30 +1,32 @@
 import SwiftUI
 
-/// Edge-aware directional chevrons for the dual-axis navigation. A chevron
-/// is rendered for a direction only when movement that way is possible, so
-/// the absence of a chevron is itself the "you're at the edge" signal.
+/// Edge-aware directional chevrons for the dual-axis navigation, drawn as a
+/// timed reveal: mostly hidden, **lit** on the scrolled direction, then a brief
+/// **visible-unlit** settle window after a scroll and on first load. Per-
+/// direction styling comes from `ScrollAffordanceVisibilityModel`; a `.hidden`
+/// chevron is removed from the hierarchy entirely (not merely transparent), so
+/// at rest the affordance renders nothing.
 ///
-/// The chevrons are always present; their overall emphasis is full while a
-/// scroll is in progress and de-emphasized at rest, so the edge cue never
-/// disappears mid-gesture. Each sits on a Liquid Glass chip (grouped in a
-/// `GlassEffectContainer` so they blend correctly on watchOS 26). Purely an
-/// affordance hint — it never intercepts touches, so it can't interfere with
-/// the scroll/crown gestures underneath.
+/// The four chevrons are anchored to the **card's center** as a symmetric
+/// cross — each the same fixed `centerOffset` from the center — so they never
+/// shift as the card's content width changes from phase to phase. Purely an
+/// affordance hint: it never intercepts touches.
 struct ScrollAffordanceView: View {
-  let affordances: ScrollAffordances
-  let isInteracting: Bool
+  let state: ChevronVisibilityState
 
-  /// Emphasis while a scroll is in progress.
-  private static let interactingOpacity: Double = 0.9
-  /// Ambient emphasis at rest — quiet but never zero, so an
-  /// available-direction chevron is always at least faintly visible.
-  private static let restingOpacity: Double = 0.35
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  /// Distance of each chevron from the card center; the four form a symmetric
+  /// cross/diamond independent of the card's per-phase width. Tunable on-device.
+  private static let centerOffset: CGFloat = 86
+  /// Vertical nudge so the cross centers on the card, which sits slightly above
+  /// the overlay's center because of the bottom page-indicator gutter.
+  private static let cardCenterYAdjust: CGFloat = -10
+  private static let symbolSize: CGFloat = 16
 
   var body: some View {
     chevronLayer
       .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .opacity(Self.chevronOpacity(isInteracting: isInteracting))
-      .animation(.easeInOut(duration: 0.2), value: isInteracting)
       .allowsHitTesting(false)
   }
 
@@ -41,28 +43,30 @@ struct ScrollAffordanceView: View {
 
   private var chevrons: some View {
     ZStack {
-      if affordances.canGoUp { chevron("chevron.up", alignment: .top) }
-      if affordances.canGoDown { chevron("chevron.down", alignment: .bottom) }
-      if affordances.canGoLeft { chevron("chevron.left", alignment: .leading) }
-      if affordances.canGoRight { chevron("chevron.right", alignment: .trailing) }
+      chevron("chevron.up", style: state.up, offset: CGSize(width: 0, height: -Self.centerOffset))
+      chevron("chevron.down", style: state.down, offset: CGSize(width: 0, height: Self.centerOffset))
+      chevron("chevron.left", style: state.left, offset: CGSize(width: -Self.centerOffset, height: 0))
+      chevron("chevron.right", style: state.right, offset: CGSize(width: Self.centerOffset, height: 0))
     }
+    .offset(y: Self.cardCenterYAdjust)
+    // Opacity-only cross-fade (no positional motion) so reveal/hide reads
+    // gently under Reduce Motion; shortened there to avoid a lingering flash.
+    .animation(.easeInOut(duration: reduceMotion ? 0.1 : 0.2), value: state)
   }
 
-  /// Full while a scroll is in progress, de-emphasized at rest. Never zero,
-  /// which is what keeps a chevron from ever disappearing on a timer.
-  static func chevronOpacity(isInteracting: Bool) -> Double {
-    isInteracting ? interactingOpacity : restingOpacity
-  }
-
-  /// Chips are intentionally untinted (neutral glass) so the chevrons stay
-  /// layer-agnostic, unlike the layer-tinted card.
-  private func chevron(_ systemName: String, alignment: Alignment) -> some View {
-    Image(systemName: systemName)
-      .font(.system(size: 12, weight: .semibold))
-      .foregroundStyle(.white)
-      .padding(5)
-      .wlGlass(.regular, cornerRadius: WLSpacingTokens.pillCornerRadius)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
-      .padding(4)
+  /// `lit` uses prominent glass at full strength; `visibleUnlit` uses the
+  /// subtler glass at reduced opacity; `hidden` removes the view entirely.
+  @ViewBuilder
+  private func chevron(_ systemName: String, style: ChevronStyle, offset: CGSize) -> some View {
+    if style != .hidden {
+      Image(systemName: systemName)
+        .font(.system(size: Self.symbolSize, weight: .bold))
+        .foregroundStyle(.white)
+        .padding(7)
+        .wlGlass(style == .lit ? .prominent : .regular, cornerRadius: WLSpacingTokens.pillCornerRadius)
+        .opacity(style == .lit ? 1.0 : 0.6)
+        .offset(offset)
+        .transition(.opacity)
+    }
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
@@ -16,5 +16,6 @@ struct ScrollAffordanceViewTests {
     #expect(view.state.up == .lit)
     #expect(view.state.down == .visibleUnlit)
     #expect(view.state.left == .hidden)
+    #expect(view.state.right == .visibleUnlit)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceViewTests.swift
@@ -1,29 +1,20 @@
 import Testing
 @testable import WavelengthWatch_Watch_App
 
-/// Tests for `ScrollAffordanceView`'s emphasis policy. Visibility itself is
-/// edge-driven (covered by `ScrollAffordanceModelTests`); this pins the
-/// opacity contract that replaced the old timer — an available-direction
-/// chevron is emphasized while scrolling and merely de-emphasized at rest,
-/// never hidden (the structural guarantee against B1).
+/// `ScrollAffordanceView` is now a thin renderer of a `ChevronVisibilityState`;
+/// the lit / visible-unlit / hidden timing logic lives in
+/// `ScrollAffordanceVisibilityModel` (see `ScrollAffordanceVisibilityModelTests`).
+/// Per the project's view-test philosophy this is a shallow construction check.
+@MainActor
 struct ScrollAffordanceViewTests {
-  @Test("chevrons are more emphasized while interacting than at rest")
-  func interacting_isMoreEmphasizedThanRest() {
-    let interacting = ScrollAffordanceView.chevronOpacity(isInteracting: true)
-    let atRest = ScrollAffordanceView.chevronOpacity(isInteracting: false)
+  @Test("view constructs from a visibility state and exposes it")
+  func constructsFromState() {
+    let view = ScrollAffordanceView(state: ChevronVisibilityState(
+      up: .lit, down: .visibleUnlit, left: .hidden, right: .visibleUnlit
+    ))
 
-    #expect(interacting > atRest)
-  }
-
-  @Test("chevrons stay visible at rest — opacity is never zero")
-  func atRest_isNonZero() {
-    #expect(ScrollAffordanceView.chevronOpacity(isInteracting: false) > 0)
-  }
-
-  @Test("interacting opacity is a valid opacity value (never above 1.0)")
-  func interacting_isValidOpacity() {
-    let interacting = ScrollAffordanceView.chevronOpacity(isInteracting: true)
-    #expect(interacting > 0)
-    #expect(interacting <= 1.0)
+    #expect(view.state.up == .lit)
+    #expect(view.state.down == .visibleUnlit)
+    #expect(view.state.left == .hidden)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceVisibilityModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceVisibilityModelTests.swift
@@ -11,9 +11,7 @@ struct ScrollAffordanceVisibilityModelTests {
   )
 
   private func model() -> ScrollAffordanceVisibilityModel {
-    ScrollAffordanceVisibilityModel(availability: ScrollAffordances(
-      canGoUp: true, canGoDown: true, canGoLeft: true, canGoRight: true
-    ))
+    ScrollAffordanceVisibilityModel(availability: allAvailable)
   }
 
   // MARK: - Resting / load

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceVisibilityModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ScrollAffordanceVisibilityModelTests.swift
@@ -1,0 +1,174 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Transition coverage for the directional-chevron timed-reveal state machine
+/// (#438). Timing is injected via `advance(by:)`, so these are pure-logic tests
+/// with no wall-clock dependency.
+@MainActor
+struct ScrollAffordanceVisibilityModelTests {
+  private let allAvailable = ScrollAffordances(
+    canGoUp: true, canGoDown: true, canGoLeft: true, canGoRight: true
+  )
+
+  private func model() -> ScrollAffordanceVisibilityModel {
+    ScrollAffordanceVisibilityModel(availability: ScrollAffordances(
+      canGoUp: true, canGoDown: true, canGoLeft: true, canGoRight: true
+    ))
+  }
+
+  // MARK: - Resting / load
+
+  @Test("at rest (no events) every chevron is hidden")
+  func rest_allHidden() {
+    let m = model()
+    #expect(m.state == ChevronVisibilityState(
+      up: .hidden, down: .hidden, left: .hidden, right: .hidden
+    ))
+  }
+
+  @Test("first load: lit for 300ms, then visible-unlit for 800ms, then hidden")
+  func load_litThenVisibleThenHidden() {
+    let m = model()
+    m.appeared()
+    #expect(m.state == ChevronVisibilityState(
+      up: .lit, down: .lit, left: .lit, right: .lit
+    ))
+
+    m.advance(by: .milliseconds(300))
+    #expect(m.state == ChevronVisibilityState(
+      up: .visibleUnlit, down: .visibleUnlit, left: .visibleUnlit, right: .visibleUnlit
+    ))
+
+    m.advance(by: .milliseconds(800))
+    #expect(m.state == ChevronVisibilityState(
+      up: .hidden, down: .hidden, left: .hidden, right: .hidden
+    ))
+  }
+
+  @Test("load-lit overflow carries through the settle window to hidden")
+  func load_overflowResolvesToHidden() {
+    let m = model()
+    m.appeared()
+    // 300ms lit + 800ms settle = 1100ms total -> hidden.
+    m.advance(by: .milliseconds(1100))
+    #expect(m.state.up == .hidden)
+  }
+
+  @Test("load-lit partially elapsed stays lit")
+  func load_partialStaysLit() {
+    let m = model()
+    m.appeared()
+    m.advance(by: .milliseconds(150))
+    #expect(m.state.up == .lit)
+  }
+
+  // MARK: - Scroll
+
+  @Test("on scroll the scrolled direction is lit, other available are visible-unlit")
+  func scroll_directionLit_othersVisible() {
+    let m = model()
+    m.scrollStarted(.up)
+    #expect(m.state.up == .lit)
+    #expect(m.state.down == .visibleUnlit)
+    #expect(m.state.left == .visibleUnlit)
+    #expect(m.state.right == .visibleUnlit)
+  }
+
+  @Test("scrolling has no timeout — advancing keeps it lit")
+  func scroll_hasNoTimeout() {
+    let m = model()
+    m.scrollStarted(.right)
+    m.advance(by: .seconds(10))
+    #expect(m.state.right == .lit)
+  }
+
+  @Test("scroll end: visible-unlit for 800ms, then hidden")
+  func scrollEnd_visibleThenHidden() {
+    let m = model()
+    m.scrollEnded()
+    #expect(m.state == ChevronVisibilityState(
+      up: .visibleUnlit, down: .visibleUnlit, left: .visibleUnlit, right: .visibleUnlit
+    ))
+
+    m.advance(by: .milliseconds(800))
+    #expect(m.state == ChevronVisibilityState(
+      up: .hidden, down: .hidden, left: .hidden, right: .hidden
+    ))
+  }
+
+  @Test("each scroll-end restarts the 800ms window")
+  func scrollEnd_restartsWindow() {
+    let m = model()
+    m.scrollEnded()
+    m.advance(by: .milliseconds(500))
+    #expect(m.state.up == .visibleUnlit)
+
+    m.scrollEnded() // restart
+    m.advance(by: .milliseconds(500)) // 500 < 800, so still visible
+    #expect(m.state.up == .visibleUnlit)
+
+    m.advance(by: .milliseconds(300)) // now 800 total since restart
+    #expect(m.state.up == .hidden)
+  }
+
+  @Test("a new scroll pre-empts an in-progress settle window")
+  func newScroll_preemptsWindow() {
+    let m = model()
+    m.scrollEnded()
+    m.advance(by: .milliseconds(400))
+    m.scrollStarted(.left)
+    #expect(m.state.left == .lit)
+    #expect(m.state.up == .visibleUnlit)
+  }
+
+  @Test("a new scroll pre-empts the load sequence")
+  func newScroll_preemptsLoad() {
+    let m = model()
+    m.appeared()
+    m.advance(by: .milliseconds(100)) // still in load-lit
+    m.scrollStarted(.down)
+    #expect(m.state.down == .lit)
+  }
+
+  // MARK: - Edge availability
+
+  @Test("unavailable directions never render in any phase")
+  func unavailable_neverRendered() {
+    let m = ScrollAffordanceVisibilityModel(availability: ScrollAffordances(
+      canGoUp: false, canGoDown: true, canGoLeft: false, canGoRight: true
+    ))
+    m.appeared() // lit phase
+    #expect(m.state.up == .hidden)
+    #expect(m.state.left == .hidden)
+    #expect(m.state.down == .lit)
+    #expect(m.state.right == .lit)
+  }
+
+  @Test("availability changes restyle without disturbing the timing phase")
+  func availabilityChange_restylesInPlace() {
+    let m = ScrollAffordanceVisibilityModel(availability: allAvailable)
+    m.scrollStarted(.up)
+    m.updateAvailability(ScrollAffordances(
+      canGoUp: true, canGoDown: false, canGoLeft: true, canGoRight: true
+    ))
+    #expect(m.state.up == .lit) // scroll phase preserved
+    #expect(m.state.down == .hidden) // newly unavailable
+  }
+
+  // MARK: - nextDeadline (live-driver contract)
+
+  @Test("nextDeadline is nil at rest and while scrolling, set while timed")
+  func nextDeadline_reflectsPhase() {
+    let m = model()
+    #expect(m.nextDeadline == nil) // hidden/rest
+
+    m.appeared()
+    #expect(m.nextDeadline == .milliseconds(300))
+
+    m.scrollStarted(.up)
+    #expect(m.nextDeadline == nil) // scrolling waits on an event
+
+    m.scrollEnded()
+    #expect(m.nextDeadline == .milliseconds(800))
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the directional chevrons' always-on opacity policy with the timed
**auto-hide reveal** from #438:

- **Pure state machine** (`ScrollAffordanceVisibilityModel`) — three styles
  **lit / visible-unlit / hidden**; first-load **lit 300 ms → visible-unlit
  800 ms → hidden**; scroll lights the scrolled direction; scroll-end gives an
  **800 ms** visible-unlit window then hidden; each scroll-end restarts the
  window and a new scroll pre-empts any load/settle window. Timing is
  **injectable** (`advance(by:)`), so it's fully unit-tested with no sleeps.
  `hidden` **removes** the chevron (not `opacity(0)`).
- **Center-anchored symmetric placement** — the four chevrons sit at the same
  fixed offset from the **card's center** (a cross/diamond), so they don't shift
  as the card's content width changes per phase.
- **Both-axis triggers** in `LayerScrollView` — the programmatic vertical axis
  (which emits no reliable `onScrollPhaseChange`) is driven by layer/phase
  `onChange` + a synthesised scroll-end; native horizontal settling uses
  `onScrollPhaseChange`. A `.task(id:version)` deadline driver advances the
  machine in real time.
- **Unchanged:** `ScrollAffordanceModel` edge math; the colored card; the
  position indicators (consolidation is #432).

## Test plan

- **TDD (Gate 1):** `ScrollAffordanceVisibilityModelTests` — 14 pure-logic tests
  covering load → lit → visible-unlit → hidden, scroll-end → visible-unlit →
  hidden, on-scroll direction lit / others visible-unlit, no-timeout while
  scrolling, window restart, pre-empt (load + settle), edge-availability
  (unavailable never rendered), in-place availability restyle, and the
  `nextDeadline` live-driver contract. Written first, all green.
- **Full suite:** `frontend/WavelengthWatch/run-tests-individually.sh` — all
  48 suites pass (existing `ScrollAffordanceModelTests` edge-math green;
  `ScrollAffordanceViewTests` reduced to a shallow construction check since the
  logic moved to the model).
- **Gate 2:** `pre-commit run --all-files` clean (SwiftFormat etc.).

## ⚠️ On-device QA required (flagged — not verifiable in tests)

SwiftUI rendering/timing isn't unit-tested here, so please confirm on the watch:

- [ ] **Reveal feel:** first load shows the arrows lit ~300 ms, then unlit
      ~800 ms, then they vanish; scrolling re-reveals them and the scrolled
      direction lights up; they hide ~800 ms after you stop. Both crown and drag.
- [ ] **Both axes light up** on a real move — especially **vertical** (crown /
      drag between layers), since that path is programmatic.
- [ ] **Symmetry:** the four arrows are the **same distance from the card
      center** on every phase (regardless of card width) and every layer.
- [ ] **Lit vs visible-unlit** are visually distinct (prominent glass + full
      opacity vs subtler glass at 0.6) and legible on light and dark cards.
- [ ] **Reduce Motion:** no jarring flicker.
- [ ] Sizes 41 / 45 / 49mm; edge layers (Self Care has no down, Clear Light no up).

### Tunables (expect to nudge during QA)
`ScrollAffordanceView.centerOffset` (86), `cardCenterYAdjust` (-10),
`symbolSize` (16); `ScrollAffordanceVisibilityModel.loadLitDuration` (300 ms) /
`settleDuration` (800 ms); the synthesised vertical scroll-end delay (350 ms) in
`LayerScrollView.registerScroll`. The exact "lit" emphasis treatment may want a
stronger highlight than prominent-glass-at-full-opacity.

Refs #425
Closes #438
