### PR TITLE
chore(config): point the watch app's default backend at Railway

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Resources/APIConfiguration.plist
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Resources/APIConfiguration.plist
@@ -3,15 +3,16 @@
 <plist version="1.0">
 <dict>
     <key>API_BASE_URL</key>
-    <string>https://api.not-configured.local</string>
+    <string>https://wavelengthwatch-production.up.railway.app</string>
     <!--
     PRODUCTION CONFIGURATION
-    This file should contain production API URLs when shipping.
+    Points at the Railway-hosted backend (managed Postgres, auto-deploy on
+    merge to main). See backend/README.md "Deployment (Railway)".
 
     For local development:
     1. Copy APIConfiguration-Template.plist to APIConfiguration-Local.plist
-    2. Update with your local development URL
-    3. APIConfiguration-Local.plist will be loaded first if it exists
+    2. Update with your local development URL (e.g. http://<mac-ip>:8000)
+    3. APIConfiguration-Local.plist is loaded first if it exists (gitignored)
     -->
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Follow-up to the Railway deploy (#437, PR #459). Now that the FastAPI backend is live on Railway with managed Postgres, point the watch app's **committed default** `API_BASE_URL` at it, replacing the `https://api.not-configured.local` placeholder.

## Live verification (before repointing)

```
GET https://wavelengthwatch-production.up.railway.app/health        -> 200 {"status":"ok"}
GET https://wavelengthwatch-production.up.railway.app/api/v1/catalog -> 200, seeded catalog payload
```

The catalog response returns the full seeded layers/phases/strategies, confirming Postgres provisioned and seeded on first boot.

## Notes

- Local development is unaffected: `APIConfiguration-Local.plist` (gitignored) is loaded **before** the committed plist, so anyone pointing at a LAN dev backend keeps their override.
- This is the repoint the #437 spec scoped as a separate follow-up.

Refs #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
