### PR TITLE
docs(agents): steer every agent session to query the knowledge graph first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,3 +174,17 @@ WavelengthWatch is a **watch-only app** that displays the Archetypal Wavelength 
 - **No disabling CI checks** - make the code pass legitimately
 - **Exception**: Missing type stubs for third-party libraries are acceptable to ignore with proper documentation
 - Fix root causes, not symptoms
+
+## Knowledge Graph (graphify) — query first
+
+This repo commits its code graph at `graphify-out/graph.json` (part of the
+adepthood federation). For ANY question about this codebase — structure,
+relationships, impact — query the graph BEFORE grep/read sweeps:
+
+- `graphify query "<question>"` · `graphify path "A" "B"` ·
+  `graphify explain "X"` · `graphify affected "X"` (before changing X).
+- Quote each cited node's `source_location`; verify before trusting.
+- Install once per session if absent: `pip install graphifyy` (match the
+  pinned version in `.github/workflows/graph-update.yml`). Fail-soft: if the
+  CLI or graph is unavailable, proceed with normal file tools — never stall.
+- After code changes, `graphify update .` (AST-only, keyless, $0).


### PR DESCRIPTION
Adds a compact "Knowledge Graph (graphify) — query first" section to `CLAUDE.md`, so every Claude session in this repo orients via the committed `graphify-out/graph.json` (3,125 nodes) before grep/read sweeps. Companion to [adepthood#2034](https://github.com/Geoffe-Ga/adepthood/pull/2034) (utilization enforcement on the hub): the federation measured a **175× query-token reduction** on the live pan-graph, but only the hub had agent steering wired. Fail-soft throughout: sessions proceed normally when the CLI or graph is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg)_