### PR TITLE
chore(diagnostics): Phase 0.1 chevron-frame instrumentation (#457)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Extensions/EnvironmentValues+ChevronViewport.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Extensions/EnvironmentValues+ChevronViewport.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension EnvironmentValues {
+  /// TEMPORARY (#457 Phase 0.2): the scroll viewport's global frame, published
+  /// by `LayerScrollView`.
+  ///
+  /// Phase 0.1 judged the chevron against its own card and always returned
+  /// `onscreen`, even when the chevron wasn't visible — because a card can be
+  /// laid out *taller than the viewport* (observed `cardH` 257 vs the settled
+  /// 193), pushing a bottom-anchored chevron below the visible area while still
+  /// inside the card. Re-referencing the verdict against this viewport frame
+  /// distinguishes that *overflow* failure (`offscreenBelow`) from a genuine
+  /// *compositing* miss (`onscreen` yet invisible). Remove with the rest of the
+  /// Phase 0 diagnostics once the RCA lands.
+  @Entry var chevronDiagnosticViewportFrame: CGRect = .zero
+}

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -70,6 +70,11 @@ struct LayerScrollView: View {
           .overlay(alignment: .trailing) {
             sideIndicator(in: geometry.size)
           }
+          // TEMPORARY (#457 Phase 0.2): publish the viewport's global frame so
+          // PhasePageView's chevron diagnostic can judge the chevron against the
+          // actually-visible area rather than its own (possibly overflowing)
+          // card. Remove with the rest of the Phase 0 diagnostics.
+          .environment(\.chevronDiagnosticViewportFrame, geometry.frame(in: .global))
           // DragGesture writes raw `layerSelection`; the bounds check uses
           // `filteredLayers.count` since reads downstream are clamped via
           // `clampedSelection`.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
@@ -1,6 +1,32 @@
 import os
 import SwiftUI
 
+/// TEMPORARY (#457 Phase 0.1): where did the chevron's resolved frame land,
+/// relative to its own card? Distinguishes a *layout* failure (off-card or
+/// zero-size) from a *compositing* failure (a correct, on-card frame that
+/// still never paints) on lazily-realized cards. Both rects are read in the
+/// same `.global` space. Remove with the rest of the Phase 0 diagnostics once
+/// the RCA lands.
+enum ChevronFrameDiagnosis: String {
+  case onscreen
+  case zeroSize
+  case offscreenAbove
+  case offscreenBelow
+  case offscreenSide
+  case indeterminate
+
+  static func classify(chevron: CGRect, container: CGRect) -> ChevronFrameDiagnosis {
+    guard container.width > 0, container.height > 0 else { return .indeterminate }
+    guard chevron.width > 0, chevron.height > 0 else { return .zeroSize }
+    if chevron.maxY <= container.minY { return .offscreenAbove }
+    if chevron.minY >= container.maxY { return .offscreenBelow }
+    if chevron.maxX <= container.minX || chevron.minX >= container.maxX {
+      return .offscreenSide
+    }
+    return .onscreen
+  }
+}
+
 struct PhasePageView: View {
   let layer: CatalogLayerModel
   let phase: CatalogPhaseModel
@@ -12,6 +38,10 @@ struct PhasePageView: View {
     subsystem: "com.wavelengthwatch.watch",
     category: "chevron"
   )
+
+  /// TEMPORARY (#457 Phase 0.1): the card's resolved global frame, captured so
+  /// the chevron's frame can be judged against its own container.
+  @State private var cardFrame: CGRect = .zero
 
   var body: some View {
     // Use screenWidth from parent to avoid nested GeometryReader race conditions
@@ -79,6 +109,15 @@ struct PhasePageView: View {
           .onAppear {
             Self.chevronLog.log("chevron onAppear layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public)")
           }
+          // TEMPORARY (#457 Phase 0.1): where did the chevron actually land?
+          // Off-screen / zero-size => layout failure; an on-screen frame that
+          // still doesn't paint => compositing failure. Fires on settle.
+          .onGeometryChange(for: CGRect.self) { proxy in
+            proxy.frame(in: .global)
+          } action: { frame in
+            let verdict = ChevronFrameDiagnosis.classify(chevron: frame, container: cardFrame)
+            Self.chevronLog.log("chevron frame layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public) x=\(Int(frame.minX), privacy: .public) y=\(Int(frame.minY), privacy: .public) w=\(Int(frame.width), privacy: .public) h=\(Int(frame.height), privacy: .public) cardY=\(Int(cardFrame.minY), privacy: .public) cardH=\(Int(cardFrame.height), privacy: .public) verdict=\(verdict.rawValue, privacy: .public)")
+          }
         }
         .padding(.bottom, 20)
       }
@@ -86,6 +125,13 @@ struct PhasePageView: View {
     // TEMPORARY (#457 Phase 0): page lazily created on first scroll to this card.
     .onAppear {
       Self.chevronLog.log("page onAppear layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public)")
+    }
+    // TEMPORARY (#457 Phase 0.1): the card's own frame, used as the chevron's
+    // container reference in the same `.global` coordinate space.
+    .onGeometryChange(for: CGRect.self) { proxy in
+      proxy.frame(in: .global)
+    } action: { frame in
+      cardFrame = frame
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
@@ -39,9 +39,15 @@ struct PhasePageView: View {
     category: "chevron"
   )
 
-  /// TEMPORARY (#457 Phase 0.1): the card's resolved global frame, captured so
-  /// the chevron's frame can be judged against its own container.
+  /// TEMPORARY (#457 Phase 0.1): the card's resolved global frame. No longer
+  /// the verdict reference (Phase 0.2 uses the viewport) but still logged: a
+  /// card taller than the viewport is the overflow signal we're chasing.
   @State private var cardFrame: CGRect = .zero
+
+  /// TEMPORARY (#457 Phase 0.2): the scroll viewport's global frame, published
+  /// by `LayerScrollView`. The chevron is judged visible against this, not the
+  /// card — a card can overflow the viewport and hide a bottom-anchored chevron.
+  @Environment(\.chevronDiagnosticViewportFrame) private var viewportFrame
 
   var body: some View {
     // Use screenWidth from parent to avoid nested GeometryReader race conditions
@@ -109,14 +115,16 @@ struct PhasePageView: View {
           .onAppear {
             Self.chevronLog.log("chevron onAppear layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public)")
           }
-          // TEMPORARY (#457 Phase 0.1): where did the chevron actually land?
-          // Off-screen / zero-size => layout failure; an on-screen frame that
-          // still doesn't paint => compositing failure. Fires on settle.
+          // TEMPORARY (#457 Phase 0.2): where did the chevron land relative to
+          // the *viewport*? `offscreenBelow` => the card overflowed and pushed
+          // the chevron below the visible area (a layout bug); `onscreen` yet
+          // reported invisible => a compositing miss. `cardH` is logged too: a
+          // value above the settled viewport height is the overflow signal.
           .onGeometryChange(for: CGRect.self) { proxy in
             proxy.frame(in: .global)
           } action: { frame in
-            let verdict = ChevronFrameDiagnosis.classify(chevron: frame, container: cardFrame)
-            Self.chevronLog.log("chevron frame layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public) x=\(Int(frame.minX), privacy: .public) y=\(Int(frame.minY), privacy: .public) w=\(Int(frame.width), privacy: .public) h=\(Int(frame.height), privacy: .public) cardY=\(Int(cardFrame.minY), privacy: .public) cardH=\(Int(cardFrame.height), privacy: .public) verdict=\(verdict.rawValue, privacy: .public)")
+            let verdict = ChevronFrameDiagnosis.classify(chevron: frame, container: viewportFrame)
+            Self.chevronLog.log("chevron frame layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public) x=\(Int(frame.minX), privacy: .public) y=\(Int(frame.minY), privacy: .public) w=\(Int(frame.width), privacy: .public) h=\(Int(frame.height), privacy: .public) vpY=\(Int(viewportFrame.minY), privacy: .public) vpH=\(Int(viewportFrame.height), privacy: .public) cardH=\(Int(cardFrame.height), privacy: .public) verdict=\(verdict.rawValue, privacy: .public)")
           }
         }
         .padding(.bottom, 20)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ChevronFrameDiagnosisTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ChevronFrameDiagnosisTests.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// TEMPORARY (#457 Phase 0.1): unit coverage for the chevron-frame classifier
+/// that the cold-start instrumentation logs. Remove alongside the rest of the
+/// Phase 0 diagnostics once the RCA lands.
+///
+/// The classifier is the bit of real logic in the instrumentation — it turns a
+/// resolved global frame into a verdict that tells a *layout* failure
+/// (off-screen / zero-size) apart from a *compositing* failure (a correct,
+/// on-screen frame that still never paints).
+struct ChevronFrameDiagnosisTests {
+  private let screen = CGRect(x: 0, y: 0, width: 184, height: 224)
+
+  @Test("a centred, sized frame reads as onscreen")
+  func onscreen() {
+    let chevron = CGRect(x: 140, y: 180, width: 32, height: 32)
+    #expect(
+      ChevronFrameDiagnosis.classify(chevron: chevron, container: screen)
+        == .onscreen
+    )
+  }
+
+  @Test("a zero-size frame reads as zeroSize even when positioned onscreen")
+  func zeroSize() {
+    let chevron = CGRect(x: 140, y: 180, width: 0, height: 0)
+    #expect(
+      ChevronFrameDiagnosis.classify(chevron: chevron, container: screen)
+        == .zeroSize
+    )
+  }
+
+  @Test("a frame entirely below the screen reads as offscreenBelow")
+  func offscreenBelow() {
+    let chevron = CGRect(x: 140, y: 240, width: 32, height: 32)
+    #expect(
+      ChevronFrameDiagnosis.classify(chevron: chevron, container: screen)
+        == .offscreenBelow
+    )
+  }
+
+  @Test("a frame entirely above the screen reads as offscreenAbove")
+  func offscreenAbove() {
+    let chevron = CGRect(x: 140, y: -64, width: 32, height: 32)
+    #expect(
+      ChevronFrameDiagnosis.classify(chevron: chevron, container: screen)
+        == .offscreenAbove
+    )
+  }
+
+  @Test("a frame past the horizontal edge reads as offscreenSide")
+  func offscreenSide() {
+    let chevron = CGRect(x: 184, y: 180, width: 32, height: 32)
+    #expect(
+      ChevronFrameDiagnosis.classify(chevron: chevron, container: screen)
+        == .offscreenSide
+    )
+  }
+
+  @Test("an empty screen rect is indeterminate, not a false offscreen")
+  func indeterminate() {
+    let chevron = CGRect(x: 140, y: 180, width: 32, height: 32)
+    #expect(
+      ChevronFrameDiagnosis.classify(chevron: chevron, container: .zero)
+        == .indeterminate
+    )
+  }
+
+  @Test("a frame straddling the bottom edge still counts as onscreen")
+  func straddlingBottomEdgeIsOnscreen() {
+    // maxY past the edge but minY still within: partially visible => onscreen.
+    let chevron = CGRect(x: 140, y: 210, width: 32, height: 32)
+    #expect(
+      ChevronFrameDiagnosis.classify(chevron: chevron, container: screen)
+        == .onscreen
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0.1 of the cold-start chevron diagnostics (#457). Logging-only; reverted with the rest of the Phase 0 instrumentation once the RCA lands.

### What Phase 0 told us
The `chevron onAppear` logs fire on lazily-realized cards, but the chevron **doesn't paint even when the card is centered and settled** (device-confirmed). And on the simulator the missing chevron reproduces **without** the journal "couldn't be opened" storage error — so the #457 premise is corrected: **these are two independent bugs, not a correlated one.** This change touches only the chevron half.

### What this captures
With the per-card `scrollTransition` depth/blur already removed (#449), the chevron has no parent opacity/transform suppressing it, so the cause is narrowed to two classes that need different fixes:
- **Layout failure** — the chevron lands off-card or at zero size.
- **Compositing failure** — it has a correct, on-card frame but still never paints (the classic nested `.page`-TabView-in-`LazyVStack` realization bug).

Phase 0.1 records the discriminating signal:
- `onGeometryChange` logs the chevron's resolved **global** frame on settle, plus the card's own global frame as the container reference (same coordinate space).
- `ChevronFrameDiagnosis.classify(chevron:container:)` turns the two rects into a verdict — `onscreen` / `zeroSize` / `offscreenAbove|Below|Side` / `indeterminate` — so the logs say directly which failure class we're in.

`onscreen` + invisible ⇒ compositing bug. `offscreen*` / `zeroSize` ⇒ layout bug.

### Capture protocol (maintainer)
Build this branch → force-close → scroll vertically to an unseen card → settle → Console.app filtered by subsystem `com.wavelengthwatch.watch`, category `chevron`. Paste the `chevron frame ... verdict=...` lines.

### Tests
One pure-logic unit test for the classifier (`ChevronFrameDiagnosisTests`) covering on-screen, zero-size, all three off-screen directions, the indeterminate empty-container guard, and the partial-straddle boundary. Per the project view-test philosophy, the rendering itself is device-verified, not unit-tested. Build + suite green locally.

Refs #457 #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)
