### PR TITLE
fix(journal): Restore the guided flow + secondary-emotion prompt (#445)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/LogConfirmation.swift
@@ -38,16 +38,16 @@ struct LogConfirmationRequest: Equatable {
 /// Performs the journal-logging action behind a `LogConfirmationRequest`.
 ///
 /// This is the single home for the branching the three leaf cards used to
-/// each duplicate in their private `handleLogAction`. While a guided-flow
-/// selection step is active (`selectingPrimary`/`selectingSecondary`/
-/// `selectingStrategy`) the confirmation captures into `FlowCoordinator`;
-/// every other step — including `idle` (a single tap from normal browsing) —
-/// quick-logs directly via `ContentViewModel.journal`. A tap from idle
-/// therefore persists immediately and shows feedback rather than auto-starting
-/// the multi-step flow. `perform` is `async` so the direct-log path can `await`
-/// the journal call (the cards previously wrapped it in a fire-and-forget
-/// `Task`); the flow-capture paths are synchronous and complete before the
-/// first await.
+/// each duplicate in their private `handleLogAction`. A tap from `idle`
+/// (normal browsing) starts the guided flow (`startPrimarySelection` +
+/// `capturePrimary`) so the secondary-emotion / strategy / review steps are
+/// offered (#445). While a selection step is active
+/// (`selectingPrimary`/`selectingSecondary`/`selectingStrategy`) the
+/// confirmation captures into `FlowCoordinator`; the remaining non-selecting
+/// steps (already inside the flow) log directly via `ContentViewModel.journal`.
+/// `perform` is `async` so the direct-log path can `await` the journal call
+/// (the cards previously wrapped it in a fire-and-forget `Task`); the
+/// flow-capture paths are synchronous and complete before the first await.
 @MainActor
 struct LogConfirmationHandler {
   let flowCoordinator: FlowCoordinator
@@ -61,10 +61,15 @@ struct LogConfirmationHandler {
         flowCoordinator.capturePrimary(entry)
       case .selectingSecondary:
         flowCoordinator.captureSecondary(entry)
-      case .idle, .confirmingPrimary, .confirmingSecondary,
+      case .idle:
+        // A tap from normal browsing starts the guided flow so the
+        // "Add Secondary Emotion" / strategy / review steps are offered (#445).
+        flowCoordinator.startPrimarySelection()
+        flowCoordinator.capturePrimary(entry)
+      case .confirmingPrimary, .confirmingSecondary,
            .selectingStrategy, .confirmingStrategy, .review:
-        // Non-selecting steps persist immediately and render feedback from the
-        // result; they never enter the guided flow or change layerFilterMode.
+        // Already inside the flow on a non-selecting step: persist immediately
+        // and render feedback from the result.
         await viewModel.journal(curriculumID: entry.id)
       }
     case let .strategy(strategy, curriculumID):

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Curriculum/ClearLightEmotionCard.swift
@@ -78,9 +78,14 @@ struct ClearLightEmotionCard: View {
       flowCoordinator.capturePrimary(emotion.entry)
     case .selectingSecondary:
       flowCoordinator.captureSecondary(emotion.entry)
-    case .idle, .confirmingPrimary, .confirmingSecondary,
+    case .idle:
+      // A tap from normal browsing starts the guided flow so the secondary /
+      // strategy / review steps are offered (#445).
+      flowCoordinator.startPrimarySelection()
+      flowCoordinator.capturePrimary(emotion.entry)
+    case .confirmingPrimary, .confirmingSecondary,
          .selectingStrategy, .confirmingStrategy, .review:
-      // Non-selecting steps log immediately; they never enter the guided flow.
+      // Already inside the flow on a non-selecting step: log immediately.
       Task { await viewModel.journal(curriculumID: emotion.entry.id) }
     }
   }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LogConfirmationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/LogConfirmationTests.swift
@@ -47,20 +47,20 @@ struct LogConfirmationTests {
 
   // MARK: - Handler: curriculum
 
-  @Test("curriculum action from idle quick-logs immediately without entering the flow")
-  func handler_curriculum_fromIdle_quickLogsImmediately() async {
+  @Test("curriculum action from idle starts the guided flow and captures primary")
+  func handler_curriculum_fromIdle_startsAndCaptures() async {
     let (viewModel, flow, journalClient, catalog) = await setup()
     let entry = catalog.layers[1].phases[0].medicinal[0]
     let handler = LogConfirmationHandler(flowCoordinator: flow, viewModel: viewModel)
 
     await handler.perform(.curriculum(entry: entry))
 
-    // Quick-log (#427): one confirm persists exactly one row right now,
-    // and must NOT auto-start the guided flow or change the layer filter.
-    #expect(journalClient.submissions.count == 1)
-    #expect(flow.currentStep == .idle)
-    #expect(flow.selections.primary == nil)
-    #expect(viewModel.layerFilterMode == .all)
+    // #445: a tap from idle ENTERS the guided flow so the secondary-emotion
+    // step (and strategy/review) are offered — it must not quick-log.
+    #expect(flow.currentStep == .confirmingPrimary)
+    #expect(flow.selections.primary == entry)
+    #expect(viewModel.layerFilterMode == .emotionsOnly)
+    #expect(journalClient.submissions.isEmpty)
   }
 
   @Test("curriculum action while selectingPrimary captures primary")


### PR DESCRIPTION
## Summary

Restores the guided logging flow so the **"Add Secondary Emotion"** step
reappears. #427 had reinterpreted a tap as a "quick log", which skipped the flow
— so the secondary prompt (the `.confirmingPrimary` alert in
`FlowConfirmationAlertsModifier`) never showed, even on back-out. That was the
wrong fix for the original bug #1, which actually wanted the secondary prompt.

**Change:** a tap from `.idle` now `startPrimarySelection()` +
`capturePrimary(entry)` (re-enters the flow) in both `LogConfirmationHandler` and
the `ClearLightEmotionCard` duplicate. Confirming the primary emotion then offers
**Add Secondary Emotion / Add Strategy / Done**. Genuinely non-selecting in-flow
steps still log immediately.

## Test plan

- TDD: flipped `LogConfirmationTests` idle test back to asserting flow entry
  (`.confirmingPrimary`, primary captured, `.emotionsOnly`, no submission) — was
  red against #427's quick-log, green after the fix.
- Full suite `run-tests-individually.sh` — all 48 suites pass (cancel-to-idle,
  strategy no-op, and the explicit-Done flow tests stay green).
- `pre-commit run --all-files` clean.

## ⚠️ On-device QA (required, auto-merging per Geoff's directive)

- Tap an emotion → "Would you like to log X?" → **Yes** → the **"Add Secondary
  Emotion"** alert appears **immediately** (not only after backing out) → pick a
  secondary → strategy → review → save.
- If the secondary alert is *deferred* (shows only after backing out of a detail
  view), that's the residual original-bug-#1 deferral and needs a follow-up
  (pop-to-root / hoist the flow alerts) — flag it.

## Note

Touches the same flow area as #428 (PR #444, still awaiting Geoff's sim check) —
when that merges it'll need a trivial reconciliation.

Refs #424
Closes #445
