### PR TITLE
fix(journal): tolerate stray field values + normalize sync_status (#472)

### DIFF
--- a/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch App/Services/JournalDatabase.swift
@@ -50,8 +50,9 @@ final class JournalDatabase {
   /// `migrateToV2`/`V3` are column-changing migrations. The former v4 step added
   /// analytics indexes only, now ensured on every open by `createIndexes()`
   /// (hence no `migrateToV4`). v5 is a data migration that rewrites the removed
-  /// `entry_type = 'rest'` value to `'emotion'` (#435).
-  static let schemaVersion = 5
+  /// `entry_type = 'rest'` value to `'emotion'` (#435). v6 normalizes any
+  /// out-of-range `sync_status` value back to `'pending'` (#472).
+  static let schemaVersion = 6
 
   /// SQLite database pointer.
   private var db: OpaquePointer?
@@ -255,6 +256,9 @@ final class JournalDatabase {
     if currentVersion < 5 {
       try migrateRestEntriesToEmotion()
     }
+    if currentVersion < 6 {
+      try migrateInvalidSyncStatusToPending()
+    }
 
     // Set the schema version by collapsing `schema_version` to a single
     // authoritative row. An older build's `INSERT OR IGNORE` could have left a
@@ -357,6 +361,27 @@ final class JournalDatabase {
     guard let db else { throw JournalDatabaseError.databaseNotOpen }
 
     let sql = "UPDATE journal_entry SET entry_type = 'emotion' WHERE entry_type = 'rest'"
+    var errorMessage: UnsafeMutablePointer<CChar>?
+    if sqlite3_exec(db, sql, nil, nil, &errorMessage) != SQLITE_OK {
+      let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"
+      sqlite3_free(errorMessage)
+      throw JournalDatabaseError.failedToUpdate(message)
+    }
+  }
+
+  /// Migrates to v6: normalizes any `sync_status` value outside the current
+  /// `SyncStatus` set (`pending`/`synced`/`failed`) back to `'pending'`. Older
+  /// builds wrote values the enum no longer recognizes; left as-is, a single
+  /// such row makes `parseEntry` throw and breaks every full-table read —
+  /// journal history, analytics, and sync (#472). Rewriting to `'pending'` is
+  /// safe: the entry simply re-syncs on the next cycle.
+  private func migrateInvalidSyncStatusToPending() throws {
+    guard let db else { throw JournalDatabaseError.databaseNotOpen }
+
+    let sql = """
+      UPDATE journal_entry SET sync_status = 'pending'
+      WHERE sync_status NOT IN ('pending', 'synced', 'failed')
+    """
     var errorMessage: UnsafeMutablePointer<CChar>?
     if sqlite3_exec(db, sql, nil, nil, &errorMessage) != SQLITE_OK {
       let message = errorMessage.map { String(cString: $0) } ?? "Unknown error"
@@ -694,11 +719,13 @@ final class JournalDatabase {
     let lastSyncAttemptCol = 10
     let retryCountCol = 11
 
-    // Parse required fields
+    // A row whose primary key can't be parsed is unusable, so skip it (return
+    // nil) rather than throwing — one corrupt row must not fail the entire
+    // fetch and break every reader (journal history, analytics, sync) (#472).
     guard let idString = sqlite3_column_text(statement, Int32(idCol)).map({ String(cString: $0) }),
           let id = UUID(uuidString: idString)
     else {
-      throw JournalDatabaseError.invalidData("Invalid or missing ID")
+      return nil
     }
 
     let createdAt = Date(timeIntervalSince1970: sqlite3_column_double(statement, Int32(createdAtCol)))
@@ -709,11 +736,11 @@ final class JournalDatabase {
       ? Int(sqlite3_column_int64(statement, Int32(curriculumIdCol)))
       : nil
 
-    guard let initiatedByString = sqlite3_column_text(statement, Int32(initiatedByCol)).map({ String(cString: $0) }),
-          let initiatedBy = InitiatedBy(rawValue: initiatedByString)
-    else {
-      throw JournalDatabaseError.invalidData("Invalid initiated_by value")
-    }
+    // Unrecognized initiated_by reads as self-initiated rather than failing the
+    // whole fetch (#472), mirroring entry_type / sync_status resilience.
+    let initiatedByString = sqlite3_column_text(statement, Int32(initiatedByCol))
+      .map { String(cString: $0) } ?? ""
+    let initiatedBy = InitiatedBy(rawValue: initiatedByString) ?? .self_initiated
 
     // entry_type defaults to "emotion" for v2 databases without the column, and
     // any unrecognized value (e.g. a legacy "rest" row predating the v5
@@ -723,11 +750,13 @@ final class JournalDatabase {
     let entryTypeString = sqlite3_column_text(statement, Int32(entryTypeCol)).map { String(cString: $0) } ?? "emotion"
     let entryType = EntryType(rawValue: entryTypeString) ?? .emotion
 
-    guard let syncStatusString = sqlite3_column_text(statement, Int32(syncStatusCol)).map({ String(cString: $0) }),
-          let syncStatus = SyncStatus(rawValue: syncStatusString)
-    else {
-      throw JournalDatabaseError.invalidData("Invalid sync_status value")
-    }
+    // Unrecognized sync_status (e.g. a value written by an older build) reads as
+    // pending rather than throwing — losing the whole journal to one stray value
+    // is far worse, and a pending entry simply re-syncs (#472). The v6 migration
+    // also normalizes such values on disk.
+    let syncStatusString = sqlite3_column_text(statement, Int32(syncStatusCol))
+      .map { String(cString: $0) } ?? ""
+    let syncStatus = SyncStatus(rawValue: syncStatusString) ?? .pending
 
     // Parse optional fields
     var entry = LocalJournalEntry(

--- a/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
+++ b/frontend/WavelengthWatch/WavelengthWatch Watch AppTests/JournalRepositoryTests.swift
@@ -289,6 +289,85 @@ struct JournalRepositoryTests {
     return false
   }
 
+  @Test("fetchAll tolerates a row with an unrecognized sync_status (#472)")
+  func fetchAll_tolerantOfInvalidSyncStatus() throws {
+    let tempPath = NSTemporaryDirectory() + UUID().uuidString + ".db"
+    defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+    let db = JournalDatabase(path: tempPath)
+    try db.open()
+    let entry = LocalJournalEntry(
+      createdAt: Date(), userID: 1, curriculumID: 1,
+      initiatedBy: .self_initiated, entryType: .emotion
+    )
+    try db.insert(entry)
+
+    // Corrupt sync_status AFTER open so the v6 migration can't normalize it —
+    // this exercises parseEntry's tolerance directly. An older build could have
+    // written a value the current `SyncStatus` enum no longer recognizes.
+    #expect(Self.execRaw(
+      "UPDATE journal_entry SET sync_status = 'syncing' WHERE id = '\(entry.id.uuidString)'",
+      at: tempPath
+    ))
+
+    // fetchAll must NOT throw; the stray value reads as pending. Previously one
+    // such row broke every full-table read (history, analytics, sync).
+    let all = try db.fetchAll()
+    #expect(all.count == 1)
+    #expect(all.first?.syncStatus == .pending)
+    db.close()
+  }
+
+  @Test("open() normalizes an out-of-range sync_status to pending on disk (#472 v6)")
+  func open_v6NormalizesInvalidSyncStatus() throws {
+    let tempPath = NSTemporaryDirectory() + UUID().uuidString + ".db"
+    defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+    let first = JournalDatabase(path: tempPath)
+    try first.open()
+    let entry = LocalJournalEntry(
+      createdAt: Date(), userID: 1, curriculumID: 1,
+      initiatedBy: .self_initiated, entryType: .emotion
+    )
+    try first.insert(entry)
+    first.close()
+
+    // Corrupt the row and roll the stored schema version below 6 so v6 runs.
+    #expect(Self.execRaw(
+      "UPDATE journal_entry SET sync_status = 'syncing' WHERE id = '\(entry.id.uuidString)'",
+      at: tempPath
+    ))
+    #expect(Self.execRaw("UPDATE schema_version SET version = 5", at: tempPath))
+
+    let reopened = JournalDatabase(path: tempPath)
+    #expect(throws: Never.self) { try reopened.open() }
+    reopened.close()
+
+    #expect(Self.rawSyncStatus(forID: entry.id, at: tempPath) == "pending")
+  }
+
+  /// Runs raw SQL via a separate connection (test seeding / corruption).
+  @discardableResult
+  private static func execRaw(_ sql: String, at path: String) -> Bool {
+    var raw: OpaquePointer?
+    guard sqlite3_open(path, &raw) == SQLITE_OK else { return false }
+    defer { sqlite3_close(raw) }
+    return sqlite3_exec(raw, sql, nil, nil, nil) == SQLITE_OK
+  }
+
+  /// Reads one entry's `sync_status` via a raw connection.
+  private static func rawSyncStatus(forID id: UUID, at path: String) -> String? {
+    var raw: OpaquePointer?
+    guard sqlite3_open(path, &raw) == SQLITE_OK else { return nil }
+    defer { sqlite3_close(raw) }
+    var statement: OpaquePointer?
+    let sql = "SELECT sync_status FROM journal_entry WHERE id = '\(id.uuidString)'"
+    guard sqlite3_prepare_v2(raw, sql, -1, &statement, nil) == SQLITE_OK else { return nil }
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+    return sqlite3_column_text(statement, 0).map { String(cString: $0) }
+  }
+
   @Test func journalDatabaseError_localizedDescription_surfacesReason() {
     // The journal-open failure log and the on-device Storage Error alert (#462)
     // both rely on `localizedDescription` carrying the real SQLite reason +


### PR DESCRIPTION
## Summary
Fixes the analytics failure the #470 diagnostic pinpointed: *"couldn't read journal entries — invalid data: Invalid sync_status value"*. A `journal_entry` row holds a `sync_status` the current `SyncStatus` enum (`pending`/`synced`/`failed`) doesn't recognize — written by an older build and never normalized.

`parseEntry` **threw** on it, and `fetchAll` propagates the throw, so **one malformed row broke every full-table read** — journal history, analytics, and sync.

## Fix (two-part)
1. **Resilient parsing** — a single bad row must never fail the whole read:
   - unknown `sync_status` → `.pending`
   - unknown `initiated_by` → `.self_initiated`
   - unparseable `id` → skip that row (return nil)
   - (matches the existing `entry_type` tolerance from #435)
2. **v6 data migration** — normalize any `sync_status NOT IN ('pending','synced','failed')` to `'pending'` on disk (safe: the entry just re-syncs).

## Test plan
- `fetchAll_tolerantOfInvalidSyncStatus` — `fetchAll` survives a stray `sync_status`, reading it as `pending` instead of throwing.
- `open_v6NormalizesInvalidSyncStatus` — the v6 migration rewrites an out-of-range value to `pending` on disk.
- `run-tests-individually.sh` → **48/48 green**; pre-commit clean.
- **On-device:** rebuild and open Analytics — it should now load (the bad row is normalized/tolerated).

## Note
This makes the journal read robust against *any* future enum drift, not just this value — the storage layer should degrade gracefully, never brick the whole journal over one row.

Closes #472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)