### PR TITLE
fix(navigation): Remove the per-card depth effect (permanent blur) (#449)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerCardView.swift
@@ -8,9 +8,11 @@ import SwiftUI
 /// used to live here (a perspective x-axis rotation over a negative-spacing
 /// `LazyVStack`) re-projected the card's optical center as it animated and
 /// were the source of the "leftward bump" on vertical scroll (B3 in
-/// `prompts/claude-comm/spec-primary-selector-rebuild.md`). Depth is now a
-/// single offset-derived `scrollTransition` (#409) that resolves to an exact
-/// identity at the resting/centered page, so it can never shift the card.
+/// `prompts/claude-comm/spec-primary-selector-rebuild.md`). They are gone, and
+/// so is the later `scrollTransition` depth effect (#409/#440) — its sharp-at-
+/// rest state never resolved reliably and left cards permanently blurred (#449).
+/// Cards are now always crisp; the no-bump guarantee holds simply by having no
+/// vertical transform at all.
 struct LayerCardView: View {
   let layer: CatalogLayerModel
   let phaseCount: Int
@@ -25,10 +27,5 @@ struct LayerCardView: View {
       screenWidth: screenWidth
     )
     .containerRelativeFrame([.horizontal, .vertical])
-    // The vertical-scroll depth effect now lives on `PhaseCrystalCard` (in
-    // `PhasePageView`) rather than the whole page, so the bottom-right logging
-    // chevron and the page background are never dimmed by it — the chevron
-    // stays visible on first load even before the centered card's scroll phase
-    // resolves to identity (#440).
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
@@ -18,17 +18,6 @@ struct PhasePageView: View {
         Spacer()
 
         PhaseCrystalCard(layer: layer, phase: phase, color: color, scale: scale)
-          // Offset-derived depth (#409, SPEC §4.1): center-anchored scale +
-          // opacity + blur driven from page geometry, an exact identity at the
-          // resting/centered card (the B3 no-shift guarantee). Scoped to the
-          // card so the logging chevron + background stay visible on first load
-          // (#440).
-          .scrollTransition(.interactive, axis: .vertical) { content, phase in
-            content
-              .opacity(phase.isIdentity ? 1 : 0.35)
-              .scaleEffect(phase.isIdentity ? 1 : 0.95)
-              .blur(radius: phase.isIdentity ? 0 : 1)
-          }
 
         Spacer()
           .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
Fixes the **permanent blur** on the phase/layer selector (regression from #440).

**RCA:** the per-card depth `scrollTransition` (opacity/scale/**blur** keyed on
`phase.isIdentity`) never resolves to identity at rest on the nested
`PhaseCrystalCard`, so the card stays blurred. Same root flakiness as the
original first-load chevron dimming.

**Fix (Geoff's call):** remove the depth effect entirely — cards always crisp.
The B3 no-bump guarantee is unaffected (it came from the old hand-stacked
transforms, already removed, not this `scrollTransition`).

## Test plan
- Full suite — all 48 pass (no regression).
- `pre-commit run --all-files` clean.
- **On-device:** scroll between layers — cards are crisp throughout and at rest,
  no blur, no leftward "bump".

Closes #449
Refs #425
