### PR TITLE
fix(journal): Present the Add-Secondary-Emotion alert immediately (#450)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/MainContentDialogsModifier.swift
@@ -84,17 +84,30 @@ struct MainContentDialogsModifier: ViewModifier {
 
   // MARK: - Navigation
 
-  /// Pops the navigation stack to root on flow-step transitions that
-  /// should leave the user free to navigate again (fixes #157 / #162 / #164:
-  /// prevents being stuck in a detail view across flow boundaries).
+  /// Pops the navigation stack to root on flow-step transitions that should
+  /// leave the user free to navigate again (fixes #157 / #162 / #164: prevents
+  /// being stuck in a detail view across flow boundaries).
   private func popNavigationPath(for step: FlowCoordinator.FlowStep) {
+    guard Self.popsToRoot(for: step), !navigationPath.isEmpty else { return }
+    navigationPath.removeLast(navigationPath.count)
+  }
+
+  /// Whether reaching `step` should pop the navigation stack to root.
+  ///
+  /// The **confirming** steps pop too (#450): the flow-confirmation alert
+  /// (`FlowConfirmationAlertsModifier`, e.g. "Add Secondary Emotion") is hosted
+  /// on the root content, so if the user tapped an emotion inside a pushed
+  /// detail view the alert would otherwise wait until they backed out. Only
+  /// `.review` doesn't pop — its sheet is presented above the push by
+  /// `RootPresentationHost`. `static` so the decision is unit-testable without
+  /// rendering the modifier.
+  static func popsToRoot(for step: FlowCoordinator.FlowStep) -> Bool {
     switch step {
-    case .selectingPrimary, .selectingSecondary, .selectingStrategy, .idle:
-      if !navigationPath.isEmpty {
-        navigationPath.removeLast(navigationPath.count)
-      }
-    default:
-      break
+    case .idle, .selectingPrimary, .selectingSecondary, .selectingStrategy,
+         .confirmingPrimary, .confirmingSecondary, .confirmingStrategy:
+      true
+    case .review:
+      false
     }
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/MainContentDialogsModifierTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/MainContentDialogsModifierTests.swift
@@ -83,4 +83,20 @@ struct MainContentDialogsModifierTests {
     #expect(flowCoordinator.currentStep == .confirmingPrimary)
     #expect(flowCoordinator.selections.primary == primary)
   }
+
+  // MARK: - popsToRoot (#450)
+
+  @Test("idle, selecting and confirming steps pop to root; review does not")
+  func popsToRoot_perStep() {
+    let popping: [FlowCoordinator.FlowStep] = [
+      .idle, .selectingPrimary, .selectingSecondary, .selectingStrategy,
+      .confirmingPrimary, .confirmingSecondary, .confirmingStrategy,
+    ]
+    for step in popping {
+      #expect(MainContentDialogsModifier.popsToRoot(for: step))
+    }
+    // The review sheet is presented above the navigation push, so reaching
+    // .review must not pop the user to root.
+    #expect(!MainContentDialogsModifier.popsToRoot(for: .review))
+  }
 }


### PR DESCRIPTION
## Summary
The "Add Secondary Emotion" alert appeared only after backing out of the
curriculum detail view (the original bug-#1 deferral; #445 restored flow entry
but not immediacy).

**RCA:** the flow-confirmation alert (`FlowConfirmationAlertsModifier`,
`.confirmingPrimary`) is hosted on the root content, behind the navigation push.
Entering the flow runs `startPrimarySelection` → `capturePrimary` synchronously,
so `popNavigationPath`'s `onChange` coalesced to `.confirmingPrimary` and skipped
the `.selectingPrimary` pop — the user stayed pushed, deferring the alert.

**Fix:** pop to root on the **confirming** steps too. Extracted a unit-testable
`popsToRoot(for:)` — true for idle/selecting*/confirming*, false only for
`.review` (its sheet is already above the push). Reaching a confirm step pops to
root so the alert is topmost and presents immediately.

## Test plan
- New `popsToRoot_perStep` asserts the per-step decision.
- Full suite (48) + `pre-commit run --all-files` green.

## ⚠️ On-device QA (auto-merging per Geoff's directive)
- Tap an emotion in the curriculum detail → "Log X?" → Yes → the **"Add
  Secondary Emotion" alert appears immediately** (no back-out) → secondary →
  strategy → review → save.
- Confirm no nav glitch from the pop-while-presenting. If it races, the fallback
  is hoisting the flow alerts into `RootPresentationHost` (above the push).

## Note
Conflicts with **#428 / PR #444** (which reworks `popNavigationPath` into
`FlowStepReactionPolicy`). When #444 is merged, that policy needs the same
`.confirming*` cases — reconcile then.

Closes #450
Refs #424
