### PR TITLE
fix(navigation): hoist the chevron to a single viewport overlay (#457)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/CatalogModels.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/CatalogModels.swift
@@ -26,6 +26,11 @@ struct CatalogPhaseModel: Codable, Identifiable, Equatable, Hashable {
 }
 
 struct CatalogLayerModel: Codable, Identifiable, Equatable, Hashable {
+  /// The strategies layer's id. It routes to the strategy list rather than a
+  /// curriculum (see `DetailDestination.forPhase`); naming it survives a future
+  /// data change that the bare literal `0` would not.
+  static let strategiesLayerID = 0
+
   let id: Int
   let color: String
   let title: String

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/DetailDestination.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/DetailDestination.swift
@@ -3,4 +3,16 @@
 enum DetailDestination: Hashable {
   case curriculum(layer: CatalogLayerModel, phase: CatalogPhaseModel, colorName: String)
   case strategy(phase: CatalogPhaseModel, colorName: String)
+
+  /// The destination for a layer/phase pair: the strategies layer (id 0)
+  /// routes to `.strategy`, every other layer to `.curriculum`. Centralized so
+  /// the single hoisted navigation chevron (see `LayerScrollView`) and any
+  /// other caller route identically.
+  static func forPhase(in layer: CatalogLayerModel, phase: CatalogPhaseModel) -> DetailDestination {
+    if layer.id == 0 {
+      .strategy(phase: phase, colorName: layer.color)
+    } else {
+      .curriculum(layer: layer, phase: phase, colorName: layer.color)
+    }
+  }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/DetailDestination.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Models/DetailDestination.swift
@@ -9,7 +9,7 @@ enum DetailDestination: Hashable {
   /// the single hoisted navigation chevron (see `LayerScrollView`) and any
   /// other caller route identically.
   static func forPhase(in layer: CatalogLayerModel, phase: CatalogPhaseModel) -> DetailDestination {
-    if layer.id == 0 {
+    if layer.id == CatalogLayerModel.strategiesLayerID {
       .strategy(phase: phase, colorName: layer.color)
     } else {
       .curriculum(layer: layer, phase: phase, colorName: layer.color)

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -95,34 +95,27 @@ struct LayerScrollView: View {
 
   // MARK: - Navigation chevron
 
-  /// The layer currently centered in the vertical scroller.
+  /// The layer currently centered in the vertical scroller. Clamps the raw
+  /// `layerSelection` against this single `filteredLayers` snapshot, so it can't
+  /// read out of bounds if the filter changes mid-render.
   private var currentLayer: CatalogLayerModel? {
     let layers = viewModel.filteredLayers
     guard !layers.isEmpty else { return nil }
-    // Re-clamp against this exact snapshot: `clampedSelection` reads
-    // `filteredLayers.count` in a separate access, so a filter change between
-    // the two could momentarily push it past this `layers`' bounds.
-    return layers[min(clampedSelection, layers.count - 1)]
+    return layers[min(max(layerSelection, 0), layers.count - 1)]
   }
 
-  /// Single navigation chevron, pinned to the viewport's bottom-trailing
-  /// corner, navigating to the currently centered layer/phase. Replaces the
-  /// former per-page chevron (one per `PhasePageView`), which a viewport-
-  /// overflowing card could push out of sight and which lazily realized pages
-  /// left intermittently uncomposited (#457). One always-present chevron at a
-  /// fixed viewport position sidesteps both.
-  ///
-  /// The phase is read straight from `phaseSelection` — the same binding the
-  /// inner `TabView` is driven by — and normalized with the same
-  /// `PhaseNavigator` math the pages use, so the destination always matches the
-  /// page actually on screen, even mid-scroll (no reliance on the separately
-  /// derived `selectedPhaseIndex`, which can lag a render behind).
+  /// The single navigation chevron, pinned to the viewport's bottom-trailing
+  /// corner — one always-present chevron rather than one per page, which a
+  /// viewport-overflowing card could clip out of sight (#457). Its phase is read
+  /// from `phaseSelection` (the `TabView`'s own binding) so the destination
+  /// tracks the page on screen even mid-scroll.
   @ViewBuilder
   private var navigationChevron: some View {
     if let layer = currentLayer, !layer.phases.isEmpty {
-      // `normalizedIndex` is `(selection - 1 + n) % n`, which for any phaseCount
-      // n > 0 (guaranteed by the `!isEmpty` check) returns a value in 0..<n — so
-      // it indexes `phases` safely without a further clamp.
+      // `phaseSelection` is the TabView's 1-based tag (tag 0 is the infinite-
+      // scroll lead-in page). `normalizedIndex` maps it back with
+      // `(tag - 1 + n) % n`, always in 0..<n for n > 0 (guaranteed by
+      // `!phases.isEmpty`) — so it indexes `phases` safely without a clamp.
       let normalized = PhaseNavigator.normalizedIndex(
         phaseSelection, phaseCount: layer.phases.count
       )

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -99,7 +99,10 @@ struct LayerScrollView: View {
   private var currentLayer: CatalogLayerModel? {
     let layers = viewModel.filteredLayers
     guard !layers.isEmpty else { return nil }
-    return layers[clampedSelection]
+    // Re-clamp against this exact snapshot: `clampedSelection` reads
+    // `filteredLayers.count` in a separate access, so a filter change between
+    // the two could momentarily push it past this `layers`' bounds.
+    return layers[min(clampedSelection, layers.count - 1)]
   }
 
   /// Single navigation chevron, pinned to the viewport's bottom-trailing
@@ -117,10 +120,13 @@ struct LayerScrollView: View {
   @ViewBuilder
   private var navigationChevron: some View {
     if let layer = currentLayer, !layer.phases.isEmpty {
+      // `normalizedIndex` is `(selection - 1 + n) % n`, which for any phaseCount
+      // n > 0 (guaranteed by the `!isEmpty` check) returns a value in 0..<n — so
+      // it indexes `phases` safely without a further clamp.
       let normalized = PhaseNavigator.normalizedIndex(
         phaseSelection, phaseCount: layer.phases.count
       )
-      let phase = layer.phases[normalized.clamped(to: 0 ... (layer.phases.count - 1))]
+      let phase = layer.phases[normalized]
       NavigationLink(value: DetailDestination.forPhase(in: layer, phase: phase)) {
         Image(systemName: "chevron.right.circle.fill")
           .foregroundStyle(.white.opacity(0.8))

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -70,6 +70,9 @@ struct LayerScrollView: View {
           .overlay(alignment: .trailing) {
             sideIndicator(in: geometry.size)
           }
+          .overlay(alignment: .bottomTrailing) {
+            navigationChevron
+          }
           // DragGesture writes raw `layerSelection`; the bounds check uses
           // `filteredLayers.count` since reads downstream are clamped via
           // `clampedSelection`.
@@ -87,6 +90,49 @@ struct LayerScrollView: View {
               }
           )
       }
+    }
+  }
+
+  // MARK: - Navigation chevron
+
+  /// The layer currently centered in the vertical scroller.
+  private var currentLayer: CatalogLayerModel? {
+    let layers = viewModel.filteredLayers
+    guard !layers.isEmpty else { return nil }
+    return layers[clampedSelection]
+  }
+
+  /// The detail destination for the currently centered layer + phase, used by
+  /// the single hoisted navigation chevron. `selectedPhaseIndex` is the
+  /// normalized phase index the inner `TabView` keeps in sync.
+  private var currentDestination: DetailDestination? {
+    guard let layer = currentLayer, !layer.phases.isEmpty else { return nil }
+    let phaseIndex = min(max(viewModel.selectedPhaseIndex, 0), layer.phases.count - 1)
+    return DetailDestination.forPhase(in: layer, phase: layer.phases[phaseIndex])
+  }
+
+  /// Single navigation chevron, pinned to the viewport's bottom-trailing
+  /// corner, navigating to the currently centered layer/phase. Replaces the
+  /// former per-page chevron (one per `PhasePageView`), which a viewport-
+  /// overflowing card could push out of sight and which lazily realized pages
+  /// left intermittently uncomposited (#457). One always-present chevron at a
+  /// fixed viewport position sidesteps both.
+  @ViewBuilder
+  private var navigationChevron: some View {
+    if let destination = currentDestination, let layer = currentLayer {
+      NavigationLink(value: destination) {
+        Image(systemName: "chevron.right.circle.fill")
+          .foregroundColor(.white.opacity(0.8))
+          .font(.title2)
+          .background(
+            Circle()
+              .fill(Color(stage: layer.color).opacity(0.3))
+              .frame(width: 32, height: 32)
+          )
+      }
+      .buttonStyle(.plain)
+      .padding(.trailing, 12)
+      .padding(.bottom, 20)
     }
   }
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/LayerScrollView.swift
@@ -102,27 +102,28 @@ struct LayerScrollView: View {
     return layers[clampedSelection]
   }
 
-  /// The detail destination for the currently centered layer + phase, used by
-  /// the single hoisted navigation chevron. `selectedPhaseIndex` is the
-  /// normalized phase index the inner `TabView` keeps in sync.
-  private var currentDestination: DetailDestination? {
-    guard let layer = currentLayer, !layer.phases.isEmpty else { return nil }
-    let phaseIndex = min(max(viewModel.selectedPhaseIndex, 0), layer.phases.count - 1)
-    return DetailDestination.forPhase(in: layer, phase: layer.phases[phaseIndex])
-  }
-
   /// Single navigation chevron, pinned to the viewport's bottom-trailing
   /// corner, navigating to the currently centered layer/phase. Replaces the
   /// former per-page chevron (one per `PhasePageView`), which a viewport-
   /// overflowing card could push out of sight and which lazily realized pages
   /// left intermittently uncomposited (#457). One always-present chevron at a
   /// fixed viewport position sidesteps both.
+  ///
+  /// The phase is read straight from `phaseSelection` — the same binding the
+  /// inner `TabView` is driven by — and normalized with the same
+  /// `PhaseNavigator` math the pages use, so the destination always matches the
+  /// page actually on screen, even mid-scroll (no reliance on the separately
+  /// derived `selectedPhaseIndex`, which can lag a render behind).
   @ViewBuilder
   private var navigationChevron: some View {
-    if let destination = currentDestination, let layer = currentLayer {
-      NavigationLink(value: destination) {
+    if let layer = currentLayer, !layer.phases.isEmpty {
+      let normalized = PhaseNavigator.normalizedIndex(
+        phaseSelection, phaseCount: layer.phases.count
+      )
+      let phase = layer.phases[normalized.clamped(to: 0 ... (layer.phases.count - 1))]
+      NavigationLink(value: DetailDestination.forPhase(in: layer, phase: phase)) {
         Image(systemName: "chevron.right.circle.fill")
-          .foregroundColor(.white.opacity(0.8))
+          .foregroundStyle(.white.opacity(0.8))
           .font(.title2)
           .background(
             Circle()

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
@@ -55,6 +55,9 @@ struct PhasePageView: View {
         )
       )
     )
+    // Card fills the screen edge-to-edge by design. This used to inflate the
+    // card past the viewport and clip the chevron, but the chevron now lives in
+    // LayerScrollView's overlay, so the bleed is purely cosmetic here (#457).
     .ignoresSafeArea(.all)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Navigation/PhasePageView.swift
@@ -1,100 +1,60 @@
-import os
 import SwiftUI
 
+/// A single phase page: the crystal card on its layer-tinted background.
+///
+/// The navigation chevron used to live here, one per page. It was bottom-
+/// anchored inside a card that `.ignoresSafeArea` could inflate taller than the
+/// viewport, which pushed the chevron below the visible area — and, on lazily
+/// realized pages, left it intermittently uncomposited (#457). It now lives as
+/// a single viewport-pinned overlay in `LayerScrollView`, so this view is
+/// purely the (non-interactive) card.
 struct PhasePageView: View {
   let layer: CatalogLayerModel
   let phase: CatalogPhaseModel
   let color: Color
   let screenWidth: CGFloat // Stable width from parent GeometryReader
 
-  /// TEMPORARY (#457 Phase 0): cold-start chevron diagnostics. Remove after RCA.
-  private static let chevronLog = Logger(
-    subsystem: "com.wavelengthwatch.watch",
-    category: "chevron"
-  )
-
   var body: some View {
     // Use screenWidth from parent to avoid nested GeometryReader race conditions
     // during LayerFilterMode transitions (fixes #119, #158, #165)
     let scale = UIConstants.scaleFactor(for: screenWidth)
 
-    ZStack {
-      // Background - non-tappable
-      VStack(spacing: 0) {
-        // Top gutter for vertical scroll
-        Spacer()
+    VStack(spacing: 0) {
+      // Top gutter for vertical scroll
+      Spacer()
 
-        PhaseCrystalCard(layer: layer, phase: phase, color: color, scale: scale)
+      PhaseCrystalCard(layer: layer, phase: phase, color: color, scale: scale)
 
-        Spacer()
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      Spacer()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-        // Bottom gutter for page indicators
-        Spacer()
-          .frame(height: 16)
-      }
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .background(
-        LinearGradient(
+      // Bottom gutter for page indicators
+      Spacer()
+        .frame(height: 16)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(
+      LinearGradient(
+        gradient: Gradient(colors: [
+          Color.black.opacity(0.98),
+          Color.black.opacity(0.9),
+          Color.black,
+        ]),
+        startPoint: .top,
+        endPoint: .bottom
+      )
+      .overlay(
+        RadialGradient(
           gradient: Gradient(colors: [
-            Color.black.opacity(0.98),
-            Color.black.opacity(0.9),
-            Color.black,
+            color.opacity(0.18),
+            Color.clear,
           ]),
-          startPoint: .top,
-          endPoint: .bottom
-        )
-        .overlay(
-          RadialGradient(
-            gradient: Gradient(colors: [
-              color.opacity(0.18),
-              Color.clear,
-            ]),
-            center: .center,
-            startRadius: 20,
-            endRadius: screenWidth * 0.9
-          )
+          center: .center,
+          startRadius: 20,
+          endRadius: screenWidth * 0.9
         )
       )
-      .ignoresSafeArea(.all)
-
-      // Small tappable navigation button - bottom right
-      VStack {
-        Spacer()
-        HStack {
-          Spacer()
-          NavigationLink(value: navigationDestination) {
-            Image(systemName: "chevron.right.circle.fill")
-              .foregroundColor(.white.opacity(0.8))
-              .font(.title2)
-              .background(
-                Circle()
-                  .fill(color.opacity(0.3))
-                  .frame(width: 32, height: 32)
-              )
-          }
-          .buttonStyle(.plain)
-          .padding(.trailing, 12)
-          // TEMPORARY (#457 Phase 0): did the chevron view get created at all?
-          .onAppear {
-            Self.chevronLog.log("chevron onAppear layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public)")
-          }
-        }
-        .padding(.bottom, 20)
-      }
-    }
-    // TEMPORARY (#457 Phase 0): page lazily created on first scroll to this card.
-    .onAppear {
-      Self.chevronLog.log("page onAppear layer=\(layer.id, privacy: .public) phase=\(phase.id, privacy: .public)")
-    }
-  }
-
-  /// Value-based navigation destination for NavigationPath tracking
-  private var navigationDestination: DetailDestination {
-    if layer.id == 0 {
-      .strategy(phase: phase, colorName: layer.color)
-    } else {
-      .curriculum(layer: layer, phase: phase, colorName: layer.color)
-    }
+    )
+    .ignoresSafeArea(.all)
   }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/DetailDestinationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/DetailDestinationTests.swift
@@ -25,11 +25,4 @@ struct DetailDestinationTests {
     let destination = DetailDestination.forPhase(in: emotionLayer, phase: phase)
     #expect(destination == .curriculum(layer: emotionLayer, phase: phase, colorName: "Red"))
   }
-
-  @Test("strategiesLayerID is 0 — the data contract the routing relies on")
-  func strategiesLayerID_isZero() {
-    // Guards the routing: if this drifts from the catalog's strategies-layer id,
-    // `forPhase` would silently send layer 0 to a curriculum and vice versa.
-    #expect(CatalogLayerModel.strategiesLayerID == 0)
-  }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/DetailDestinationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/DetailDestinationTests.swift
@@ -25,4 +25,11 @@ struct DetailDestinationTests {
     let destination = DetailDestination.forPhase(in: emotionLayer, phase: phase)
     #expect(destination == .curriculum(layer: emotionLayer, phase: phase, colorName: "Red"))
   }
+
+  @Test("strategiesLayerID is 0 — the data contract the routing relies on")
+  func strategiesLayerID_isZero() {
+    // Guards the routing: if this drifts from the catalog's strategies-layer id,
+    // `forPhase` would silently send layer 0 to a curriculum and vice versa.
+    #expect(CatalogLayerModel.strategiesLayerID == 0)
+  }
 }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/DetailDestinationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/DetailDestinationTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import WavelengthWatch_Watch_App
+
+/// Coverage for `DetailDestination.forPhase(in:phase:)` — the routing the single
+/// hoisted navigation chevron relies on (#457). The strategies layer (id 0)
+/// must reach the strategy list; every other layer reaches its curriculum.
+struct DetailDestinationTests {
+  private let phase = CatalogPhaseModel(
+    id: 1, name: "Rising", medicinal: [], toxic: [], strategies: []
+  )
+
+  private func layer(id: Int) -> CatalogLayerModel {
+    CatalogLayerModel(id: id, color: "Red", title: "T", subtitle: "S", phases: [phase])
+  }
+
+  @Test("the strategies layer (id 0) routes to a strategy destination")
+  func strategiesLayerRoutesToStrategy() {
+    let destination = DetailDestination.forPhase(in: layer(id: 0), phase: phase)
+    #expect(destination == .strategy(phase: phase, colorName: "Red"))
+  }
+
+  @Test("any non-strategies layer routes to a curriculum destination")
+  func emotionLayerRoutesToCurriculum() {
+    let emotionLayer = layer(id: 5)
+    let destination = DetailDestination.forPhase(in: emotionLayer, phase: phase)
+    #expect(destination == .curriculum(layer: emotionLayer, phase: phase, colorName: "Red"))
+  }
+}


### PR DESCRIPTION
## The bug
On a physical watch the detail chevron was invisible on many layer/phase pages — appearing and disappearing seemingly at random as you scrolled.

## Root cause (found via the #461 Phase 0.2 instrumentation)
Each `PhasePageView` drew its own chevron, **bottom-anchored inside the card**. On-device logs showed the card's height flips between **191** (the viewport) and **257** — and `257 = 191 + 66`, the 66 being the top safe-area inset that `.ignoresSafeArea(.all)` adds to the card's layout box. On the 257-tall cards the bottom-anchored chevron landed at global **y≈260–270**, just past the viewport bottom (**257**) → **clipped off-screen**.

Two things made it look random:
- The card flips 191↔257 depending on scroll position, so the same page worked sometimes and not others (the chevron sits right on the viewport edge).
- The vertical `LazyVStack` keeps neighbour pages realized, so 3 cards log per scroll tick — most are off-screen neighbours by design.

## The fix
Render **one** chevron as an overlay pinned to the scroll viewport's bottom-trailing corner in `LayerScrollView`, navigating to the currently centered layer/phase via a new `DetailDestination.forPhase(in:phase:)` factory.

- A single always-present chevron at a **fixed viewport position** can't be pushed out by an overflowing card.
- It isn't subject to the per-page lazy-realization / compositing flakiness of 12+ separate chevrons.
- `PhasePageView` becomes purely the (non-interactive) card; the temporary `#457` chevron instrumentation it carried is removed.

## Tests (TDD)
- `DetailDestinationTests` — routing: strategies layer (id 0) → `.strategy`, every other layer → `.curriculum`.
- Full watch suite green (**48/48**).

## ⚠️ Needs on-device visual check
This is a watchOS layout change I can't render here. Please verify on your watch: the chevron is present at the **bottom-right on every layer/phase**, taps through to the correct curriculum/strategy detail, and no longer vanishes while scrolling.

## Housekeeping
Supersedes the diagnostic-only PR **#461** (Phase 0.1/0.2) — that branch can be closed once this is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)