### PR TITLE
fix(journal): Open the DB despite duplicate schema_version rows (#451)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
@@ -200,8 +200,15 @@ final class JournalDatabase {
       try migrateToV4()
     }
 
-    // Update schema version
-    let updateVersionSQL = "UPDATE schema_version SET version = \(Self.schemaVersion)"
+    // Set the schema version by collapsing `schema_version` to a single
+    // authoritative row. An older build's `INSERT OR IGNORE` could have left a
+    // second row; a plain `UPDATE … SET version = N` then violates the `version`
+    // PRIMARY KEY and the open fails (forcing the in-memory fallback, #451).
+    // Delete-then-insert is duplicate-safe.
+    let updateVersionSQL = """
+    DELETE FROM schema_version;
+    INSERT INTO schema_version (version) VALUES (\(Self.schemaVersion));
+    """
     var errorMessage: UnsafeMutablePointer<CChar>?
     if sqlite3_exec(db, updateVersionSQL, nil, nil, &errorMessage) != SQLITE_OK {
       let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import Testing
 @testable import WavelengthWatch_Watch_App
 
@@ -167,6 +168,37 @@ struct JournalRepositoryTests {
   }
 
   // MARK: - SQLite Repository Tests
+
+  @Test func sqliteOpensDespiteDuplicateSchemaVersionRows() throws {
+    let tempPath = NSTemporaryDirectory() + UUID().uuidString + ".db"
+    defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+    // A valid v4 database has exactly one schema_version row.
+    let first = JournalDatabase(path: tempPath)
+    try first.open()
+    first.close()
+
+    // Reproduce the historical corruption: a second schema_version row (an
+    // older build's INSERT OR IGNORE could add one when reopening an older DB).
+    Self.insertSchemaVersionRow(at: tempPath, version: 3)
+
+    // Reopening must NOT throw. With two rows, `UPDATE schema_version SET
+    // version = 4` violates the version PRIMARY KEY → open() throws → the app
+    // falls back to in-memory storage (logging blocked, #451).
+    let reopened = JournalDatabase(path: tempPath)
+    #expect(throws: Never.self) { try reopened.open() }
+    reopened.close()
+  }
+
+  /// Inserts an extra `schema_version` row via a raw connection, to simulate the
+  /// historical duplicate-row corruption.
+  private static func insertSchemaVersionRow(at path: String, version: Int) {
+    var raw: OpaquePointer?
+    #expect(sqlite3_open(path, &raw) == SQLITE_OK)
+    defer { sqlite3_close(raw) }
+    let sql = "INSERT INTO schema_version (version) VALUES (\(version));"
+    #expect(sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK)
+  }
 
   @Test func sqliteSavesAndFetchesEntry() throws {
     let tempPath = NSTemporaryDirectory() + UUID().uuidString + ".db"


### PR DESCRIPTION
## Summary

Fixes the journal database failing to open on launch → in-memory fallback →
**"entries can't be loaded / logging impossible"** (#451).

**RCA:** an older build's `INSERT OR IGNORE` could leave **two rows** in
`schema_version`. `migrate()` then ran `UPDATE schema_version SET version = 4`,
which violates the `version` PRIMARY KEY when two rows exist → `open()` throws →
`ContentViewDependencies` falls back to in-memory storage (no persistence).

**Fix:** set the version with a duplicate-safe **delete-then-insert** that
collapses the table to a single authoritative row.

## Test plan

- **Red → Green:** new `sqliteOpensDespiteDuplicateSchemaVersionRows` opens a
  valid DB, injects a second `schema_version` row via a raw SQLite connection,
  and asserts reopening no longer throws. Confirmed it **failed** before the fix
  (PK violation) and passes after.
- Full suite `run-tests-individually.sh` — all 48 suites pass.
- `pre-commit run --all-files` clean.

## On-device

Existing watches with the corrupted DB will open cleanly on next launch and
logging will persist again (no reinstall needed).

Closes #451
Refs #186
