### PR TITLE
fix(journal): recover old journal DBs that fail to open (#451)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -37,6 +37,10 @@ struct ContentViewDependencies {
   /// this session will not persist past app termination; the App layer should
   /// surface this to the user.
   let journalStorageIsEphemeral: Bool
+  /// The on-disk-open failure reason (an `error.localizedDescription`) when
+  /// `journalStorageIsEphemeral` is true, else `nil`. Surfaced in the Storage
+  /// Error alert so the cause is legible on-device (#457 RCA).
+  let journalStorageFailureReason: String?
   let catalogRepository: CatalogRepositoryProtocol
   /// Owns the dual-axis navigation selection and its reconciliation with
   /// `viewModel`; `ContentView` holds it as its single navigation state.
@@ -75,7 +79,7 @@ struct ContentViewDependencies {
       cache: FileCatalogCacheStore()
     )
     coldStart.log("live(): opening journal repository")
-    let (journalRepository, journalStorageIsEphemeral) = Self.makeJournalRepository()
+    let (journalRepository, journalStorageIsEphemeral, journalStorageFailureReason) = Self.makeJournalRepository()
     coldStart.log("live(): journal open done, ephemeral=\(journalStorageIsEphemeral, privacy: .public)")
     let syncSettings = SyncSettings()
     let journalQueue = Self.makeJournalQueue()
@@ -99,7 +103,8 @@ struct ContentViewDependencies {
       journalClient: journalClient,
       initialLayerIndex: initialLayer,
       initialPhaseIndex: storedPhase,
-      journalStorageIsEphemeral: journalStorageIsEphemeral
+      journalStorageIsEphemeral: journalStorageIsEphemeral,
+      journalStorageFailureReason: journalStorageFailureReason
     )
     coldStart.log("live(): viewModel built (initialLayer=\(initialLayer, privacy: .public) initialPhase=\(storedPhase, privacy: .public))")
     let flowCoordinator = FlowCoordinator(contentViewModel: viewModel)
@@ -122,6 +127,7 @@ struct ContentViewDependencies {
       journalClient: journalClient,
       journalRepository: journalRepository,
       journalStorageIsEphemeral: journalStorageIsEphemeral,
+      journalStorageFailureReason: journalStorageFailureReason,
       catalogRepository: catalogRepository,
       navigationViewModel: navigationViewModel
     )
@@ -147,14 +153,18 @@ struct ContentViewDependencies {
       try repository.open()
       return repository
     }
-  ) -> (repository: JournalRepositoryProtocol, isInMemoryFallback: Bool) {
+  ) -> (repository: JournalRepositoryProtocol, isInMemoryFallback: Bool, failureReason: String?) {
     do {
-      return try (openPersistent(), false)
+      return try (openPersistent(), false, nil)
     } catch {
+      // Carry the reason out, not just into the log: on-device Console capture
+      // is unreliable, so the App layer surfaces it in the Storage Error alert
+      // where a watch screenshot reveals the exact failing step (#457 RCA).
+      let reason = error.localizedDescription
       logger.warning(
-        "Journal database open failed: \(error.localizedDescription, privacy: .public). Falling back to in-memory storage."
+        "Journal database open failed: \(reason, privacy: .public). Falling back to in-memory storage."
       )
-      return (InMemoryJournalRepository(), true)
+      return (InMemoryJournalRepository(), true, reason)
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
@@ -46,6 +46,11 @@ extension JournalDatabaseError: LocalizedError {
 /// The database includes a version table for future migrations.
 final class JournalDatabase {
   /// Current schema version for migration tracking.
+  ///
+  /// There are only three column-changing migrations (`migrateToV2`/`V3`); the
+  /// former v4 step added analytics indexes only, which are now ensured on every
+  /// open by `createIndexes()`. The version still advances to 4 so databases
+  /// already at 4 aren't seen as stale — hence 4 with no `migrateToV4`.
   static let schemaVersion = 4
 
   /// SQLite database pointer.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
@@ -105,6 +105,13 @@ final class JournalDatabase {
     db = dbPointer
     try createTables()
     try migrate()
+    // Indexes are created last, AFTER migrations have added every column they
+    // reference (e.g. `entry_type`, added in v3). Creating them inside
+    // `createTables()` — before `migrate()` — fails with "no such column:
+    // entry_type" on a database carried across builds, because `CREATE TABLE
+    // IF NOT EXISTS` is a no-op on the pre-existing old table and the column
+    // isn't there yet. That threw, forcing the in-memory fallback (#451).
+    try createIndexes()
   }
 
   /// Closes the database connection.
@@ -135,7 +142,8 @@ final class JournalDatabase {
         WHERE NOT EXISTS (SELECT 1 FROM schema_version);
     """
 
-    // Journal entries table with indexes for common queries
+    // Journal entries table. Indexes are created separately, in
+    // `createIndexes()`, AFTER migrations run — see `open()` for why.
     let journalSQL = """
       CREATE TABLE IF NOT EXISTS journal_entry (
         id TEXT PRIMARY KEY,
@@ -151,7 +159,36 @@ final class JournalDatabase {
         last_sync_attempt REAL,
         retry_count INTEGER NOT NULL DEFAULT 0
       );
+    """
 
+    var errorMessage: UnsafeMutablePointer<CChar>?
+
+    if sqlite3_exec(db, versionSQL, nil, nil, &errorMessage) != SQLITE_OK {
+      let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"
+      sqlite3_free(errorMessage)
+      throw JournalDatabaseError.failedToCreateTable(message)
+    }
+
+    if sqlite3_exec(db, journalSQL, nil, nil, &errorMessage) != SQLITE_OK {
+      let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"
+      sqlite3_free(errorMessage)
+      throw JournalDatabaseError.failedToCreateTable(message)
+    }
+  }
+
+  /// Creates every `journal_entry` index, idempotently.
+  ///
+  /// Called from `open()` AFTER `migrate()`, so every column these indexes
+  /// reference is guaranteed to exist — including ones added by migrations on
+  /// an upgraded database (`entry_type` in v3). The two analytics indexes
+  /// (`idx_journal_strategy`, `idx_journal_created_curriculum`) were formerly
+  /// created in `migrateToV4`; centralizing them here means they're ensured on
+  /// every open regardless of the stored schema version, which is strictly
+  /// more robust than version-gating them.
+  private func createIndexes() throws {
+    guard let db else { throw JournalDatabaseError.databaseNotOpen }
+
+    let sql = """
       CREATE INDEX IF NOT EXISTS idx_journal_user_created
         ON journal_entry(user_id, created_at DESC);
 
@@ -175,14 +212,7 @@ final class JournalDatabase {
     """
 
     var errorMessage: UnsafeMutablePointer<CChar>?
-
-    if sqlite3_exec(db, versionSQL, nil, nil, &errorMessage) != SQLITE_OK {
-      let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"
-      sqlite3_free(errorMessage)
-      throw JournalDatabaseError.failedToCreateTable(message)
-    }
-
-    if sqlite3_exec(db, journalSQL, nil, nil, &errorMessage) != SQLITE_OK {
+    if sqlite3_exec(db, sql, nil, nil, &errorMessage) != SQLITE_OK {
       let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"
       sqlite3_free(errorMessage)
       throw JournalDatabaseError.failedToCreateTable(message)
@@ -215,9 +245,9 @@ final class JournalDatabase {
     if currentVersion < 3 {
       try migrateToV3()
     }
-    if currentVersion < 4 {
-      try migrateToV4()
-    }
+    // The former v4 step only added analytics indexes; those are now ensured on
+    // every open by `createIndexes()`, so there is no column-changing migration
+    // past v3. The version is still advanced to `schemaVersion` below.
 
     // Set the schema version by collapsing `schema_version` to a single
     // authoritative row. An older build's `INSERT OR IGNORE` could have left a
@@ -310,31 +340,6 @@ final class JournalDatabase {
         sqlite3_free(errorMessage)
         throw JournalDatabaseError.failedToUpdate(message)
       }
-    }
-  }
-
-  /// Migrates from schema v3 to v4 by adding analytics-critical indexes.
-  ///
-  /// Adds `idx_journal_strategy` on `strategy_id` for quick per-strategy
-  /// lookups and `idx_journal_created_curriculum` on `(created_at,
-  /// curriculum_id)` so date-range analytics queries can be answered
-  /// directly from the index without scanning the full table.
-  private func migrateToV4() throws {
-    guard let db else { throw JournalDatabaseError.databaseNotOpen }
-
-    let sql = """
-      CREATE INDEX IF NOT EXISTS idx_journal_strategy
-        ON journal_entry(strategy_id);
-
-      CREATE INDEX IF NOT EXISTS idx_journal_created_curriculum
-        ON journal_entry(created_at, curriculum_id);
-    """
-
-    var errorMessage: UnsafeMutablePointer<CChar>?
-    if sqlite3_exec(db, sql, nil, nil, &errorMessage) != SQLITE_OK {
-      let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"
-      sqlite3_free(errorMessage)
-      throw JournalDatabaseError.failedToUpdate(message)
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
@@ -54,6 +54,11 @@ final class ContentViewModel: ObservableObject {
   /// the App layer surfaces this to the user as a "Storage Error" alert.
   let journalStorageIsEphemeral: Bool
 
+  /// The on-disk-open failure reason when `journalStorageIsEphemeral` is true,
+  /// else `nil`. Passed to the Storage Error alert so the cause is legible
+  /// on-device (#457 RCA).
+  let journalStorageFailureReason: String?
+
   /// Returns layers filtered according to the current filter mode.
   ///
   /// The filtered layers change based on `layerFilterMode`:
@@ -83,7 +88,8 @@ final class ContentViewModel: ObservableObject {
     journalClient: JournalClientProtocol,
     initialLayerIndex: Int = 0,
     initialPhaseIndex: Int = 0,
-    journalStorageIsEphemeral: Bool = false
+    journalStorageIsEphemeral: Bool = false,
+    journalStorageFailureReason: String? = nil
   ) {
     self.catalogRepository = catalogRepository
     self.journalRepository = journalRepository
@@ -91,6 +97,7 @@ final class ContentViewModel: ObservableObject {
     self.selectedLayerIndex = initialLayerIndex
     self.selectedPhaseIndex = initialPhaseIndex
     self.journalStorageIsEphemeral = journalStorageIsEphemeral
+    self.journalStorageFailureReason = journalStorageFailureReason
   }
 
   @MainActor

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
@@ -71,6 +71,13 @@ final class PresentationCoordinator: ObservableObject {
   /// writing `true` requests it and writing `false` (a "Done" button or a
   /// swipe-dismiss) dismisses it through the queue policy, preserving the
   /// self-dismiss behavior the migrated sheets relied on.
+  ///
+  /// - Important: matching is by full `Equatable` value, so for cases that
+  ///   carry an associated value (e.g. `.storageError(reason:)`) the argument
+  ///   must equal the *active* value exactly — `isPresented(for:
+  ///   .storageError(reason: nil))` reads `false` while
+  ///   `.storageError(reason: "…")` is active. For those cases bind with a
+  ///   case-pattern-matching binding instead (see `RootPresentationHost`).
   func isPresented(for presentation: ActivePresentation) -> Binding<Bool> {
     Binding(
       get: { self.active == presentation },

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/PresentationCoordinator.swift
@@ -104,7 +104,11 @@ final class PresentationCoordinator: ObservableObject {
     case idle
     case menu
     case onboarding
-    case storageError
+    /// The journal-storage failure warning. Carries the open-failure
+    /// `reason` (an `error.localizedDescription`, e.g. the failing SQLite
+    /// step) so the on-screen alert can surface it for diagnostics — a
+    /// watch screenshot then reveals the exact cause (#457 storage RCA).
+    case storageError(reason: String?)
     /// The "Would you like to log …?" journal confirmation, carrying the
     /// alert copy and the action to perform on "Yes".
     case logConfirmation(LogConfirmationRequest)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootPresentationHost.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootPresentationHost.swift
@@ -31,12 +31,45 @@ struct RootPresentationHost: ViewModifier {
   private func storageErrorAlert(_ view: some View) -> some View {
     view.alert(
       "Storage Error",
-      isPresented: coordinator.isPresented(for: .storageError)
+      isPresented: storageErrorPresented
     ) {
       Button("OK", role: .cancel) {}
     } message: {
-      Text("Your journal couldn't be opened, so entries logged this session won't be saved. Please reopen the app; if the problem continues, contact support.")
+      Text(Self.storageErrorMessage(reason: storageErrorReason))
     }
+  }
+
+  /// The active storage-error's open-failure reason, if one is presented.
+  private var storageErrorReason: String? {
+    if case let .storageError(reason) = coordinator.active { return reason }
+    return nil
+  }
+
+  /// Presentation binding for the storage-error alert. The `.storageError`
+  /// case carries an associated reason, so a plain `isPresented(for:)` can't
+  /// match it reason-agnostically — this binding reads `true` for any
+  /// storage error and dismisses on write-`false`.
+  private var storageErrorPresented: Binding<Bool> {
+    Binding(
+      get: {
+        if case .storageError = coordinator.active { return true }
+        return false
+      },
+      set: { isPresented in
+        if !isPresented { coordinator.dismiss() }
+      }
+    )
+  }
+
+  /// Builds the storage-error alert copy. The user guidance is always shown;
+  /// when an open-failure `reason` is known it is appended verbatim so the
+  /// exact failing SQLite step is legible straight off the watch screen
+  /// (#457 storage RCA). `static` and pure so it's unit-testable without
+  /// rendering the host.
+  static func storageErrorMessage(reason: String?) -> String {
+    let guidance = "Your journal couldn't be opened, so entries logged this session won't be saved. Please reopen the app; if the problem continues, contact support."
+    guard let reason, !reason.isEmpty else { return guidance }
+    return guidance + "\n\nDetails: \(reason)"
   }
 
   /// The journal log-confirmation, hoisted above the navigation push so it

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/RootShellView.swift
@@ -61,7 +61,9 @@ struct RootShellView: View {
     .task {
       if viewModel.journalStorageIsEphemeral, !didSurfaceStorageWarning {
         didSurfaceStorageWarning = true
-        presentationCoordinator.request(.storageError)
+        presentationCoordinator.request(
+          .storageError(reason: viewModel.journalStorageFailureReason)
+        )
       }
     }
     .rootPresentationHost(coordinator: presentationCoordinator)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewDependenciesTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import WavelengthWatch_Watch_App
 
@@ -5,6 +6,12 @@ import Testing
 @MainActor
 struct ContentViewDependenciesTests {
   private struct FactoryFailure: Error {}
+
+  /// A failure whose `localizedDescription` is a known string, so the test
+  /// can assert the open-failure reason is threaded through verbatim.
+  private struct ReasonedFailure: LocalizedError {
+    let errorDescription: String?
+  }
 
   // MARK: - makeJournalRepository
 
@@ -14,6 +21,8 @@ struct ContentViewDependenciesTests {
     let result = ContentViewDependencies.makeJournalRepository(openPersistent: { persistent })
     #expect(result.repository as AnyObject === persistent)
     #expect(result.isInMemoryFallback == false)
+    // No failure => no reason to surface.
+    #expect(result.failureReason == nil)
   }
 
   @Test("makeJournalRepository falls back to in-memory and signals isInMemoryFallback when the open fails")
@@ -23,6 +32,16 @@ struct ContentViewDependenciesTests {
     })
     #expect(result.repository is InMemoryJournalRepository)
     #expect(result.isInMemoryFallback == true)
+  }
+
+  @Test("makeJournalRepository surfaces the open-failure reason for on-device diagnostics")
+  func makeJournalRepository_surfacesFailureReason() {
+    let result = ContentViewDependencies.makeJournalRepository(openPersistent: {
+      throw ReasonedFailure(errorDescription: "open failed: unable to open database file")
+    })
+    // The reason must reach the UI verbatim so a watch screenshot reveals the
+    // exact SQLite step that failed (#457 storage RCA).
+    #expect(result.failureReason == "open failed: unable to open database file")
   }
 
   // MARK: - makeJournalQueue

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
@@ -200,7 +200,8 @@ struct JournalRepositoryTests {
     #expect(sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK)
   }
 
-  @Test func sqliteOpensWhenUpgradingDatabasePredatingEntryTypeColumn() throws {
+  @Test("open() recovers a database that predates the entry_type column")
+  func sqliteOpensWhenUpgradingDatabasePredatingEntryTypeColumn() throws {
     let tempPath = NSTemporaryDirectory() + UUID().uuidString + ".db"
     defer { try? FileManager.default.removeItem(atPath: tempPath) }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
@@ -200,6 +200,63 @@ struct JournalRepositoryTests {
     #expect(sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK)
   }
 
+  @Test func sqliteOpensWhenUpgradingDatabasePredatingEntryTypeColumn() throws {
+    let tempPath = NSTemporaryDirectory() + UUID().uuidString + ".db"
+    defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+    // Simulate an on-device database carried across builds: a journal_entry
+    // table that exists but predates the `entry_type` column (added in v3),
+    // with the schema version pinned below 3 so the migration must add it.
+    Self.seedPreEntryTypeDatabase(at: tempPath)
+
+    // open() must NOT throw. The bug: createTables() ran *before* migrate() and
+    // tried `CREATE INDEX idx_journal_entry_type ON journal_entry(entry_type)`
+    // on the old table whose entry_type column didn't exist yet → "no such
+    // column: entry_type" → open() throws → in-memory fallback (#451).
+    let db = JournalDatabase(path: tempPath)
+    #expect(throws: Never.self) { try db.open() }
+
+    // The migration added the column and the dependent index now exists, so a
+    // modern entry round-trips.
+    #expect(try db.listIndexes().contains("idx_journal_entry_type"))
+    let entry = LocalJournalEntry(
+      createdAt: Date(),
+      userID: 1,
+      curriculumID: 1,
+      initiatedBy: .self_initiated,
+      entryType: .emotion
+    )
+    #expect(throws: Never.self) { try db.insert(entry) }
+    db.close()
+  }
+
+  /// Seeds a `journal_entry` table that predates the `entry_type` column (the
+  /// pre-v3 shape) plus a `schema_version` row below 3, via a raw connection —
+  /// reproducing a database upgraded across builds on a physical watch.
+  private static func seedPreEntryTypeDatabase(at path: String) {
+    var raw: OpaquePointer?
+    #expect(sqlite3_open(path, &raw) == SQLITE_OK)
+    defer { sqlite3_close(raw) }
+    let sql = """
+      CREATE TABLE journal_entry (
+        id TEXT PRIMARY KEY,
+        server_id INTEGER,
+        created_at REAL NOT NULL,
+        user_id INTEGER NOT NULL,
+        curriculum_id INTEGER,
+        secondary_curriculum_id INTEGER,
+        strategy_id INTEGER,
+        initiated_by TEXT NOT NULL,
+        sync_status TEXT NOT NULL DEFAULT 'pending',
+        last_sync_attempt REAL,
+        retry_count INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+      INSERT INTO schema_version (version) VALUES (2);
+    """
+    #expect(sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK)
+  }
+
   @Test func journalDatabaseError_localizedDescription_surfacesReason() {
     // TEMPORARY (#457 Phase 0): the journal-open failure log relies on
     // `localizedDescription` carrying the real SQLite reason + failing step.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
@@ -207,7 +207,12 @@ struct JournalRepositoryTests {
     // Simulate an on-device database carried across builds: a journal_entry
     // table that exists but predates the `entry_type` column (added in v3),
     // with the schema version pinned below 3 so the migration must add it.
-    Self.seedPreEntryTypeDatabase(at: tempPath)
+    try Self.seedPreEntryTypeDatabase(at: tempPath)
+
+    // Guard the test's own premise: a seeding regression that produced a
+    // fresh/empty database would let open() pass vacuously (an empty DB opens
+    // fine), silently disarming this regression test. Assert the pre-v3 shape.
+    #expect(Self.journalEntryHasColumn("entry_type", at: tempPath) == false)
 
     // open() must NOT throw. The bug: createTables() ran *before* migrate() and
     // tried `CREATE INDEX idx_journal_entry_type ON journal_entry(entry_type)`
@@ -230,12 +235,18 @@ struct JournalRepositoryTests {
     db.close()
   }
 
+  /// Error thrown when the raw test seed can't establish its precondition, so a
+  /// seeding regression fails the containing test loudly rather than silently
+  /// producing a vacuous pass.
+  private enum SeedError: Error { case open, exec(String) }
+
   /// Seeds a `journal_entry` table that predates the `entry_type` column (the
   /// pre-v3 shape) plus a `schema_version` row below 3, via a raw connection —
   /// reproducing a database upgraded across builds on a physical watch.
-  private static func seedPreEntryTypeDatabase(at path: String) {
+  /// Throws on any SQLite failure so the seed can't silently no-op.
+  private static func seedPreEntryTypeDatabase(at path: String) throws {
     var raw: OpaquePointer?
-    #expect(sqlite3_open(path, &raw) == SQLITE_OK)
+    guard sqlite3_open(path, &raw) == SQLITE_OK else { throw SeedError.open }
     defer { sqlite3_close(raw) }
     let sql = """
       CREATE TABLE journal_entry (
@@ -254,7 +265,27 @@ struct JournalRepositoryTests {
       CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
       INSERT INTO schema_version (version) VALUES (2);
     """
-    #expect(sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK)
+    guard sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK else {
+      throw SeedError.exec(String(cString: sqlite3_errmsg(raw)))
+    }
+  }
+
+  /// Whether `journal_entry` has `column`, read via a raw connection and
+  /// `PRAGMA table_info`. Lets a test positively assert its starting schema.
+  private static func journalEntryHasColumn(_ column: String, at path: String) -> Bool {
+    var raw: OpaquePointer?
+    guard sqlite3_open(path, &raw) == SQLITE_OK else { return false }
+    defer { sqlite3_close(raw) }
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(raw, "PRAGMA table_info(journal_entry)", -1, &statement, nil) == SQLITE_OK
+    else { return false }
+    defer { sqlite3_finalize(statement) }
+    while sqlite3_step(statement) == SQLITE_ROW {
+      if let name = sqlite3_column_text(statement, 1).map({ String(cString: $0) }), name == column {
+        return true
+      }
+    }
+    return false
   }
 
   @Test func journalDatabaseError_localizedDescription_surfacesReason() {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationCoordinatorTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationCoordinatorTests.swift
@@ -28,20 +28,25 @@ struct PresentationCoordinatorTests {
     #expect(coordinator.active == .menu)
   }
 
-  @Test("a second request replaces the active presentation (skeleton policy)")
-  func request_replacesActivePresentation() {
+  @Test("an equal-priority second request queues behind the active one")
+  func request_equalPriorityQueuesBehindActive() {
     let coordinator = PresentationCoordinator()
 
     coordinator.request(.menu)
+    // `.onboarding` shares `.menu`'s priority (1), so under the #407
+    // priority/queue policy it queues rather than replacing the active
+    // presentation. (This supersedes the old "skeleton" replace policy.)
     coordinator.request(.onboarding)
 
-    #expect(coordinator.active == .onboarding)
+    #expect(coordinator.active == .menu)
+    coordinator.dismiss()
+    #expect(coordinator.active == .onboarding) // queued request surfaces on dismiss
   }
 
   @Test("dismiss returns to none")
   func dismiss_returnsToNone() {
     let coordinator = PresentationCoordinator()
-    coordinator.request(.storageError)
+    coordinator.request(.storageError(reason: nil))
 
     coordinator.dismiss()
 
@@ -66,7 +71,7 @@ struct PresentationCoordinatorTests {
 
     #expect(coordinator.isPresented(for: .menu).wrappedValue == true)
     #expect(coordinator.isPresented(for: .onboarding).wrappedValue == false)
-    #expect(coordinator.isPresented(for: .storageError).wrappedValue == false)
+    #expect(coordinator.isPresented(for: .storageError(reason: nil)).wrappedValue == false)
   }
 
   @Test("writing true through the binding activates that presentation")

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationPolicyTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/PresentationPolicyTests.swift
@@ -44,9 +44,9 @@ struct PresentationPolicyTests {
     let feedback = sampleFeedback()
 
     coordinator.request(.journalFeedback(feedback))
-    coordinator.request(.storageError)
+    coordinator.request(.storageError(reason: nil))
 
-    #expect(coordinator.active == .storageError) // higher priority shown immediately
+    #expect(coordinator.active == .storageError(reason: nil)) // higher priority shown immediately
     coordinator.dismiss()
     #expect(coordinator.active == .journalFeedback(feedback)) // displaced feedback resurfaces
   }
@@ -58,9 +58,9 @@ struct PresentationPolicyTests {
 
     coordinator.request(.menu) // active (priority 1)
     coordinator.request(.journalFeedback(feedback)) // queued (priority 0)
-    coordinator.request(.storageError) // preempts menu (priority 2); menu queued
+    coordinator.request(.storageError(reason: nil)) // preempts menu (priority 2); menu queued
 
-    #expect(coordinator.active == .storageError)
+    #expect(coordinator.active == .storageError(reason: nil))
     coordinator.dismiss()
     #expect(coordinator.active == .menu) // priority 1 beats queued feedback (0)
     coordinator.dismiss()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/RootPresentationHostTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/RootPresentationHostTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Coverage for `RootPresentationHost`'s pure message composition. The host
+/// itself is a `ViewModifier` (not unit-testable in isolation), but the
+/// storage-error copy is built by a static helper so the diagnostic-reason
+/// threading (#457 storage RCA) can be verified without rendering.
+struct RootPresentationHostTests {
+  /// The user-facing guidance must always be present, reason or not.
+  private let userGuidance = "entries logged this session won't be saved"
+
+  @Test("storage-error message is the plain user copy when there is no reason")
+  func storageErrorMessage_withoutReason_isPlainCopy() {
+    let message = RootPresentationHost.storageErrorMessage(reason: nil)
+    #expect(message.contains(userGuidance))
+    // No diagnostic block when there's nothing to diagnose.
+    #expect(!message.contains("Details:"))
+  }
+
+  @Test("an empty reason is treated as no reason")
+  func storageErrorMessage_withEmptyReason_isPlainCopy() {
+    let message = RootPresentationHost.storageErrorMessage(reason: "")
+    #expect(message.contains(userGuidance))
+    #expect(!message.contains("Details:"))
+  }
+
+  @Test("storage-error message appends the failure reason verbatim for diagnostics")
+  func storageErrorMessage_withReason_includesItVerbatim() {
+    let reason = "open failed: unable to open database file"
+    let message = RootPresentationHost.storageErrorMessage(reason: reason)
+    // Both the human guidance and the exact SQLite reason must be readable
+    // straight off the watch screen.
+    #expect(message.contains(userGuidance))
+    #expect(message.contains(reason))
+  }
+}


### PR DESCRIPTION
## The bug (P0, data loss on device)

On Geoff's physical watch the journal failed to open at every cold start: the app fell back to in-memory storage, showed the generic **Storage Error** alert, and silently lost every entry logged that session (Analytics showed no history on-device; the simulator was fine).

## Root cause — *found via the diagnostic in this PR*

Step 1 of this PR surfaced the real reason in the alert (it was being caught and discarded). Geoff's watch reported:

> `Details: create-table failed: no such column: entry_type`

`JournalDatabase.open()` ran `createTables()` **before** `migrate()`. `createTables()` issued `CREATE INDEX idx_journal_entry_type ON journal_entry(entry_type)`. On a **fresh** DB the `CREATE TABLE` includes `entry_type`, so the index succeeds (why the simulator worked). On a DB **carried across builds**, `journal_entry` already exists from a build that predates `entry_type`, so `CREATE TABLE IF NOT EXISTS` is a no-op and the column is still missing — the index build fails *before* `migrate()` (v3) adds it → `open()` throws → in-memory fallback → lost data. An ordering bug: indexes on migration-added columns were built before the migration ran.

## The fix

1. **Diagnostic (kept):** thread the open-failure reason all the way to the Storage Error alert (`makeJournalRepository` → `ContentViewModel` → `PresentationCoordinator.storageError(reason:)` → pure, tested `RootPresentationHost.storageErrorMessage(reason:)`). Makes this and any future storage failure legible from a single watch screenshot.
2. **Root-cause fix:** create all `journal_entry` indexes in a new `createIndexes()` invoked from `open()` **after** `migrate()`, so every indexed column (including migration-added ones) exists first. The former `migrateToV4` only added analytics indexes; those move into `createIndexes()`, ensured on every open regardless of stored schema version (strictly more robust than version-gating).

### Incidental
`request_replacesActivePresentation` asserted the obsolete "skeleton" replace policy and was already failing on `main`; rewritten to assert the documented `#407` priority/queue behavior.

## Tests (TDD)
- `sqliteOpensWhenUpgradingDatabasePredatingEntryTypeColumn` — seeds a pre-v3 table (no `entry_type`) at `schema_version = 2`, asserts `open()` recovers, the dependent index exists, and a modern entry inserts. **Red before, green after.**
- `makeJournalRepository_surfacesFailureReason` + `RootPresentationHostTests` cover the reason threading and message composition.
- Full watch suite green (**48/48**).

Closes #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)