### PR TITLE
fix(analytics): surface the local-calc failure reason (#470)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
@@ -64,6 +64,22 @@ final class AnalyticsViewModel: ObservableObject {
     }
   }
 
+  /// Why a local analytics calculation couldn't be produced. Surfaced in the
+  /// user-facing error so a blind "unavailable" no longer hides the cause (#470).
+  private enum LocalCalculationError: Error {
+    case noCalculator // no in-memory or cached catalog to build the calculator
+    case noRepository // journal storage not wired
+    case fetchFailed(String) // reading journal entries threw
+
+    var reason: String {
+      switch self {
+      case .noCalculator: "no catalog is loaded yet"
+      case .noRepository: "journal storage is unavailable"
+      case let .fetchFailed(message): "couldn't read journal entries — \(message)"
+      }
+    }
+  }
+
   /// Loads from backend with fallback to local calculator on backend error.
   private func loadWithBackendFallback() async {
     do {
@@ -71,56 +87,54 @@ final class AnalyticsViewModel: ObservableObject {
       let overview = try await analyticsService.getOverview(userId: userId)
       state = .loaded(overview)
     } catch {
-      // Try local fallback if available
-      if let localOverview = await tryLocalCalculation() {
-        state = .loaded(localOverview)
-      } else {
-        state = .error("Failed to load analytics: \(error.localizedDescription)")
+      do {
+        state = try .loaded(calculateLocally())
+      } catch {
+        state = .error(
+          "Failed to load analytics: \(error.localizedDescription) "
+            + "(local: \(localReason(error)))"
+        )
       }
     }
   }
 
   /// Loads exclusively from the local calculator (cloud sync disabled mode).
   private func loadFromLocalOnly() async {
-    if let localOverview = await tryLocalCalculation() {
-      state = .loaded(localOverview)
-    } else {
-      // Reached only when the view is constructed without local components
-      // (a wiring bug, not user-facing). Avoid telling a user who deliberately
-      // disabled cloud sync to "enable cloud sync".
-      state = .error("Analytics are temporarily unavailable. Please try again later.")
+    do {
+      state = try .loaded(calculateLocally())
+    } catch {
+      state = .error(
+        "Analytics are temporarily unavailable. Please try again later. "
+          + "(\(localReason(error)))"
+      )
     }
   }
 
-  /// Attempts to calculate analytics from local storage.
-  ///
-  /// - Returns: Locally calculated overview if all components available, nil otherwise
-  private func tryLocalCalculation() async -> AnalyticsOverview? {
-    // The calculator already holds the catalog it was built with, so require
-    // only it and the journal repository. The previous extra
-    // `catalogRepository.cachedCatalog()` guard was unused yet could veto a
-    // perfectly good calculation whenever the on-disk cache was empty (#468).
-    guard
-      let calculator = localCalculator,
-      let repository = journalRepository
-    else {
-      return nil
-    }
+  /// Calculates analytics from local storage, throwing a `LocalCalculationError`
+  /// that names the failing step so the cause is never silently swallowed.
+  private func calculateLocally() throws -> AnalyticsOverview {
+    guard let calculator = localCalculator else { throw LocalCalculationError.noCalculator }
+    guard let repository = journalRepository else { throw LocalCalculationError.noRepository }
 
+    let entries: [LocalJournalEntry]
     do {
-      let entries = try repository.fetchAll()
-      let endDate = Date()
-      let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
-
-      return calculator.calculateOverview(
-        entries: entries,
-        startDate: startDate,
-        endDate: endDate
-      )
+      entries = try repository.fetchAll()
     } catch {
-      print("⚠️ Local analytics calculation failed: \(error.localizedDescription)")
-      return nil
+      throw LocalCalculationError.fetchFailed(error.localizedDescription)
     }
+
+    let endDate = Date()
+    let startDate = Calendar.current.date(byAdding: .day, value: -30, to: endDate) ?? endDate
+    return calculator.calculateOverview(
+      entries: entries,
+      startDate: startDate,
+      endDate: endDate
+    )
+  }
+
+  /// Human-readable reason for a local-calculation failure.
+  private func localReason(_ error: Error) -> String {
+    (error as? LocalCalculationError)?.reason ?? error.localizedDescription
   }
 
   /// Retries loading analytics after an error.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/ViewModels/AnalyticsViewModel.swift
@@ -66,12 +66,14 @@ final class AnalyticsViewModel: ObservableObject {
 
   /// Why a local analytics calculation couldn't be produced. Surfaced in the
   /// user-facing error so a blind "unavailable" no longer hides the cause (#470).
-  private enum LocalCalculationError: Error {
+  /// Conforms to `LocalizedError` so `localizedDescription` yields the reason
+  /// directly — no helper to forget at a call site.
+  private enum LocalCalculationError: LocalizedError {
     case noCalculator // no in-memory or cached catalog to build the calculator
     case noRepository // journal storage not wired
     case fetchFailed(String) // reading journal entries threw
 
-    var reason: String {
+    var errorDescription: String? {
       switch self {
       case .noCalculator: "no catalog is loaded yet"
       case .noRepository: "journal storage is unavailable"
@@ -86,13 +88,13 @@ final class AnalyticsViewModel: ObservableObject {
       let userId = numericUserIdentifier()
       let overview = try await analyticsService.getOverview(userId: userId)
       state = .loaded(overview)
-    } catch {
+    } catch let backendError {
       do {
         state = try .loaded(calculateLocally())
       } catch {
         state = .error(
-          "Failed to load analytics: \(error.localizedDescription) "
-            + "(local: \(localReason(error)))"
+          "Failed to load analytics: \(backendError.localizedDescription) "
+            + "(local: \(error.localizedDescription))"
         )
       }
     }
@@ -105,7 +107,7 @@ final class AnalyticsViewModel: ObservableObject {
     } catch {
       state = .error(
         "Analytics are temporarily unavailable. Please try again later. "
-          + "(\(localReason(error)))"
+          + "(\(error.localizedDescription))"
       )
     }
   }
@@ -130,11 +132,6 @@ final class AnalyticsViewModel: ObservableObject {
       startDate: startDate,
       endDate: endDate
     )
-  }
-
-  /// Human-readable reason for a local-calculation failure.
-  private func localReason(_ error: Error) -> String {
-    (error as? LocalCalculationError)?.reason ?? error.localizedDescription
   }
 
   /// Retries loading analytics after an error.

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -470,6 +470,34 @@ struct AnalyticsViewModelTests {
     }
   }
 
+  @Test("a local fetch failure surfaces its reason in the error message (#470)")
+  @MainActor
+  func viewModel_localFetchFailure_surfacesReason() async {
+    let mockService = MockAnalyticsService()
+    let mockCalculator = MockLocalAnalyticsCalculator()
+    let mockRepository = MockJournalRepository()
+    mockRepository.errorToThrow = NSError(
+      domain: "db", code: 7,
+      userInfo: [NSLocalizedDescriptionKey: "query failed: no such table"]
+    )
+
+    let viewModel = AnalyticsViewModel(
+      analyticsService: mockService,
+      localCalculator: mockCalculator,
+      journalRepository: mockRepository,
+      syncSettings: cloudSyncOff()
+    )
+
+    await viewModel.loadAnalytics()
+
+    if case let .error(message) = viewModel.state {
+      #expect(message.contains("couldn't read journal entries"))
+      #expect(message.contains("query failed: no such table"))
+    } else {
+      Issue.record("Expected error surfacing the fetch reason, got \(viewModel.state)")
+    }
+  }
+
   @Test("viewModel uses backend successfully without trying local")
   @MainActor
   func viewModel_usesBackendWithoutTryingLocal() async {

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/AnalyticsViewModelTests.swift
@@ -448,14 +448,17 @@ struct AnalyticsViewModelTests {
   @MainActor
   func viewModel_reportsErrorWhenBothFail() async {
     let mockService = MockAnalyticsService()
-    mockService.errorToThrow = NSError(domain: "test", code: -1)
+    mockService.errorToThrow = NSError(
+      domain: "net", code: -1009,
+      userInfo: [NSLocalizedDescriptionKey: "The Internet connection appears to be offline."]
+    )
 
     let mockRepository = MockJournalRepository()
     mockRepository.errorToThrow = NSError(domain: "test", code: -2)
 
     let viewModel = AnalyticsViewModel(
       analyticsService: mockService,
-      localCalculator: nil,
+      localCalculator: nil, // no catalog → the local fallback reports noCalculator
       journalRepository: mockRepository,
       syncSettings: cloudSyncOn()
     )
@@ -464,6 +467,10 @@ struct AnalyticsViewModelTests {
 
     if case let .error(message) = viewModel.state {
       #expect(message.contains("Failed to load analytics"))
+      // The backend error must survive into the message (regression: the inner
+      // catch used to shadow it), and the local reason must be named.
+      #expect(message.contains("The Internet connection appears to be offline."))
+      #expect(message.contains("no catalog is loaded yet"))
       #expect(mockService.getOverviewCallCount == 1)
     } else {
       Issue.record("Expected error state, got \(viewModel.state)")
@@ -495,6 +502,25 @@ struct AnalyticsViewModelTests {
       #expect(message.contains("query failed: no such table"))
     } else {
       Issue.record("Expected error surfacing the fetch reason, got \(viewModel.state)")
+    }
+  }
+
+  @Test("a missing journal repository surfaces 'journal storage is unavailable' (#470)")
+  @MainActor
+  func viewModel_noRepository_surfacesReason() async {
+    let viewModel = AnalyticsViewModel(
+      analyticsService: MockAnalyticsService(),
+      localCalculator: MockLocalAnalyticsCalculator(),
+      journalRepository: nil,
+      syncSettings: cloudSyncOff()
+    )
+
+    await viewModel.loadAnalytics()
+
+    if case let .error(message) = viewModel.state {
+      #expect(message.contains("journal storage is unavailable"))
+    } else {
+      Issue.record("Expected error naming the missing repository, got \(viewModel.state)")
     }
   }
 


### PR DESCRIPTION
## Summary
Analytics still shows the blind **"Analytics are temporarily unavailable"** on a confirmed-fresh build (the #468 fix is present — #467's chevron taps through), so the real cause is hidden. This makes the error **name the failing step**, the same move that cracked the storage RCA (#451/#462).

## Change
- Replace the nil-returning `tryLocalCalculation` with a throwing `calculateLocally()` that throws a typed `LocalCalculationError`: **no catalog** / **no journal repository** / **`fetchAll` failed: \<reason\>**.
- Both error paths (local-only and backend-fallback) append that reason:
  - sync off → `"Analytics are temporarily unavailable. Please try again later. (couldn't read journal entries — \<sqlite reason\>)"`
  - sync on → `"Failed to load analytics: \<backend\> (local: \<reason\>)"`

## Test plan
- `viewModel_localFetchFailure_surfacesReason` — a thrown `fetchAll` error is surfaced verbatim in the message.
- Existing prefix assertions preserved (`"Failed to load analytics"`, `"temporarily unavailable"`).
- `run-tests-individually.sh` → **48/48 green**; pre-commit clean.

## Next step
After this merges, rebuild and screenshot the Analytics error — the parenthetical now tells us exactly what's failing (almost certainly `fetchAll` on the journal DB), and I'll ship the real fix for that cause.

Closes #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)