### PR TITLE
chore(diagnostics): Phase 0 instrumentation for cold-start chevron + storage error (#457)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -47,6 +47,12 @@ struct ContentViewDependencies {
     category: "ContentViewDependencies"
   )
 
+  /// TEMPORARY (#457 Phase 0): cold-start sequence diagnostics. Remove after RCA.
+  private static let coldStart = Logger(
+    subsystem: "com.wavelengthwatch.watch",
+    category: "coldstart"
+  )
+
   /// Filesystem path for the temp-directory journal-queue fallback,
   /// composed via `URL` so it stays correct even if `NSTemporaryDirectory`
   /// ever stops returning a trailing-slash path.
@@ -61,13 +67,16 @@ struct ContentViewDependencies {
   /// real network monitor. Used by the app's runtime entry point.
   @MainActor
   static func live() -> ContentViewDependencies {
+    coldStart.log("live(): start")
     let configuration = AppConfiguration()
     let apiClient = APIClient(baseURL: configuration.apiBaseURL)
     let catalogRepository = CatalogRepository(
       remote: CatalogAPIService(apiClient: apiClient),
       cache: FileCatalogCacheStore()
     )
+    coldStart.log("live(): opening journal repository")
     let (journalRepository, journalStorageIsEphemeral) = Self.makeJournalRepository()
+    coldStart.log("live(): journal open done, ephemeral=\(journalStorageIsEphemeral, privacy: .public)")
     let syncSettings = SyncSettings()
     let journalQueue = Self.makeJournalQueue()
     let networkMonitor = NetworkMonitor()
@@ -92,6 +101,7 @@ struct ContentViewDependencies {
       initialPhaseIndex: storedPhase,
       journalStorageIsEphemeral: journalStorageIsEphemeral
     )
+    coldStart.log("live(): viewModel built (initialLayer=\(initialLayer, privacy: .public) initialPhase=\(storedPhase, privacy: .public))")
     let flowCoordinator = FlowCoordinator(contentViewModel: viewModel)
     let syncSettingsViewModel = SyncSettingsViewModel(syncSettings: syncSettings)
     let navigationViewModel = NavigationViewModel(

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
@@ -13,6 +13,25 @@ enum JournalDatabaseError: Error, Equatable {
   case databaseNotOpen
 }
 
+/// TEMPORARY (#457 Phase 0): surface the real SQLite reason + failing step via
+/// `error.localizedDescription` (already logged in `makeJournalRepository`), so
+/// the journal-open failure is no longer diagnosed blind. Fold into a proper
+/// error-presentation pass after RCA.
+extension JournalDatabaseError: LocalizedError {
+  var errorDescription: String? {
+    switch self {
+    case let .failedToOpenDatabase(message): "open failed: \(message)"
+    case let .failedToCreateTable(message): "create-table failed: \(message)"
+    case let .failedToInsert(message): "insert failed: \(message)"
+    case let .failedToUpdate(message): "update failed: \(message)"
+    case let .failedToDelete(message): "delete failed: \(message)"
+    case let .failedToQuery(message): "query failed: \(message)"
+    case let .invalidData(message): "invalid data: \(message)"
+    case .databaseNotOpen: "database not open"
+    }
+  }
+}
+
 /// Low-level SQLite database wrapper for journal entry storage.
 ///
 /// This class provides direct SQLite operations using the C API via Foundation.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 
 struct PhasePageView: View {
@@ -5,6 +6,12 @@ struct PhasePageView: View {
   let phase: CatalogPhaseModel
   let color: Color
   let screenWidth: CGFloat // Stable width from parent GeometryReader
+
+  /// TEMPORARY (#457 Phase 0): cold-start chevron diagnostics. Remove after RCA.
+  private static let chevronLog = Logger(
+    subsystem: "com.wavelengthwatch.watch",
+    category: "chevron"
+  )
 
   var body: some View {
     // Use screenWidth from parent to avoid nested GeometryReader race conditions
@@ -68,9 +75,17 @@ struct PhasePageView: View {
           }
           .buttonStyle(.plain)
           .padding(.trailing, 12)
+          // TEMPORARY (#457 Phase 0): did the chevron view get created at all?
+          .onAppear {
+            Self.chevronLog.log("chevron onAppear layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public)")
+          }
         }
         .padding(.bottom, 20)
       }
+    }
+    // TEMPORARY (#457 Phase 0): page lazily created on first scroll to this card.
+    .onAppear {
+      Self.chevronLog.log("page onAppear layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public)")
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
@@ -200,6 +200,14 @@ struct JournalRepositoryTests {
     #expect(sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK)
   }
 
+  @Test func journalDatabaseError_localizedDescription_surfacesReason() {
+    // TEMPORARY (#457 Phase 0): the journal-open failure log relies on
+    // `localizedDescription` carrying the real SQLite reason + failing step.
+    let error = JournalDatabaseError.failedToOpenDatabase("unable to open database file")
+    #expect(error.localizedDescription.contains("unable to open database file"))
+    #expect(error.localizedDescription.contains("open failed"))
+  }
+
   @Test func sqliteSavesAndFetchesEntry() throws {
     let tempPath = NSTemporaryDirectory() + UUID().uuidString + ".db"
     let db = JournalDatabase(path: tempPath)


### PR DESCRIPTION
## Summary
**Temporary Phase 0 instrumentation** (logging only) to diagnose the correlated
cold-start bug: on **force-close** cold start, the logging chevron fails to
render on the first **vertical-scroll** to an unseen card, AND the "journal
couldn't be opened" warning appears (intermittent; not on background resume).

We've been fixing the journal-open path blind — `JournalDatabaseError` didn't
conform to `LocalizedError`, so the warning logged a generic message, never the
real SQLite reason.

## What this adds
1. **Real journal error** — `JournalDatabaseError: LocalizedError` → the
   `makeJournalRepository` warning now shows e.g. `open failed: unable to open
   database file` or `create-table failed: database is locked`.
2. **Cold-start signposts** — `coldstart` category in
   `ContentViewDependencies.live()`: start, journal-open, ephemeral flag,
   viewModel-built. The Logger timestamps give the launch timeline.
3. **Chevron render path** — `chevron` category `.onAppear` on the page and on
   the bottom-right chevron itself, to tell *created-but-not-rendered* from
   *never-created*.

## Capture protocol
Build this branch on the watch → **force-close** the app → scroll vertically to a
not-yet-seen card → reproduce → Console.app / Xcode device console filtered by
subsystem `com.wavelengthwatch.watch` → paste the logs on #457.

## Notes
- **Do not merge** — this is diagnostic scaffolding to install and capture from;
  it'll be reverted/replaced by the real fix after RCA.
- Built off latest `main`, so it includes the recent fixes (#451/#449/#450/#452).
- One test pins the `LocalizedError` conformance; full suite + pre-commit green.

Refs #457
