### PR TITLE
fix(analytics): build local analytics from the in-memory catalog (#468)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
@@ -27,7 +27,6 @@ final class AnalyticsViewModel: ObservableObject {
   private let analyticsService: AnalyticsServiceProtocol
   private let localCalculator: LocalAnalyticsCalculatorProtocol?
   private let journalRepository: JournalRepositoryProtocol?
-  private let catalogRepository: CatalogRepositoryProtocol?
   private let syncSettings: SyncSettings
   private let userDefaults: UserDefaults
   private let userDefaultsKey = "com.wavelengthwatch.userIdentifier"
@@ -36,14 +35,12 @@ final class AnalyticsViewModel: ObservableObject {
     analyticsService: AnalyticsServiceProtocol,
     localCalculator: LocalAnalyticsCalculatorProtocol? = nil,
     journalRepository: JournalRepositoryProtocol? = nil,
-    catalogRepository: CatalogRepositoryProtocol? = nil,
     syncSettings: SyncSettings = SyncSettings(),
     userDefaults: UserDefaults = .standard
   ) {
     self.analyticsService = analyticsService
     self.localCalculator = localCalculator
     self.journalRepository = journalRepository
-    self.catalogRepository = catalogRepository
     self.syncSettings = syncSettings
     self.userDefaults = userDefaults
   }
@@ -99,11 +96,13 @@ final class AnalyticsViewModel: ObservableObject {
   ///
   /// - Returns: Locally calculated overview if all components available, nil otherwise
   private func tryLocalCalculation() async -> AnalyticsOverview? {
+    // The calculator already holds the catalog it was built with, so require
+    // only it and the journal repository. The previous extra
+    // `catalogRepository.cachedCatalog()` guard was unused yet could veto a
+    // perfectly good calculation whenever the on-disk cache was empty (#468).
     guard
       let calculator = localCalculator,
-      let repository = journalRepository,
-      let catalogRepo = catalogRepository,
-      let catalog = catalogRepo.cachedCatalog()
+      let repository = journalRepository
     else {
       return nil
     }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/ContentViewModel.swift
@@ -7,6 +7,12 @@ final class ContentViewModel: ObservableObject {
   @Published var loadErrorMessage: String?
   @Published var journalFeedback: JournalFeedback?
 
+  /// The catalog currently applied, kept whole so consumers that need a full
+  /// `CatalogResponseModel` (e.g. offline analytics) can use the in-memory copy
+  /// instead of re-reading the on-disk cache, which may be empty if the backend
+  /// fetch succeeded but the cache write didn't persist (#468).
+  @Published private(set) var loadedCatalog: CatalogResponseModel?
+
   /// Index in the full (unfiltered) layers array. Derived from selectedLayerId.
   @Published var selectedLayerIndex: Int {
     didSet {
@@ -223,6 +229,7 @@ final class ContentViewModel: ObservableObject {
 
   @MainActor
   private func applyCatalog(_ catalog: CatalogResponseModel) {
+    loadedCatalog = catalog
     layers = catalog.layers.reversed()
     phaseOrder = catalog.phaseOrder
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Analytics/AnalyticsView.swift
@@ -21,6 +21,7 @@ struct AnalyticsView: View {
   init(
     journalRepository: JournalRepositoryProtocol,
     catalogRepository: CatalogRepositoryProtocol,
+    catalog: CatalogResponseModel? = nil,
     syncSettings: SyncSettings = SyncSettings()
   ) {
     self.journalRepository = journalRepository
@@ -30,20 +31,19 @@ struct AnalyticsView: View {
     let apiClient = APIClient(baseURL: configuration.apiBaseURL)
     let analyticsService = AnalyticsService(apiClient: apiClient)
 
-    // Create local calculator with cached catalog for offline support
-    let localCalculator: LocalAnalyticsCalculatorProtocol? = {
-      guard let catalog = catalogRepository.cachedCatalog() else {
-        return nil
-      }
-      return LocalAnalyticsCalculator(catalog: catalog)
-    }()
+    // Prefer the in-memory catalog the app already loaded; fall back to the
+    // on-disk cache. The disk cache can be empty even when the catalog is loaded
+    // (the backend fetch succeeded but the cache write didn't persist), which
+    // used to leave offline analytics permanently "unavailable" (#468).
+    let resolvedCatalog = catalog ?? catalogRepository.cachedCatalog()
+    let localCalculator: LocalAnalyticsCalculatorProtocol? =
+      resolvedCatalog.map { LocalAnalyticsCalculator(catalog: $0) }
 
     _viewModel = StateObject(
       wrappedValue: AnalyticsViewModel(
         analyticsService: analyticsService,
         localCalculator: localCalculator,
         journalRepository: journalRepository,
-        catalogRepository: catalogRepository,
         syncSettings: syncSettings
       )
     )

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Menu/MenuView.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Views/Menu/MenuView.swift
@@ -33,7 +33,8 @@ struct MenuView: View {
 
       NavigationLink(destination: AnalyticsView(
         journalRepository: viewModel.journalRepository,
-        catalogRepository: viewModel.catalogRepository
+        catalogRepository: viewModel.catalogRepository,
+        catalog: viewModel.loadedCatalog
       )) {
         Label("Analytics", systemImage: "chart.bar")
       }

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewIntegrationTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewIntegrationTests.swift
@@ -161,18 +161,14 @@ struct AnalyticsViewIntegrationTests {
     let mockRepository = MockJournalRepository()
     mockRepository.entries = createTestEntries()
 
-    let mockCatalog = MockCatalogRepository()
     let catalog = createTestCatalog()
-    mockCatalog.catalog = catalog
-
     let calculator = LocalAnalyticsCalculator(catalog: catalog)
 
     // Create ViewModel with all dependencies (this is what AnalyticsView should do)
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
       localCalculator: calculator,
-      journalRepository: mockRepository,
-      catalogRepository: mockCatalog
+      journalRepository: mockRepository
     )
 
     // Act: Load analytics
@@ -201,8 +197,7 @@ struct AnalyticsViewIntegrationTests {
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
       localCalculator: nil, // Missing!
-      journalRepository: nil, // Missing!
-      catalogRepository: nil // Missing!
+      journalRepository: nil // Missing!
     )
 
     // Act: Load analytics

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -425,14 +425,10 @@ struct AnalyticsViewModelTests {
       LocalJournalEntry(createdAt: Date(), userID: 1, curriculumID: 1, entryType: .emotion),
     ]
 
-    let mockCatalog = MockCatalogRepository()
-    mockCatalog.catalogToReturn = testCatalog()
-
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
       localCalculator: mockCalculator,
       journalRepository: mockRepository,
-      catalogRepository: mockCatalog,
       syncSettings: cloudSyncOn()
     )
 
@@ -457,13 +453,10 @@ struct AnalyticsViewModelTests {
     let mockRepository = MockJournalRepository()
     mockRepository.errorToThrow = NSError(domain: "test", code: -2)
 
-    let mockCatalog = MockCatalogRepository()
-
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
       localCalculator: nil,
       journalRepository: mockRepository,
-      catalogRepository: mockCatalog,
       syncSettings: cloudSyncOn()
     )
 
@@ -499,13 +492,11 @@ struct AnalyticsViewModelTests {
 
     let mockCalculator = MockLocalAnalyticsCalculator()
     let mockRepository = MockJournalRepository()
-    let mockCatalog = MockCatalogRepository()
 
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
       localCalculator: mockCalculator,
       journalRepository: mockRepository,
-      catalogRepository: mockCatalog,
       syncSettings: cloudSyncOn()
     )
 
@@ -577,14 +568,10 @@ struct AnalyticsViewModelTests {
     mockRepository.entriesToReturn = [
       LocalJournalEntry(createdAt: Date(), userID: 1, curriculumID: 1, entryType: .emotion),
     ]
-    let mockCatalog = MockCatalogRepository()
-    mockCatalog.catalogToReturn = testCatalog()
-
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
       localCalculator: mockCalculator,
       journalRepository: mockRepository,
-      catalogRepository: mockCatalog,
       syncSettings: cloudSyncOff()
     )
 

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/ContentViewModelTests.swift
@@ -15,6 +15,23 @@ struct ContentViewModelTests {
     #expect(viewModel.isLoading == false)
   }
 
+  @Test("loadCatalog keeps the whole catalog in memory for offline analytics (#468)")
+  func loadCatalog_retainsLoadedCatalog() async {
+    let repository = CatalogRepositoryMock(cached: nil, result: .success(SampleData.catalog))
+    let viewModel = ContentViewModel(
+      catalogRepository: repository,
+      journalRepository: InMemoryJournalRepository(),
+      journalClient: JournalClientMock()
+    )
+
+    #expect(viewModel.loadedCatalog == nil)
+    await viewModel.loadCatalog()
+
+    // Even though the mock has no on-disk cache, the fetched catalog is retained
+    // in memory so analytics can build its local calculator from it.
+    #expect(viewModel.loadedCatalog == SampleData.catalog)
+  }
+
   @Test func surfacesErrorWhenLoadingFails() async {
     enum TestError: Error { case failure }
     let repository = CatalogRepositoryMock(result: .failure(TestError.failure))


### PR DESCRIPTION
## Summary
Fixes Analytics showing **"unavailable"** on-device with cloud sync both on and off (even after adding a new entry), while the backend is healthy and the main UI works.

## Root cause
The offline analytics path depended entirely on the on-disk catalog cache (`catalog-cache.json`):
- `AnalyticsView` built its `LocalAnalyticsCalculator` only if `catalogRepository.cachedCatalog()` was non-nil.
- `AnalyticsViewModel.tryLocalCalculation()` *also* guarded on `cachedCatalog()` — a guard whose result it never even used.

But `loadCatalog` writes the disk cache with `try? writeEnvelope(...)`, a **silently-swallowed write**. So the backend fetch can succeed (the main UI gets the catalog in memory) while the disk cache stays empty → `cachedCatalog()` nil → no calculator → permanently "unavailable", regardless of sync or new entries.

## Fix
- `ContentViewModel` retains the loaded `CatalogResponseModel` in memory (`loadedCatalog`).
- `MenuView` passes it into `AnalyticsView`, which builds the calculator from the in-memory catalog, falling back to `cachedCatalog()`.
- Remove the redundant, vetoing `cachedCatalog()` guard (and the now-unused `catalogRepository` dependency) from `AnalyticsViewModel`.

## Test plan
- `ContentViewModelTests.loadCatalog_retainsLoadedCatalog` — the catalog is retained in memory even with **no disk cache**.
- The analytics local-path tests now exercise the calculator without a catalog repository (matching the new contract).
- `run-tests-individually.sh` → **48/48 suites green**; pre-commit clean.
- **⚠️ On-device check:** open Analytics with sync off and confirm it loads from local journal data (it should now work even if the catalog disk cache is empty).

Closes #468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)