### PR TITLE
fix(catalog): Refresh from the backend when reachable (#452)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/CatalogRepository.swift
@@ -83,7 +83,6 @@ final class CatalogRepository: CatalogRepositoryProtocol {
   private let dateProvider: () -> Date
   private let decoder: JSONDecoder
   private let encoder: JSONEncoder
-  private let cacheTTL: TimeInterval
   private let logger: CatalogRepositoryLogging
 
   init(
@@ -92,7 +91,6 @@ final class CatalogRepository: CatalogRepositoryProtocol {
     dateProvider: @escaping () -> Date = Date.init,
     decoder: JSONDecoder = JSONDecoder(),
     encoder: JSONEncoder = JSONEncoder(),
-    cacheTTL: TimeInterval = 60 * 60 * 24,
     logger: CatalogRepositoryLogging = DefaultCatalogRepositoryLogger()
   ) {
     self.remote = remote
@@ -102,7 +100,6 @@ final class CatalogRepository: CatalogRepositoryProtocol {
     self.encoder = encoder
     self.decoder.dateDecodingStrategy = .iso8601
     self.encoder.dateEncodingStrategy = .iso8601
-    self.cacheTTL = cacheTTL
     self.logger = logger
   }
 
@@ -125,30 +122,24 @@ final class CatalogRepository: CatalogRepositoryProtocol {
     try cache.writeCatalogData(data)
   }
 
-  private func isFresh(_ envelope: CatalogCacheEnvelope) -> Bool {
-    dateProvider().timeIntervalSince(envelope.fetchedAt) < cacheTTL
-  }
-
   func cachedCatalog() -> CatalogResponseModel? {
     readEnvelope()?.catalog
   }
 
   func loadCatalog(forceRefresh: Bool = false) async throws -> CatalogResponseModel {
-    let envelope = readEnvelope()
-    if !forceRefresh, let envelope, isFresh(envelope) {
-      return envelope.catalog
-    }
+    // Always fetch from the backend when it's reachable, so freshly-published
+    // catalog changes (e.g. new self-care strategies) appear without waiting on
+    // a TTL. The on-disk cache is an OFFLINE fallback only (#452).
     do {
       let catalog = try await remote.fetchCatalog()
       try? writeEnvelope(catalog)
       return catalog
     } catch {
-      // Remote failed (offline / backend down). Rather than wiping the user's
-      // curriculum every 24h once the TTL expires, fall back to any cached
-      // envelope we have — even if it's stale. The user keeps browsing; the
-      // next successful load will refresh. Only `forceRefresh` callers (e.g.
-      // an explicit "refresh now" tap) propagate the error.
-      if !forceRefresh, let envelope {
+      // Offline / backend down: serve the last cached catalog (any age) so the
+      // user keeps browsing; the next reachable load refreshes it. A
+      // `forceRefresh` caller (an explicit "refresh now" tap) propagates the
+      // error instead of masking it with stale data.
+      if !forceRefresh, let envelope = readEnvelope() {
         logger.remoteFailedServingStaleCatalog(error)
         return envelope.catalog
       }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/CatalogRepositoryFallbackTests.swift
@@ -31,14 +31,12 @@ struct CatalogRepositoryFallbackTests {
   private func makeRepository(
     remote: CatalogRemoteServicing,
     cache: CatalogCachePersisting,
-    now: Date,
-    ttl: TimeInterval = 60 * 60 * 24
+    now: Date
   ) -> CatalogRepository {
     CatalogRepository(
       remote: remote,
       cache: cache,
-      dateProvider: { now },
-      cacheTTL: ttl
+      dateProvider: { now }
     )
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/WavelengthWatch_Watch_AppTests.swift
@@ -9,19 +9,20 @@ struct CatalogRepositoryTests {
     remote: CatalogRemoteStub,
     cache: InMemoryCatalogCacheMock,
     now: @escaping () -> Date,
-    ttl: TimeInterval = 60 * 60 * 24,
     logger: CatalogRepositoryLogging = CatalogRepositoryLoggerSpy()
   ) -> CatalogRepository {
     CatalogRepository(
       remote: remote,
       cache: cache,
       dateProvider: now,
-      cacheTTL: ttl,
       logger: logger
     )
   }
 
-  @Test func returnsCachedCatalogWhenFresh() async throws {
+  @Test func fetchesFromBackendEvenWhenCachePresent() async throws {
+    // #452: when the backend is reachable, loadCatalog always fetches fresh data
+    // (so newly-published catalog changes — e.g. new strategies — appear)
+    // rather than returning a merely time-fresh cache without a round-trip.
     let remote = CatalogRemoteStub(response: SampleData.catalog)
     let cache = InMemoryCatalogCacheMock()
     let encoder = JSONEncoder()
@@ -30,10 +31,9 @@ struct CatalogRepositoryTests {
     cache.storedData = try encoder.encode(envelope)
     let repository = makeRepository(remote: remote, cache: cache, now: { Date(timeIntervalSince1970: 1500) })
 
-    #expect(repository.cachedCatalog() == SampleData.catalog)
     let catalog = try await repository.loadCatalog()
     #expect(catalog == SampleData.catalog)
-    #expect(remote.fetchCount == 0)
+    #expect(remote.fetchCount == 1) // fetched despite the recent cache
   }
 
   @Test func refreshesWhenCacheIsStale() async throws {
@@ -51,7 +51,10 @@ struct CatalogRepositoryTests {
     #expect(remote.fetchCount == 1)
   }
 
-  @Test func invalidatesCorruptCache() async throws {
+  @Test func corruptCacheReplacedByFreshFetch() async throws {
+    // With the backend reachable, loadCatalog fetches fresh and overwrites the
+    // (corrupt) cache — it never reads the cache on the happy path, so the
+    // corrupt data is simply replaced and the cache ends up valid (#452).
     let remote = CatalogRemoteStub(response: SampleData.catalog)
     let cache = InMemoryCatalogCacheMock()
     cache.storedData = Data("invalid".utf8)
@@ -62,8 +65,7 @@ struct CatalogRepositoryTests {
     #expect(catalog == SampleData.catalog)
     #expect(remote.fetchCount == 1)
     #expect(cache.storedData != nil)
-    #expect(cache.removeCount == 1)
-    #expect(logger.errors.count == 1)
+    #expect(repository.cachedCatalog() == SampleData.catalog) // corrupt data replaced
   }
 
   @Test func propagatesNetworkFailures() async {


### PR DESCRIPTION
## Summary
New catalog content (the #434 strategies) didn't appear on the watch.

**RCA:** `loadCatalog` short-circuited to the on-disk cache without fetching
whenever the cache was within the 24h TTL — so the device served stale data for
up to a day even with the backend reachable.

**Fix:** the cache is now an **offline fallback only** — always fetch from the
backend when reachable; serve the last cached catalog (any age) only on fetch
failure. Removed the obsolete `cacheTTL`/`isFresh` gate.

## Test plan
- `fetchesFromBackendEvenWhenCachePresent` — asserts a fetch occurs even with a
  recent cache (was `returnsCachedCatalogWhenFresh`, which asserted no fetch).
- `corruptCacheReplacedByFreshFetch` — a reachable fetch overwrites the cache.
- Offline-fallback tests (`CatalogRepositoryFallbackTests`) still pass: remote
  failure serves the cached catalog.
- Full suite (48) + `pre-commit run --all-files` green.

## On-device
The new strategies appear on next launch (with the backend reachable) without a
24h wait or reinstall.

Closes #452
Refs #434
