### PR TITLE
fix(navigation): Keep the logging chevron visible on first load (#440)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
@@ -25,18 +25,10 @@ struct LayerCardView: View {
       screenWidth: screenWidth
     )
     .containerRelativeFrame([.horizontal, .vertical])
-    // Offset-derived depth (#409, SPEC §4.1): a single center-anchored
-    // scale + opacity + blur the scroll system drives from page geometry.
-    // At `phase.isIdentity` (the resting/centered page) every modifier is
-    // an exact identity (scale 1, opacity 1, blur 0), so the resting card's
-    // center cannot shift — the structural guarantee against B3. Started
-    // flat (no tilt) per SPEC §11 Q2; `scaleEffect`'s default `.center`
-    // anchor keeps the effect symmetric, never translating horizontally.
-    .scrollTransition(.interactive, axis: .vertical) { content, phase in
-      content
-        .opacity(phase.isIdentity ? 1 : 0.35)
-        .scaleEffect(phase.isIdentity ? 1 : 0.95)
-        .blur(radius: phase.isIdentity ? 0 : 1)
-    }
+    // The vertical-scroll depth effect now lives on `PhaseCrystalCard` (in
+    // `PhasePageView`) rather than the whole page, so the bottom-right logging
+    // chevron and the page background are never dimmed by it — the chevron
+    // stays visible on first load even before the centered card's scroll phase
+    // resolves to identity (#440).
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
@@ -18,6 +18,17 @@ struct PhasePageView: View {
         Spacer()
 
         PhaseCrystalCard(layer: layer, phase: phase, color: color, scale: scale)
+          // Offset-derived depth (#409, SPEC §4.1): center-anchored scale +
+          // opacity + blur driven from page geometry, an exact identity at the
+          // resting/centered card (the B3 no-shift guarantee). Scoped to the
+          // card so the logging chevron + background stay visible on first load
+          // (#440).
+          .scrollTransition(.interactive, axis: .vertical) { content, phase in
+            content
+              .opacity(phase.isIdentity ? 1 : 0.35)
+              .scaleEffect(phase.isIdentity ? 1 : 0.95)
+              .blur(radius: phase.isIdentity ? 0 : 1)
+          }
 
         Spacer()
           .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary

Fixes the logging chevron disappearing on the **first launch after install**
(it returned only after backgrounding + reopening).

**RCA:** the vertical `scrollTransition` on `LayerCardView` dimmed the **whole
page** (`opacity 0.35` + blur) until the centered card's phase resolved to
`.isIdentity` — which doesn't happen on first load until a relayout. The
bottom-right logging chevron (`PhasePageView`) lives inside that dimmed page, so
it read as missing. Backgrounding + reopening forces the relayout, which is why
it then appeared.

**Fix:** move the depth effect from the whole page (`LayerCardView`) onto
`PhaseCrystalCard` only. The card keeps its center-anchored depth + B3 no-shift
guarantee, but the chevron and page background are no longer subject to the
dimming — so the chevron is visible immediately on first load.

## Test plan

- Full suite `run-tests-individually.sh` — all 48 suites pass (no regression to
  navigation/layout).
- `pre-commit run --all-files` clean.
- **On-device QA (required):** fresh install → first launch shows the
  bottom-right logging chevron immediately; the card's vertical-scroll depth
  effect still looks right (dims/scales as you scroll between layers, crisp at
  rest); no leftward "bump" (B3).

Closes #440
Refs #425
