### PR TITLE
chore(diagnostics): remove the Phase 0 cold-start instrumentation (#457)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/App/ContentViewDependencies.swift
@@ -51,12 +51,6 @@ struct ContentViewDependencies {
     category: "ContentViewDependencies"
   )
 
-  /// TEMPORARY (#457 Phase 0): cold-start sequence diagnostics. Remove after RCA.
-  private static let coldStart = Logger(
-    subsystem: "com.wavelengthwatch.watch",
-    category: "coldstart"
-  )
-
   /// Filesystem path for the temp-directory journal-queue fallback,
   /// composed via `URL` so it stays correct even if `NSTemporaryDirectory`
   /// ever stops returning a trailing-slash path.
@@ -71,16 +65,13 @@ struct ContentViewDependencies {
   /// real network monitor. Used by the app's runtime entry point.
   @MainActor
   static func live() -> ContentViewDependencies {
-    coldStart.log("live(): start")
     let configuration = AppConfiguration()
     let apiClient = APIClient(baseURL: configuration.apiBaseURL)
     let catalogRepository = CatalogRepository(
       remote: CatalogAPIService(apiClient: apiClient),
       cache: FileCatalogCacheStore()
     )
-    coldStart.log("live(): opening journal repository")
     let (journalRepository, journalStorageIsEphemeral, journalStorageFailureReason) = Self.makeJournalRepository()
-    coldStart.log("live(): journal open done, ephemeral=\(journalStorageIsEphemeral, privacy: .public)")
     let syncSettings = SyncSettings()
     let journalQueue = Self.makeJournalQueue()
     let networkMonitor = NetworkMonitor()
@@ -106,7 +97,6 @@ struct ContentViewDependencies {
       journalStorageIsEphemeral: journalStorageIsEphemeral,
       journalStorageFailureReason: journalStorageFailureReason
     )
-    coldStart.log("live(): viewModel built (initialLayer=\(initialLayer, privacy: .public) initialPhase=\(storedPhase, privacy: .public))")
     let flowCoordinator = FlowCoordinator(contentViewModel: viewModel)
     let syncSettingsViewModel = SyncSettingsViewModel(syncSettings: syncSettings)
     let navigationViewModel = NavigationViewModel(

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
@@ -13,10 +13,10 @@ enum JournalDatabaseError: Error, Equatable {
   case databaseNotOpen
 }
 
-/// TEMPORARY (#457 Phase 0): surface the real SQLite reason + failing step via
-/// `error.localizedDescription` (already logged in `makeJournalRepository`), so
-/// the journal-open failure is no longer diagnosed blind. Fold into a proper
-/// error-presentation pass after RCA.
+/// Surfaces the real SQLite reason + failing step via `localizedDescription`,
+/// so a journal-open failure isn't diagnosed blind. This reason is both logged
+/// in `makeJournalRepository` and shown in the on-device "Storage Error" alert
+/// (#462), so it's a load-bearing part of the error-presentation path.
 extension JournalDatabaseError: LocalizedError {
   var errorDescription: String? {
     switch self {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
@@ -290,8 +290,9 @@ struct JournalRepositoryTests {
   }
 
   @Test func journalDatabaseError_localizedDescription_surfacesReason() {
-    // TEMPORARY (#457 Phase 0): the journal-open failure log relies on
-    // `localizedDescription` carrying the real SQLite reason + failing step.
+    // The journal-open failure log and the on-device Storage Error alert (#462)
+    // both rely on `localizedDescription` carrying the real SQLite reason +
+    // failing step.
     let error = JournalDatabaseError.failedToOpenDatabase("unable to open database file")
     #expect(error.localizedDescription.contains("unable to open database file"))
     #expect(error.localizedDescription.contains("open failed"))


### PR DESCRIPTION
## Summary
Closes #457 — the temporary Phase 0 cold-start diagnostics have served their purpose and are now reverted, per the issue's own acceptance criteria.

The instrumentation pinned both bugs it was added to diagnose:
- **Storage open-failure** (`create-table failed: no such column: entry_type`) → fixed in #462.
- **Invisible chevron** (card overflowing the viewport) → fixed in #463.

This removes what's left of the temporary diagnostics:
- Deletes the `coldStart` `Logger` and its `live()` signposts in `ContentViewDependencies`.
- The chevron `.onAppear` / frame instrumentation was already removed when the chevron was hoisted (#463); the `ChevronFrameDiagnosis` classifier left with the closed diagnostic PR #461.
- **Keeps** `JournalDatabaseError: LocalizedError` — it stopped being temporary in #462, where the surfaced reason became the on-device Storage Error alert text. Its doc comment is updated from "TEMPORARY" to describe that load-bearing role, and the conformance test comment likewise.

## Test plan
- Logging-only removal; no behavior change.
- `frontend/WavelengthWatch/run-tests-individually.sh` → **48/48 suites green**.
- `pre-commit run` clean.
- Verified no `#457 Phase 0` / `coldStart` references remain in app source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)